### PR TITLE
fix: wagmi provider not properly merged and reconnection

### DIFF
--- a/.changeset/nasty-rats-destroy.md
+++ b/.changeset/nasty-rats-destroy.md
@@ -1,0 +1,38 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@examples/html-ethers': patch
+'@examples/html-ethers5': patch
+'@examples/html-wagmi': patch
+'@examples/next-ethers': patch
+'@examples/next-wagmi': patch
+'@examples/react-ethers': patch
+'@examples/react-ethers5': patch
+'@examples/react-solana': patch
+'@examples/react-wagmi': patch
+'@examples/vue-ethers5': patch
+'@examples/vue-solana': patch
+'@examples/vue-wagmi': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-ethers': patch
+'@reown/appkit-ethers5': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-solana': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wagmi': patch
+---
+
+Fixes issue where wagmi would not reconnect on an active session

--- a/.changeset/two-cats-wave.md
+++ b/.changeset/two-cats-wave.md
@@ -1,0 +1,38 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@apps/laboratory': patch
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@examples/html-ethers': patch
+'@examples/html-ethers5': patch
+'@examples/html-wagmi': patch
+'@examples/next-ethers': patch
+'@examples/next-wagmi': patch
+'@examples/react-ethers': patch
+'@examples/react-ethers5': patch
+'@examples/react-solana': patch
+'@examples/react-wagmi': patch
+'@examples/vue-ethers5': patch
+'@examples/vue-solana': patch
+'@examples/vue-wagmi': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-ethers': patch
+'@reown/appkit-ethers5': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-solana': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wagmi': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes wrong wagmi authConnector name causing issues when merging multiple authConnectors

--- a/apps/laboratory/next.config.mjs
+++ b/apps/laboratory/next.config.mjs
@@ -12,7 +12,7 @@ const cspHeader = `
   img-src * 'self' data: blob: https://walletconnect.org https://walletconnect.com https://secure.walletconnect.com https://secure.walletconnect.org https://tokens-data.1inch.io https://tokens.1inch.io https://ipfs.io https://appkit-lab.reown.org;
   font-src 'self' https://fonts.gstatic.com;
   connect-src 'self' https://react-wallet.walletconnect.com https://rpc.walletconnect.com https://rpc.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org wss://www.walletlink.org https://o1095249.ingest.sentry.io https://quote-api.jup.ag;
-  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org http://localhost:3010 ${
+  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org ${
     process.env.NEXT_PUBLIC_SECURE_SITE_SDK_URL || ''
   } https://widget.solflare.com/;
   object-src 'none';

--- a/apps/laboratory/next.config.mjs
+++ b/apps/laboratory/next.config.mjs
@@ -12,7 +12,7 @@ const cspHeader = `
   img-src * 'self' data: blob: https://walletconnect.org https://walletconnect.com https://secure.walletconnect.com https://secure.walletconnect.org https://tokens-data.1inch.io https://tokens.1inch.io https://ipfs.io https://appkit-lab.reown.org;
   font-src 'self' https://fonts.gstatic.com;
   connect-src 'self' https://react-wallet.walletconnect.com https://rpc.walletconnect.com https://rpc.walletconnect.org https://relay.walletconnect.com https://relay.walletconnect.org wss://relay.walletconnect.com wss://relay.walletconnect.org https://pulse.walletconnect.com https://pulse.walletconnect.org https://api.web3modal.com https://api.web3modal.org wss://www.walletlink.org https://o1095249.ingest.sentry.io https://quote-api.jup.ag;
