### PR TITLE
feat: expose selectedChain property

### DIFF
--- a/packages/react/src/hooks/useWeb3Modal.ts
+++ b/packages/react/src/hooks/useWeb3Modal.ts
@@ -3,9 +3,18 @@ import { useEffect, useState } from 'react'
 
 export function useWeb3Modal() {
   const [modal, setModal] = useState(ModalCtrl.state)
+  const [options, setOptions] = useState(OptionsCtrl.state)
 
   useEffect(() => {
     const unsubscribe = ModalCtrl.subscribe(newModal => setModal({ ...newModal }))
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = OptionsCtrl.subscribe(newOptions => setOptions({ ...newOptions }))
 
     return () => {
       unsubscribe()
@@ -16,6 +25,7 @@ export function useWeb3Modal() {
     isOpen: modal.open,
     open: ModalCtrl.open,
     close: ModalCtrl.close,
+    selectedChain: options.selectedChain,
     setDefaultChain: OptionsCtrl.setSelectedChain
   }
 }


### PR DESCRIPTION
When a user selects a different network in the network selector without being connected to their wallet, there is no way to determine which network they have selected, leading to a case when network in the network selector is Ethereum, but data is showing for BSC. Exposing the selectedChain property will enable the ability to determine which network is selected.