### PR TITLE
fix: deeplinks not working

### DIFF
--- a/.changeset/selfish-books-applaud.md
+++ b/.changeset/selfish-books-applaud.md
@@ -1,0 +1,38 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-scaffold-ui': patch
+'@apps/laboratory': patch
+'@reown/appkit': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@examples/html-ethers': patch
+'@examples/html-ethers5': patch
+'@examples/html-wagmi': patch
+'@examples/next-ethers': patch
+'@examples/next-wagmi': patch
+'@examples/react-ethers': patch
+'@examples/react-ethers5': patch
+'@examples/react-solana': patch
+'@examples/react-wagmi': patch
+'@examples/vue-ethers5': patch
+'@examples/vue-solana': patch
+'@examples/vue-wagmi': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-ethers': patch
+'@reown/appkit-ethers5': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-solana': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wagmi': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixed deep link not working after connecting a wallet

--- a/apps/laboratory/tests/shared/utils/validation.ts
+++ b/apps/laboratory/tests/shared/utils/validation.ts
@@ -8,6 +8,6 @@ export async function expectConnection(
   await modalValidator.expectConnected()
   await walletValidator.expectConnected()
   await modalValidator.page.evaluate(
-    `window.localStorage.setItem('@appkit/deeplink_choice', JSON.stringify({ href: '', name: '' }))`
+    `window.localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', JSON.stringify({ href: '', name: '' }))`
   )
 }

--- a/apps/laboratory/tests/shared/utils/validation.ts
+++ b/apps/laboratory/tests/shared/utils/validation.ts
@@ -8,6 +8,6 @@ export async function expectConnection(
   await modalValidator.expectConnected()
   await walletValidator.expectConnected()
   await modalValidator.page.evaluate(
-    `window.localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', JSON.stringify({ href: '', name: '' }))`
+    `window.localStorage.setItem('@appkit/deeplink_choice', JSON.stringify({ href: '', name: '' }))`
   )
 }

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -829,7 +829,6 @@ export class Ethers5Adapter {
       return
     }
 