-  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org ${
+  frame-src 'self' https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://secure.walletconnect.org http://localhost:3010 ${
     process.env.NEXT_PUBLIC_SECURE_SITE_SDK_URL || ''
   } https://widget.solflare.com/;
   object-src 'none';

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -772,7 +772,7 @@ export class EthersAdapter {
     authProvider.onRpcError(() => this.handleAuthRpcError())
     authProvider.onRpcSuccess((_, request) => this.handleAuthRpcSuccess(_, request))
     authProvider.onNotConnected(() => this.handleAuthNotConnected())
-    authProvider.onIsConnected(({ preferredAccountType }) =>
+    authProvider.onConnect(({ preferredAccountType }) =>
       this.handleAuthIsConnected(preferredAccountType)
     )
     authProvider.onSetPreferredAccount(({ address, type }) => {

--- a/packages/adapters/ethers/src/tests/mocks/AuthConnector.ts
+++ b/packages/adapters/ethers/src/tests/mocks/AuthConnector.ts
@@ -6,6 +6,7 @@ export const mockAuthConnector = {
   onRpcSuccess: vi.fn(),
   onNotConnected: vi.fn(),
   onIsConnected: vi.fn(),
+  onConnect: vi.fn(),
   onSetPreferredAccount: vi.fn(),
   connect: vi.fn().mockResolvedValue({
     address: '0x1234567890123456789012345678901234567890',

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -777,7 +777,7 @@ export class Ethers5Adapter {
     authProvider.onRpcError(() => this.handleAuthRpcError())
     authProvider.onRpcSuccess((_, request) => this.handleAuthRpcSuccess(_, request))
     authProvider.onNotConnected(() => this.handleAuthNotConnected())
-    authProvider.onIsConnected(({ preferredAccountType }) =>
+    authProvider.onConnect(({ preferredAccountType }) =>
       this.handleAuthIsConnected(preferredAccountType)
     )
     authProvider.onSetPreferredAccount(({ address, type }) => {

--- a/packages/adapters/ethers5/src/tests/mocks/AuthConnector.ts
+++ b/packages/adapters/ethers5/src/tests/mocks/AuthConnector.ts
@@ -6,6 +6,7 @@ export const mockAuthConnector = {
   onRpcSuccess: vi.fn(),
   onNotConnected: vi.fn(),
   onIsConnected: vi.fn(),
+  onConnect: vi.fn(),
   onSetPreferredAccount: vi.fn(),
   connect: vi.fn().mockResolvedValue({
     address: '0x1234567890123456789012345678901234567890',

--- a/packages/adapters/solana/src/providers/AuthProvider.ts
+++ b/packages/adapters/solana/src/providers/AuthProvider.ts
@@ -229,7 +229,7 @@ export class AuthProvider extends ProviderEventEmitter implements Provider, Prov
       this.emit('auth_rpcError', error)
     })
 
-    this.getProvider().onIsConnected(response => {
+    this.getProvider().onConnect(response => {
       this.setSession(response)
       const activeNamespace = this.getActiveNamespace()
 

--- a/packages/adapters/solana/src/tests/mocks/AuthConnector.ts
+++ b/packages/adapters/solana/src/tests/mocks/AuthConnector.ts
@@ -4,6 +4,7 @@ export const mockAuthConnector = {
   onRpcRequest: vi.fn(),
   onRpcError: vi.fn(),
   onRpcSuccess: vi.fn(),
+  onConnect: vi.fn(),
   onNotConnected: vi.fn(),
   onIsConnected: vi.fn(),
   onSetPreferredAccount: vi.fn(),

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -22,7 +22,11 @@ import {
   createConfig,
   getConnectors
 } from '@wagmi/core'
-import { ChainController, ConstantsUtil as CoreConstantsUtil } from '@reown/appkit-core'
+import {
+  ChainController,
+  ConstantsUtil as CoreConstantsUtil,
+  StorageUtil
+} from '@reown/appkit-core'
 import type UniversalProvider from '@walletconnect/universal-provider'
 import type { ChainAdapter } from '@reown/appkit-core'
 import { prepareTransactionRequest, sendTransaction as wagmiSendTransaction } from '@wagmi/core'
@@ -947,24 +951,32 @@ export class WagmiAdapter implements ChainAdapter {
         }
       })
 
-      provider.onIsConnected(req => {
-        const caipAddress = `eip155:${req.chainId}:${req.address}` as CaipAddress
+      provider.onIsConnected(() => {
+        provider.connect()
+      })
+
+      provider.onConnect(user => {
+        const caipAddress = `eip155:${user.chainId}:${user.address}` as CaipAddress
         this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
-        this.appKit?.setSmartAccountDeployed(Boolean(req.smartAccountDeployed), this.chainNamespace)
-        this.appKit?.setPreferredAccountType(
-          req.preferredAccountType as W3mFrameTypes.AccountType,
+        this.appKit?.setSmartAccountDeployed(
+          Boolean(user.smartAccountDeployed),
           this.chainNamespace
         )
-        this.appKit?.setLoading(false)
+        this.appKit?.setPreferredAccountType(
+          user.preferredAccountType as W3mFrameTypes.AccountType,
+          this.chainNamespace
+        )
         this.appKit?.setAllAccounts(
-          req.accounts || [
+          user.accounts || [
             {
-              address: req.address,
-              type: (req.preferredAccountType || 'eoa') as W3mFrameTypes.AccountType
+              address: user.address,
+              type: (user.preferredAccountType || 'eoa') as W3mFrameTypes.AccountType
             }
           ],
           this.chainNamespace
         )
+        StorageUtil.setConnectedConnector('AUTH')
+        this.appKit?.setLoading(false)
       })
 
       provider.onGetSmartAccountEnabledNetworks(networks => {

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -863,7 +863,7 @@ export class WagmiAdapter implements ChainAdapter {
       this.appKit?.addConnector({
         id: ConstantsUtil.AUTH_CONNECTOR_ID,
         type: 'AUTH',
-        name: 'Auth',
+        name: 'w3mAuth',
         provider,
         chain: this.chainNamespace
       })

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -413,7 +413,7 @@ describe('Wagmi Client', () => {
       expect(mockAppKit.addConnector).toHaveBeenCalledWith({
         id: ConstantsUtil.AUTH_CONNECTOR_ID,
         type: 'AUTH',
-        name: 'Auth',
+        name: 'w3mAuth',
         provider: 'mockProvider',
         chain: 'eip155'
       })
@@ -438,7 +438,8 @@ describe('Wagmi Client', () => {
         onIsConnected: vi.fn(),
         onGetSmartAccountEnabledNetworks: vi.fn(),
         onSetPreferredAccount: vi.fn(),
-        rejectRpcRequests: vi.fn()
+        rejectRpcRequests: vi.fn(),
+        onConnect: vi.fn()
       }
       mockConnector = {
         getProvider: vi.fn().mockResolvedValue(mockProvider)

--- a/packages/core/src/controllers/ConnectorController.ts
+++ b/packages/core/src/controllers/ConnectorController.ts
@@ -55,13 +55,15 @@ export const ConnectorController = {
     connectorsByNameMap.forEach(keyConnectors => {
       const firstItem = keyConnectors[0]
 
+      const isAuthConnector = firstItem?.id === 'w3mAuth'
+
       if (keyConnectors.length > 1) {
         mergedConnectors.push({
           name: firstItem?.name,
           imageUrl: firstItem?.imageUrl,
           imageId: firstItem?.imageId,
           connectors: [...keyConnectors],
-          type: 'MULTI_CHAIN',
+          type: isAuthConnector ? 'AUTH' : 'MULTI_CHAIN',
           // These values are just placeholders, we don't use them in multi-chain connector select screen
           chain: 'eip155',
           id: firstItem?.id || ''
@@ -152,10 +154,10 @@ export const ConnectorController = {
       return undefined
     }
 
-    if (authConnector.type === 'MULTI_CHAIN' && authConnector?.connectors?.length) {
-      return authConnector.connectors.find(c => c.chain === activeNamespace) as
-        | AuthConnector
-        | undefined
+    if (authConnector?.connectors?.length) {
+      const connector = authConnector.connectors.find(c => c.chain === activeNamespace)
+
+      return connector as AuthConnector | undefined
     }
 
     return authConnector as AuthConnector

--- a/packages/core/tests/controllers/ConnectorController.test.ts
+++ b/packages/core/tests/controllers/ConnectorController.test.ts
@@ -179,7 +179,7 @@ describe('ConnectorController', () => {
         imageId: undefined,
         imageUrl: undefined,
         name: 'Auth',
-        type: 'MULTI_CHAIN',
+        type: 'AUTH',
         chain: 'eip155',
         connectors: [
           {

--- a/packages/core/tests/controllers/ConnectorController.test.ts
+++ b/packages/core/tests/controllers/ConnectorController.test.ts
@@ -53,6 +53,14 @@ const announcedConnector = {
   name: 'Announced'
 } as const
 
+const announcedConnectorSolana = {
+  id: 'announced',
+  type: 'ANNOUNCED',
+  info: { rdns: 'announced.solana.io' },
+  chain: ConstantsUtil.CHAIN.SOLANA,
+  name: 'Announced'
+} as const
+
 const syncDappDataSpy = vi.spyOn(authProvider, 'syncDappData')
 const syncThemeSpy = vi.spyOn(authProvider, 'syncTheme')
 
@@ -205,6 +213,58 @@ describe('ConnectorController', () => {
         ]
       },
       announcedConnector
+    ])
+  })
+
+  it('should merge connectors with the same chain', () => {
+    const mergedAnnouncedConnector = {
+      id: 'announced',
+      imageId: undefined,
+      imageUrl: undefined,
+      name: 'Announced',
+      type: 'MULTI_CHAIN',
+      chain: 'eip155',
+      connectors: [announcedConnector, announcedConnectorSolana]
+    }
+
+    const mergedAuthConnector = {
+      id: 'w3mAuth',
+      imageId: undefined,
+      imageUrl: undefined,
+      name: 'Auth',
+      type: 'AUTH',
+      chain: 'eip155',
+      connectors: [
+        {
+          chain: 'eip155',
+          id: 'w3mAuth',
+          name: 'Auth',
+          provider: {
+            syncDappData: syncDappDataSpy,
+            syncTheme: syncThemeSpy
+          },
+          type: 'AUTH'
+        },
+        {
+          chain: 'solana',
+          id: 'w3mAuth',
+          name: 'Auth',
+          provider: {
+            syncDappData: syncDappDataSpy,
+            syncTheme: syncThemeSpy
+          },
+          type: 'AUTH'
+        }
+      ]
+    }
+    ConnectorController.addConnector(announcedConnectorSolana)
+    expect(ConnectorController.getConnectors()).toEqual([
+      walletConnectConnector,
+      externalConnector,
+      metamaskConnector,
+      zerionConnector,
+      mergedAuthConnector,
+      mergedAnnouncedConnector
     ])
   })
 })

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -365,12 +365,13 @@ export class W3mFrameProvider {
     this.rpcErrorHandler = callback
   }
 
-  public onIsConnected(
-    callback: (request: W3mFrameTypes.Responses['FrameGetUserResponse']) => void
-  ) {
+  public onIsConnected(callback: () => void) {
     this.w3mFrame.events.onFrameEvent(event => {
-      if (event.type === W3mFrameConstants.FRAME_GET_USER_SUCCESS) {
-        callback(event.payload)
+      if (
+        event.type === W3mFrameConstants.FRAME_IS_CONNECTED_SUCCESS &&
+        event.payload.isConnected
+      ) {
+        callback()
       }
     })
   }
@@ -385,6 +386,14 @@ export class W3mFrameProvider {
         !event.payload.isConnected
       ) {
         callback()
+      }
+    })
+  }
+
+  public onConnect(callback: (user: W3mFrameTypes.Responses['FrameGetUserResponse']) => void) {
+    this.w3mFrame.events.onFrameEvent(event => {
+      if (event.type === W3mFrameConstants.FRAME_GET_USER_SUCCESS) {
+        callback(event.payload)
       }
     })
   }


### PR DESCRIPTION
# Description

- Fixes issue on wagmi + solana where wagmi auth provider was not properly merged to a multichain connector.
- Fixes wagmi's authConnector name to `w3mAuth`
- Makes type stay as `AUTH` so that it's recognized by the UI
- Amends `getAuthConnector`
- Fixes issue where wagmi would not reconnect automatically when `isConnected = true` 

Supersedes https://github.com/reown-com/appkit/pull/2876

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1131

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
