### PR TITLE
fix: add referrerPolicy to the iframe

### DIFF
--- a/packages/wallet/src/W3mFrame.ts
+++ b/packages/wallet/src/W3mFrame.ts
@@ -41,6 +41,7 @@ export class W3mFrame {
         iframe.id = 'w3m-iframe'
         iframe.src = `${SECURE_SITE_SDK}?projectId=${projectId}&chainId=${chainId}`
         iframe.name = 'w3m-secure-iframe'
+        iframe.referrerPolicy = 'strict-origin-when-cross-origin'
         iframe.style.position = 'fixed'
         iframe.style.zIndex = '999999'
         iframe.style.display = 'none'


### PR DESCRIPTION
# Description

This fixes the problem of iframe not connecting to https://secure.walletconnect.org/sdk?projectId=xxxx due to missing referrer

(this issue was not present with 5.1.1 somehow)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) 

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