-    this.appKit?.setIsConnected(true, this.chainNamespace)
     this.appKit?.setPreferredAccountType(
       preferredAccountType as W3mFrameTypes.AccountType,
       this.chainNamespace

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -110,10 +110,6 @@ export class AppKit {
     return NetworkController.switchActiveNetwork(caipNetwork)
   }
 
-  public getIsConnected() {
-    return AccountController.state.isConnected
-  }
-
   public getWalletProvider() {
     return ChainController.state.activeChain
       ? ProviderUtil.state.providers[ChainController.state.activeChain]
@@ -218,15 +214,11 @@ export class AppKit {
     ]?.replace
   }
 
-  public setIsConnected: (typeof AccountController)['setIsConnected'] = (isConnected, chain) => {
-    AccountController.setIsConnected(isConnected, chain)
-  }
-
   public setStatus: (typeof AccountController)['setStatus'] = (status, chain) => {
     AccountController.setStatus(status, chain)
   }
 
-  public getIsConnectedState = () => AccountController.state.isConnected
+  public getIsConnectedState = () => Boolean(ChainController.state.activeCaipAddress)
 
   public setAllAccounts: (typeof AccountController)['setAllAccounts'] = (addresses, chain) => {
     AccountController.setAllAccounts(addresses, chain)

--- a/packages/appkit/src/tests/appkit.test.ts
+++ b/packages/appkit/src/tests/appkit.test.ts
@@ -177,19 +177,9 @@ describe('Base', () => {
       expect(appKit.isTransactionShouldReplaceView()).toBe(true)
     })
 
-    it('should set is connected', () => {
-      appKit.setIsConnected(true, 'eip155')
-      expect(AccountController.setIsConnected).toHaveBeenCalledWith(true, 'eip155')
-    })
-
     it('should set status', () => {
       appKit.setStatus('connected', 'eip155')
       expect(AccountController.setStatus).toHaveBeenCalledWith('connected', 'eip155')
-    })
-
-    it('should get is connected state', () => {
-      vi.mocked(AccountController).state = { isConnected: true } as any
-      expect(appKit.getIsConnectedState()).toBe(true)
     })
 
     it('should set all accounts', () => {
@@ -239,6 +229,7 @@ describe('Base', () => {
 
     it('should set CAIP address', () => {
       appKit.setCaipAddress('eip155:1:0x123', 'eip155')
+      expect(appKit.getIsConnectedState()).toBe(true)
       expect(AccountController.setCaipAddress).toHaveBeenCalledWith('eip155:1:0x123', 'eip155')
     })
 

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -528,7 +528,7 @@ export class UniversalAdapterClient {
           this.syncConnectedWalletInfo()
           await Promise.all([this.appKit?.setApprovedCaipNetworksData(chainNamespace)])
         }
-        
+
         this.syncAccounts()
       })
     } else {

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -526,9 +526,10 @@ export class UniversalAdapterClient {
           this.appKit?.setPreferredAccountType(preferredAccountType, chainNamespace)
           this.appKit?.setCaipAddress(address, chainNamespace)
           this.syncConnectedWalletInfo()
-          this.syncAccounts()
           await Promise.all([this.appKit?.setApprovedCaipNetworksData(chainNamespace)])
         }
+        
+        this.syncAccounts()
       })
     } else {
       this.appKit?.resetWcConnection()

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -8,7 +8,7 @@ export type SafeLocalStorageItems = {
   '@appkit/connected_social': string
   '@appkit/connected_social_username': string
   '@appkit/recent_wallets': string
-  WALLETCONNECT_DEEPLINK_CHOICE: { href: string; name: string }
+  '@appkit/deeplink': string
 }
 
 export const SafeLocalStorageKeys = {
@@ -21,7 +21,7 @@ export const SafeLocalStorageKeys = {
   CONNECTED_SOCIAL: '@appkit/connected_social',
   CONNECTED_SOCIAL_USERNAME: '@appkit/connected_social_username',
   RECENT_WALLETS: '@appkit/recent_wallets',
-  DEEPLINK_CHOICE: 'WALLETCONNECT_DEEPLINK_CHOICE'
+  DEEPLINK: '@appkit/deeplink'
 } as const
 
 export const SafeLocalStorage = {
@@ -30,29 +30,14 @@ export const SafeLocalStorage = {
     value: SafeLocalStorageItems[Key]
   ): void {
     if (isSafe()) {
-      localStorage.setItem(
-        key,
-        key === SafeLocalStorageKeys.DEEPLINK_CHOICE ? JSON.stringify(value) : (value as string)
-      )
+      localStorage.setItem(key, value)
     }
   },
   getItem<Key extends keyof SafeLocalStorageItems>(
     key: Key
   ): SafeLocalStorageItems[Key] | undefined {
     if (isSafe()) {
-      const value = localStorage.getItem(key)
-
-      if (value) {
-        if (key === SafeLocalStorageKeys.DEEPLINK_CHOICE) {
-          try {
-            return JSON.parse(value)
-          } catch {
-            return undefined
-          }
-        }
-
-        return value as SafeLocalStorageItems[Key]
-      }
+      return localStorage.getItem(key) || undefined
     }
 
     return undefined

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -8,7 +8,8 @@ export type SafeLocalStorageItems = {
   '@appkit/connected_social': string
   '@appkit/connected_social_username': string
   '@appkit/recent_wallets': string
-  '@appkit/deeplink': string
+  // Hardcoding the value since @walletconnect/universal-provider package uses it
+  WALLETCONNECT_DEEPLINK_CHOICE: string
 }
 
 export const SafeLocalStorageKeys = {
@@ -21,7 +22,7 @@ export const SafeLocalStorageKeys = {
   CONNECTED_SOCIAL: '@appkit/connected_social',
   CONNECTED_SOCIAL_USERNAME: '@appkit/connected_social_username',
   RECENT_WALLETS: '@appkit/recent_wallets',
-  DEEPLINK: '@appkit/deeplink'
+  DEEPLINK_CHOICE: 'WALLETCONNECT_DEEPLINK_CHOICE'
 } as const
 
 export const SafeLocalStorage = {

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -8,7 +8,10 @@ export type SafeLocalStorageItems = {
   '@appkit/connected_social': string
   '@appkit/connected_social_username': string
   '@appkit/recent_wallets': string
-  // Hardcoding the value since @walletconnect/universal-provider package uses it
+  /*
+   * DO NOT CHANGE: @walletconnect/universal-provider requires us to set this specific key
+   *  This value is a stringified version of { href: stiring; name: string }
+   */
   WALLETCONNECT_DEEPLINK_CHOICE: string
 }
 

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -8,7 +8,7 @@ export type SafeLocalStorageItems = {
   '@appkit/connected_social': string
   '@appkit/connected_social_username': string
   '@appkit/recent_wallets': string
-  '@appkit/deeplink_choice': string
+  WALLETCONNECT_DEEPLINK_CHOICE: { href: string; name: string }
 }
 
 export const SafeLocalStorageKeys = {
@@ -21,7 +21,7 @@ export const SafeLocalStorageKeys = {
   CONNECTED_SOCIAL: '@appkit/connected_social',
   CONNECTED_SOCIAL_USERNAME: '@appkit/connected_social_username',
   RECENT_WALLETS: '@appkit/recent_wallets',
-  DEEPLINK_CHOICE: '@appkit/deeplink_choice'
+  DEEPLINK_CHOICE: 'WALLETCONNECT_DEEPLINK_CHOICE'
 } as const
 
 export const SafeLocalStorage = {
@@ -30,14 +30,29 @@ export const SafeLocalStorage = {
     value: SafeLocalStorageItems[Key]
   ): void {
     if (isSafe()) {
-      localStorage.setItem(key, value)
+      localStorage.setItem(
+        key,
+        key === SafeLocalStorageKeys.DEEPLINK_CHOICE ? JSON.stringify(value) : (value as string)
+      )
     }
   },
   getItem<Key extends keyof SafeLocalStorageItems>(
     key: Key
   ): SafeLocalStorageItems[Key] | undefined {
     if (isSafe()) {
-      return localStorage.getItem(key) || undefined
+      const value = localStorage.getItem(key)
+
+      if (value) {
+        if (key === SafeLocalStorageKeys.DEEPLINK_CHOICE) {
+          try {
+            return JSON.parse(value)
+          } catch {
+            return undefined
+          }
+        }
+
+        return value as SafeLocalStorageItems[Key]
+      }
     }
 
     return undefined

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -19,7 +19,6 @@ import type UniversalProvider from '@walletconnect/universal-provider'
 
 // -- Types --------------------------------------------- //
 export interface AccountControllerState {
-  isConnected: boolean
   currentTab: number
   caipAddress?: CaipAddress
   address?: string
@@ -45,7 +44,6 @@ export interface AccountControllerState {
 
 // -- State --------------------------------------------- //
 const state = proxy<AccountControllerState>({
-  isConnected: false,
   currentTab: 0,
   tokenBalance: [],
   smartAccountDeployed: false,
@@ -97,19 +95,8 @@ export const AccountController = {
     )
   },
 
-  setIsConnected(
-    isConnected: AccountControllerState['isConnected'],
-    chain: ChainNamespace | undefined
-  ) {
-    ChainController.setAccountProp('isConnected', isConnected, chain)
-  },
-
   setStatus(status: AccountControllerState['status'], chain: ChainNamespace | undefined) {
     ChainController.setAccountProp('status', status, chain)
-  },
-
-  getChainIsConnected(chain: ChainNamespace | undefined) {
-    return ChainController.getAccountProp('isConnected', chain)
   },
 
   getCaipAddress(chain: ChainNamespace | undefined) {

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -39,7 +39,6 @@ type ChainsInitializerAdapter = Pick<
 
 // -- Constants ----------------------------------------- //
 const accountState: AccountControllerState = {
-  isConnected: false,
   currentTab: 0,
   tokenBalance: [],
   smartAccountDeployed: false,
@@ -449,7 +448,6 @@ export const ChainController = {
     this.setChainAccountData(
       chainToWrite,
       ref({
-        isConnected: false,
         smartAccountDeployed: false,
         currentTab: 0,
         caipAddress: undefined,

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -7,10 +7,10 @@ import { ChainController } from '../controllers/ChainController.js'
 export const StorageUtil = {
   setWalletConnectDeepLink({ name, href }: { href: string; name: string }) {
     try {
-      const value = JSON.stringify({ href, name })
-      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK, value)
+      const deeplink = JSON.stringify({ href, name })
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK, deeplink)
       // Required by @walletconnect/universal-provider to handle deep links
-      localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', value)
+      localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', deeplink)
     } catch {
       console.info('Unable to set WalletConnect deep link')
     }

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -5,9 +5,9 @@ import { ChainController } from '../controllers/ChainController.js'
 
 // -- Utility -----------------------------------------------------------------
 export const StorageUtil = {
-  setWalletConnectDeepLink({ href }: { href: string; name: string }) {
+  setWalletConnectDeepLink({ name, href }: { href: string; name: string }) {
     try {
-      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK_CHOICE, href)
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK_CHOICE, { href, name })
     } catch {
       console.info('Unable to set WalletConnect deep link')
     }

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -7,7 +7,10 @@ import { ChainController } from '../controllers/ChainController.js'
 export const StorageUtil = {
   setWalletConnectDeepLink({ name, href }: { href: string; name: string }) {
     try {
-      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK_CHOICE, { href, name })
+      const value = JSON.stringify({ href, name })
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK, value)
+      // Required by @walletconnect/universal-provider to handle deep links
+      localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', value)
     } catch {
       console.info('Unable to set WalletConnect deep link')
     }
@@ -15,9 +18,9 @@ export const StorageUtil = {
 
   getWalletConnectDeepLink() {
     try {
-      const deepLink = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
+      const deepLink = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK)
       if (deepLink) {
-        return deepLink
+        return JSON.parse(deepLink)
       }
     } catch {
       console.info('Unable to get WalletConnect deep link')
@@ -28,7 +31,8 @@ export const StorageUtil = {
 
   deleteWalletConnectDeepLink() {
     try {
-      SafeLocalStorage.removeItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
+      SafeLocalStorage.removeItem(SafeLocalStorageKeys.DEEPLINK)
+      localStorage.removeItem('WALLETCONNECT_DEEPLINK_CHOICE')
     } catch {
       console.info('Unable to delete WalletConnect deep link')
     }

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -7,10 +7,7 @@ import { ChainController } from '../controllers/ChainController.js'
 export const StorageUtil = {
   setWalletConnectDeepLink({ name, href }: { href: string; name: string }) {
     try {
-      const deeplink = JSON.stringify({ href, name })
-      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK, deeplink)
-      // Required by @walletconnect/universal-provider to handle deep links
-      localStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', deeplink)
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.DEEPLINK_CHOICE, JSON.stringify({ href, name }))
     } catch {
       console.info('Unable to set WalletConnect deep link')
     }
@@ -18,7 +15,7 @@ export const StorageUtil = {
 
   getWalletConnectDeepLink() {
     try {
-      const deepLink = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK)
+      const deepLink = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
       if (deepLink) {
         return JSON.parse(deepLink)
       }
@@ -31,8 +28,7 @@ export const StorageUtil = {
 
   deleteWalletConnectDeepLink() {
     try {
-      SafeLocalStorage.removeItem(SafeLocalStorageKeys.DEEPLINK)
-      localStorage.removeItem('WALLETCONNECT_DEEPLINK_CHOICE')
+      SafeLocalStorage.removeItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
     } catch {
       console.info('Unable to delete WalletConnect deep link')
     }

--- a/packages/core/tests/controllers/AccountController.test.ts
+++ b/packages/core/tests/controllers/AccountController.test.ts
@@ -24,18 +24,12 @@ beforeAll(() => {
 describe('AccountController', () => {
   it('should have valid default state', () => {
     expect(AccountController.state).toEqual({
-      isConnected: false,
       smartAccountDeployed: false,
       currentTab: 0,
       tokenBalance: [],
       allAccounts: [],
       addressLabels: new Map<string, string>()
     })
-  })
-
-  it('should update state correctly on setIsConnected()', () => {
-    AccountController.setIsConnected(true, chain)
-    expect(AccountController.state.isConnected).toEqual(true)
   })
 
   it('should update state correctly on setCaipAddress()', () => {
@@ -81,7 +75,6 @@ describe('AccountController', () => {
   it('should update state correctly on resetAccount()', () => {
     AccountController.resetAccount(chain)
     expect(AccountController.state).toEqual({
-      isConnected: false,
       smartAccountDeployed: false,
       currentTab: 0,
       caipAddress: undefined,

--- a/packages/core/tests/controllers/ChainController.test.ts
+++ b/packages/core/tests/controllers/ChainController.test.ts
@@ -61,7 +61,6 @@ describe('ChainController', () => {
 
   it('should reset account as expected', () => {
     ChainController.resetAccount(ChainController.state.activeChain)
-    expect(ChainController.getAccountProp('isConnected')).toEqual(false)
     expect(ChainController.getAccountProp('smartAccountDeployed')).toEqual(false)
     expect(ChainController.getAccountProp('currentTab')).toEqual(0)
     expect(ChainController.getAccountProp('caipAddress')).toEqual(undefined)

--- a/packages/core/tests/utils/StorageUtil.test.ts
+++ b/packages/core/tests/utils/StorageUtil.test.ts
@@ -45,7 +45,7 @@ describe('StorageUtil', () => {
     it('should set WalletConnect deep link in localStorage', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
       StorageUtil.setWalletConnectDeepLink(deepLink)
-      const savedDL = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK)
+      const savedDL = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
       expect(savedDL).toBe(JSON.stringify({ href: deepLink.href, name: deepLink.name }))
     })
 
@@ -64,7 +64,7 @@ describe('StorageUtil', () => {
     it('should get WalletConnect deep link from localStorage', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
       SafeLocalStorage.setItem(
-        '@appkit/deeplink',
+        'WALLETCONNECT_DEEPLINK_CHOICE',
         JSON.stringify({ href: deepLink.href, name: deepLink.name })
       )
       expect(StorageUtil.getWalletConnectDeepLink()).toEqual({
@@ -91,11 +91,11 @@ describe('StorageUtil', () => {
   describe('deleteWalletConnectDeepLink', () => {
     it('should delete WalletConnect deep link from localStorage', () => {
       SafeLocalStorage.setItem(
-        '@appkit/deeplink',
+        'WALLETCONNECT_DEEPLINK_CHOICE',
         JSON.stringify({ href: 'https://example.com', name: 'Example' })
       )
       StorageUtil.deleteWalletConnectDeepLink()
-      expect(SafeLocalStorage.getItem('@appkit/deeplink')).toBeUndefined()
+      expect(SafeLocalStorage.getItem('WALLETCONNECT_DEEPLINK_CHOICE')).toBeUndefined()
     })
 
     it('should handle errors when deleting deep link', () => {

--- a/packages/core/tests/utils/StorageUtil.test.ts
+++ b/packages/core/tests/utils/StorageUtil.test.ts
@@ -46,7 +46,7 @@ describe('StorageUtil', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
       StorageUtil.setWalletConnectDeepLink(deepLink)
       const savedDL = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
-      expect(savedDL).toBe(deepLink.href)
+      expect(savedDL).toEqual({ href: deepLink.href, name: deepLink.name })
     })
 
     it('should handle errors when setting deep link', () => {
@@ -63,8 +63,14 @@ describe('StorageUtil', () => {
   describe('getWalletConnectDeepLink', () => {
     it('should get WalletConnect deep link from localStorage', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
-      SafeLocalStorage.setItem('@appkit/deeplink_choice', deepLink.href)
-      expect(StorageUtil.getWalletConnectDeepLink()).toEqual(deepLink.href)
+      SafeLocalStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', {
+        href: deepLink.href,
+        name: deepLink.name
+      })
+      expect(StorageUtil.getWalletConnectDeepLink()).toEqual({
+        href: deepLink.href,
+        name: deepLink.name
+      })
     })
 
     it('should return undefined if deep link is not set', () => {
@@ -84,9 +90,12 @@ describe('StorageUtil', () => {
 
   describe('deleteWalletConnectDeepLink', () => {
     it('should delete WalletConnect deep link from localStorage', () => {
-      SafeLocalStorage.setItem('@appkit/deeplink_choice', 'https://example.com')
+      SafeLocalStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', {
+        href: 'https://example.com',
+        name: 'Example'
+      })
       StorageUtil.deleteWalletConnectDeepLink()
-      expect(SafeLocalStorage.getItem('@appkit/deeplink_choice')).toBeUndefined()
+      expect(SafeLocalStorage.getItem('WALLETCONNECT_DEEPLINK_CHOICE')).toBeUndefined()
     })
 
     it('should handle errors when deleting deep link', () => {

--- a/packages/core/tests/utils/StorageUtil.test.ts
+++ b/packages/core/tests/utils/StorageUtil.test.ts
@@ -45,8 +45,8 @@ describe('StorageUtil', () => {
     it('should set WalletConnect deep link in localStorage', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
       StorageUtil.setWalletConnectDeepLink(deepLink)
-      const savedDL = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK_CHOICE)
-      expect(savedDL).toEqual({ href: deepLink.href, name: deepLink.name })
+      const savedDL = SafeLocalStorage.getItem(SafeLocalStorageKeys.DEEPLINK)
+      expect(savedDL).toBe(JSON.stringify({ href: deepLink.href, name: deepLink.name }))
     })
 
     it('should handle errors when setting deep link', () => {
@@ -63,10 +63,10 @@ describe('StorageUtil', () => {
   describe('getWalletConnectDeepLink', () => {
     it('should get WalletConnect deep link from localStorage', () => {
       const deepLink = { href: 'https://example.com', name: 'Example Wallet' }
-      SafeLocalStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', {
-        href: deepLink.href,
-        name: deepLink.name
-      })
+      SafeLocalStorage.setItem(
+        '@appkit/deeplink',
+        JSON.stringify({ href: deepLink.href, name: deepLink.name })
+      )
       expect(StorageUtil.getWalletConnectDeepLink()).toEqual({
         href: deepLink.href,
         name: deepLink.name
@@ -90,12 +90,12 @@ describe('StorageUtil', () => {
 
   describe('deleteWalletConnectDeepLink', () => {
     it('should delete WalletConnect deep link from localStorage', () => {
-      SafeLocalStorage.setItem('WALLETCONNECT_DEEPLINK_CHOICE', {
-        href: 'https://example.com',
-        name: 'Example'
-      })
+      SafeLocalStorage.setItem(
+        '@appkit/deeplink',
+        JSON.stringify({ href: 'https://example.com', name: 'Example' })
+      )
       StorageUtil.deleteWalletConnectDeepLink()
-      expect(SafeLocalStorage.getItem('WALLETCONNECT_DEEPLINK_CHOICE')).toBeUndefined()
+      expect(SafeLocalStorage.getItem('@appkit/deeplink')).toBeUndefined()
     })
 
     it('should handle errors when deleting deep link', () => {

--- a/packages/scaffold-ui/src/views/w3m-select-addresses-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-select-addresses-view/index.ts
@@ -135,8 +135,8 @@ export class W3mSelectAddressesView extends LitElement {
   }
 
   private async onCancel() {
-    const { isConnected } = AccountController.state
-    if (isConnected) {
+    const { activeCaipAddress } = ChainController.state
+    if (activeCaipAddress) {
       await ConnectionController.disconnect()
       ModalController.close()
     } else {


### PR DESCRIPTION
# Description

After connecting with a wallet on mobile deeplinks will fail when trying to sign a message or tx. 
This is happening because [this.appkit.getIsConnectedState()](https://github.com/reown-com/appkit/blob/main/packages/appkit/src/universal-adapter/client.ts#L517) is always `false`.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1133

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
