### PR TITLE
refactor: change SafeLocalStorage key type

### DIFF
--- a/packages/adapters/solana/src/client.ts
+++ b/packages/adapters/solana/src/client.ts
@@ -140,15 +140,8 @@ export class SolanaAdapter implements ChainAdapter {
     this.networkControllerClient = {
       switchCaipNetwork: async caipNetwork => {
         if (caipNetwork) {
-          SafeLocalStorage.setItem(
-            SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK,
-            JSON.stringify(caipNetwork)
-          )
-          try {
-            await this.switchNetwork(caipNetwork)
-          } catch (error) {
-            // SolStoreUtil.setError(error)
-          }
+          SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, caipNetwork)
+          await this.switchNetwork(caipNetwork)
         }
       },
 

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -230,11 +230,10 @@ export class WagmiAdapter implements ChainAdapter {
 
     this.networkControllerClient = {
       switchCaipNetwork: async caipNetwork => {
-        SafeLocalStorage.setItem(
-          SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK,
-          JSON.stringify(caipNetwork)
-        )
-        const chainId = Number(NetworkUtil.caipNetworkIdToNumber(caipNetwork?.id))
+        if (caipNetwork) {
+          SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, caipNetwork)
+        }
+        const chainId = NetworkUtil.caipNetworkIdToNumber(caipNetwork?.id)
 
         if (chainId && this.wagmiConfig) {
           await switchChain(this.wagmiConfig, { chainId })

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -22,7 +22,7 @@ import { WcHelpersUtil } from '@reown/appkit'
 import type { AppKitOptions } from '@reown/appkit'
 import type { AppKit } from '@reown/appkit'
 import { convertToAppKitChains } from '../utils/helpers.js'
-import { SafeLocalStorage, SafeLocalStorageKeys, type CaipNetwork } from '@reown/appkit-common'
+import { SafeLocalStorage, SafeLocalStorageKeys } from '@reown/appkit-common'
 
 type UniversalConnector = Connector & {
   onDisplayUri(uri: string): void
@@ -232,11 +232,8 @@ export function walletConnect(parameters: AppKitOptionsParams, appKit: AppKit) {
 
       if (chainId && currentChainId !== chainId) {
         const storedCaipNetwork = SafeLocalStorage.getItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK)
-        if (storedCaipNetwork) {
-          const parsedCaipNetwork = JSON.parse(storedCaipNetwork) as CaipNetwork
-          if (parsedCaipNetwork.chainNamespace === 'eip155') {
-            await this.switchChain?.({ chainId: Number(parsedCaipNetwork.chainId) })
-          }
+        if (storedCaipNetwork && storedCaipNetwork.chainNamespace === 'eip155') {
+          await this.switchChain?.({ chainId: Number(storedCaipNetwork.chainId) })
         } else {
           await this.switchChain?.({ chainId })
         }

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -95,10 +95,7 @@ export class UniversalAdapterClient {
       // @ts-expect-error switchCaipNetwork is async for some adapter but not for this adapter
       switchCaipNetwork: caipNetwork => {
         if (caipNetwork) {
-          SafeLocalStorage.setItem(
-            SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK,
-            JSON.stringify(caipNetwork)
-          )
+          SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, caipNetwork)
           try {
             this.switchNetwork(caipNetwork)
           } catch (error) {
@@ -400,10 +397,7 @@ export class UniversalAdapterClient {
 
       if (storedCaipNetwork) {
         try {
-          const parsedCaipNetwork = JSON.parse(storedCaipNetwork) as CaipNetwork
-          if (parsedCaipNetwork) {
-            NetworkController.setActiveCaipNetwork(parsedCaipNetwork)
-          }
+          NetworkController.setActiveCaipNetwork(storedCaipNetwork)
         } catch (error) {
           console.warn('>>> Error setting active caip network', error)
         }
@@ -418,10 +412,10 @@ export class UniversalAdapterClient {
       }
     }
 
-    SafeLocalStorage.setItem(
-      SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK,
-      JSON.stringify(this.appKit?.getCaipNetwork())
-    )
+    const caipNetworkToStore = this.appKit?.getCaipNetwork()
+    if (caipNetworkToStore) {
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, caipNetworkToStore)
+    }
 
     this.syncAccount()
     this.watchWalletConnect()

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -1,9 +1,11 @@
+import type { CaipNetwork } from './TypeUtil.js'
+
 export type SafeLocalStorageItems = {
   '@w3m/wallet_id': string
   '@w3m/wallet_name': string
   '@w3m/solana_wallet': string
   '@w3m/solana_caip_chain': string
-  '@w3m/active_caip_network': string
+  '@w3m/active_caip_network': CaipNetwork
   '@w3m/active_caip_network_id': string
   '@w3m/connected_connector': string
 }
@@ -35,7 +37,7 @@ export const SafeLocalStorage = {
         try {
           return JSON.parse(value)
         } catch {
-          return value
+          return null
         }
       }
     }

--- a/packages/common/tests/SafeLocalStorage.test.ts
+++ b/packages/common/tests/SafeLocalStorage.test.ts
@@ -46,4 +46,9 @@ describe('SafeLocalStorage safe', () => {
     expect(SafeLocalStorage.removeItem('@w3m/wallet_id')).toBe(undefined)
     expect(removeItem).toHaveBeenCalledWith('@w3m/wallet_id')
   })
+
+  it('should return null if fails to parse', () => {
+    getItem.mockReturnValueOnce('{invalid}')
+    expect(SafeLocalStorage.getItem('@w3m/wallet_id')).toBe(null)
+  })
 })

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -133,11 +133,8 @@ export const ChainController = {
 
       if (storedCaipNetwork) {
         try {
-          const parsedCaipNetwork = JSON.parse(storedCaipNetwork) as CaipNetwork
-          if (parsedCaipNetwork) {
-            state.activeChain = parsedCaipNetwork.chainNamespace
-            this.setActiveCaipNetwork(parsedCaipNetwork)
-          }
+          state.activeChain = storedCaipNetwork.chainNamespace
+          this.setActiveCaipNetwork(storedCaipNetwork)
         } catch (error) {
           console.warn('>>> Error setting active caip network', error)
         }
@@ -273,7 +270,7 @@ export const ChainController = {
       selectedNetworkId: caipNetwork?.id
     })
 
-    SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, JSON.stringify(caipNetwork))
+    SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK, caipNetwork)
     SafeLocalStorage.setItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK_ID, caipNetwork.id)
   },
 


### PR DESCRIPTION
# Description

This PR is changing the type of SafeLocalStorage `@w3m/active_caip_network` to the object type, so we don't need to stringfy or parse outside of the util function.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
