### PR TITLE
chore: Relay QR generation flow improvements

### DIFF
--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -27,7 +27,7 @@ export interface ConnectExternalOptions {
 }
 
 export interface ConnectionControllerClient {
-  connectWalletConnect: (onUri: (uri: string) => void) => Promise<void>
+  connectWalletConnect: () => Promise<void>
   disconnect: () => Promise<void>
   signMessage: (message: string) => Promise<string>
   sendTransaction: (args: SendTransactionArgs) => Promise<`0x${string}` | null>
@@ -84,10 +84,12 @@ export const ConnectionController = {
 
   async connectWalletConnect() {
     StorageUtil.setConnectedConnector('WALLET_CONNECT')
-    await this._getClient().connectWalletConnect(uri => {
-      state.wcUri = uri
-      state.wcPairingExpiry = CoreHelperUtil.getPairingExpiry()
-    })
+    await this._getClient().connectWalletConnect()
+  },
+
+  setQRCodeURI(uri: string) {
+    state.wcUri = uri
+    state.wcPairingExpiry = CoreHelperUtil.getPairingExpiry()
   },
 
   async connectExternal(options: ConnectExternalOptions, chain?: Chain) {

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -36,7 +36,8 @@ export const CoreHelperUtil = {
   },
 
   isPairingExpired(expiry?: number) {
-    return expiry ? expiry - Date.now() <= ConstantsUtil.TEN_SEC_MS : true
+    // QR code lasts 15mins
+    return expiry ? expiry - Date.now() <= 15 * 60 * 1000 : true
   },
 
   isAllowedRetry(lastRetry: number) {

--- a/packages/core/tests/controllers/ConnectionController.test.ts
+++ b/packages/core/tests/controllers/ConnectionController.test.ts
@@ -10,10 +10,7 @@ const type = 'AUTH' as ConnectorType
 const storageSpy = vi.spyOn(StorageUtil, 'setConnectedConnector')
 
 const client: ConnectionControllerClient = {
-  connectWalletConnect: async onUri => {
-    onUri(walletConnectUri)
-    await Promise.resolve(walletConnectUri)
-  },
+  connectWalletConnect: async () => Promise.resolve(),
   disconnect: async () => Promise.resolve(),
   signMessage: async (message: string) => Promise.resolve(message),
   estimateGas: async () => Promise.resolve(BigInt(0)),

--- a/packages/ethers/src/client.ts
+++ b/packages/ethers/src/client.ts
@@ -194,15 +194,11 @@ export class Web3Modal extends Web3ModalScaffold {
     }
 
     const connectionControllerClient: ConnectionControllerClient = {
-      connectWalletConnect: async onUri => {
+      connectWalletConnect: async () => {
         const WalletConnectProvider = await this.getWalletConnectProvider()
         if (!WalletConnectProvider) {
           throw new Error('connectionControllerClient:getWalletConnectUri - provider is undefined')
         }
-
-        WalletConnectProvider.on('display_uri', (uri: string) => {
-          onUri(uri)
-        })
 
         // When connecting through walletconnect, we need to set the clientId in the store
         const clientId = await WalletConnectProvider.signer?.client?.core?.crypto?.getClientId()
@@ -698,6 +694,10 @@ export class Web3Modal extends Web3ModalScaffold {
     }
 
     this.walletConnectProvider = await EthereumProvider.init(walletConnectProviderOptions)
+
+    this.walletConnectProvider.on('display_uri', (uri: string) => {
+      this.setQRCodeURI(uri)
+    })
 
     await this.checkActiveWalletConnectProvider()
   }

--- a/packages/ethers5/src/client.ts
+++ b/packages/ethers5/src/client.ts
@@ -169,15 +169,11 @@ export class Web3Modal extends Web3ModalScaffold {
     }
 
     const connectionControllerClient: ConnectionControllerClient = {
-      connectWalletConnect: async onUri => {
+      connectWalletConnect: async () => {
         const WalletConnectProvider = await this.getWalletConnectProvider()
         if (!WalletConnectProvider) {
           throw new Error('connectionControllerClient:getWalletConnectUri - provider is undefined')
         }
-
-        WalletConnectProvider.on('display_uri', (uri: string) => {
-          onUri(uri)
-        })
 
         const params = await siweConfig?.getMessageParams?.()
         // Must perform these checks to satify optional types
@@ -541,6 +537,10 @@ export class Web3Modal extends Web3ModalScaffold {
     }
 
     this.walletConnectProvider = await EthereumProvider.init(walletConnectProviderOptions)
+
+    this.walletConnectProvider.on('display_uri', (uri: string) => {
+      this.setQRCodeURI(uri)
+    })
 
     await this.checkActiveWalletConnectProvider()
   }

--- a/packages/scaffold/src/client.ts
+++ b/packages/scaffold/src/client.ts
@@ -327,6 +327,10 @@ export class Web3ModalScaffold {
     BlockchainApiController.setClientId(clientId)
   }
 
+  protected setQRCodeURI: (typeof ConnectionController)['setQRCodeURI'] = uri => {
+    ConnectionController.setQRCodeURI(uri)
+  }
+
   // -- Private ------------------------------------------------------------------
   private async initControllers(options: ScaffoldOptions) {
     ChainController.initialize([

--- a/packages/solana/src/client.ts
+++ b/packages/solana/src/client.ts
@@ -121,16 +121,14 @@ export class Web3Modal extends Web3ModalScaffold {
     }
 
     const connectionControllerClient: ConnectionControllerClient = {
-      connectWalletConnect: async onUri => {
+      connectWalletConnect: async () => {
         const WalletConnectProvider = await this.WalletConnectConnector.getProvider()
         if (!WalletConnectProvider) {
           throw new Error('connectionControllerClient:getWalletConnectUri - provider is undefined')
         }
 
-        WalletConnectProvider.on('display_uri', onUri)
         const address = await this.WalletConnectConnector.connect()
         this.setWalletConnectProvider(address)
-        WalletConnectProvider.removeListener('display_uri', onUri)
       },
 
       connectExternal: async ({ id }) => {
@@ -228,6 +226,15 @@ export class Web3Modal extends Web3ModalScaffold {
       chains,
       qrcode: true
     })
+
+    this.WalletConnectConnector.getProvider().then(provider => {
+      if (provider) {
+        provider.on('display_uri', (uri: string) => {
+          this.setQRCodeURI(uri)
+        })
+      }
+    })
+
     SolStoreUtil.setConnection(
       new Connection(
         SolHelpersUtil.detectRpcUrl(chain, OptionsController.state.projectId),

--- a/packages/solana/src/connectors/walletConnectConnector.ts
+++ b/packages/solana/src/connectors/walletConnectConnector.ts
@@ -7,7 +7,7 @@ import { UniversalProviderFactory } from './universalProvider.js'
 import { BaseConnector } from './baseConnector.js'
 
 import type { Signer } from '@solana/web3.js'
-import type UniversalProvider from '@walletconnect/universal-provider'
+import UniversalProvider from '@walletconnect/universal-provider'
 
 import type { Connector } from './baseConnector.js'
 import type { Chain } from '../utils/scaffold/SolanaTypesUtil.js'


### PR DESCRIPTION
# Description

- WC Relay QR code generation has flaky behaviors.
- There is a lot of overhead in the connection setup: repeated event handlers, multiple connection requests that are stacked on top of each other, complex retry logic with two different timing conditions and poor error handling.
- This PR refactors the QR flow to bring some improvements:
  => Only subscribe to `display_uri` event once per client
  => Only re-initialize the connection flow after 15 minutes, given the sdk internally handles retries for that time
  => Always regenerate the URI on an error.

WIP: 
- Handling internal errors / network errors => Somehow we get no messages nor session updates from event handlers

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-144

# Checklist

- [] Code in this PR is covered by automated tests (Unit tests, E2E tests) 
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
