### PR TITLE
chore: re enable tests 

### DIFF
--- a/apps/laboratory/tests/multichain/multichain-wagmi-solana.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-wagmi-solana.spec.ts
@@ -48,7 +48,7 @@ test.skip('it should show disabled networks', async () => {
   await modalPage.closeModal()
 })
 
-test.only('it should switch networks and sign', async () => {
+test('it should switch networks and sign', async () => {
   const chains = ['Polygon', 'Solana']
 
   async function processChain(index: number) {

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -1047,11 +1047,11 @@ export class EthersAdapter {
           if (this.authProvider) {
             try {
               this.appKit?.setLoading(true)
-              const { chainId } = await this.authProvider.switchNetwork(caipNetwork.id)
+              await this.authProvider.switchNetwork(caipNetwork.id)
               const { address, preferredAccountType } = await this.authProvider.connect({
                 chainId: caipNetwork.id
               })
-              const caipAddress = `${this.chainNamespace}:${chainId}:${address}`
+              const caipAddress = `${caipNetwork.id}:${address}`
 
               this.appKit?.setCaipNetwork(caipNetwork)
               this.appKit?.setCaipAddress(caipAddress as CaipAddress, this.chainNamespace)

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -1047,11 +1047,9 @@ export class EthersAdapter {
           if (this.authProvider) {
             try {
               this.appKit?.setLoading(true)
-              const { chainId } = await this.authProvider.switchNetwork(
-                caipNetwork.chainId as number
-              )
+              const { chainId } = await this.authProvider.switchNetwork(caipNetwork.id)
               const { address, preferredAccountType } = await this.authProvider.connect({
-                chainId: caipNetwork.chainId as number | undefined
+                chainId: caipNetwork.id
               })
               const caipAddress = `${this.chainNamespace}:${chainId}:${address}`
 

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -1060,11 +1060,11 @@ export class Ethers5Adapter {
           if (this.authProvider) {
             try {
               this.appKit?.setLoading(true)
-              const { chainId } = await this.authProvider.switchNetwork(caipNetwork.id)
+              await this.authProvider.switchNetwork(caipNetwork.id)
               const { address, preferredAccountType } = await this.authProvider.connect({
                 chainId: caipNetwork.id
               })
-              const caipAddress = `${this.chainNamespace}:${chainId}:${address}`
+              const caipAddress = `${caipNetwork.id}:${address}`
 
               this.appKit?.setCaipNetwork(caipNetwork)
               this.appKit?.setCaipAddress(caipAddress as CaipAddress, this.chainNamespace)

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -1060,11 +1060,9 @@ export class Ethers5Adapter {
           if (this.authProvider) {
             try {
               this.appKit?.setLoading(true)
-              const { chainId } = await this.authProvider.switchNetwork(
-                caipNetwork.chainId as number
-              )
+              const { chainId } = await this.authProvider.switchNetwork(caipNetwork.id)
               const { address, preferredAccountType } = await this.authProvider.connect({
-                chainId: caipNetwork.chainId as number | undefined
+                chainId: caipNetwork.id
               })
               const caipAddress = `${this.chainNamespace}:${chainId}:${address}`
 

--- a/packages/adapters/solana/src/client.ts
+++ b/packages/adapters/solana/src/client.ts
@@ -376,7 +376,7 @@ export class SolanaAdapter implements ChainAdapter {
     }
 
     if (!this.appKit?.getCaipNetwork()) {
-      throw new Error('CaipNetwork is not set')
+      this.appKit?.setCaipNetwork(this.defaultCaipNetwork)
     }
 
     const balance =

--- a/packages/adapters/solana/src/client.ts
+++ b/packages/adapters/solana/src/client.ts
@@ -416,13 +416,16 @@ export class SolanaAdapter implements ChainAdapter {
       const user = await this.w3mFrameProvider?.getUser({
         chainId: caipNetwork?.id
       })
-      this.authSession = user
+      if (caipNetwork.chainNamespace === 'solana') {
+        this.authSession = user
+      }
       if (user) {
-        const caipAddress = `solana:${caipNetwork.chainId}:${user.address}` as CaipAddress
-        ProviderUtil.setProvider(this.chainNamespace, this.authProvider)
-        ProviderUtil.setProviderId(this.chainNamespace, 'walletConnect')
-        this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
-        this.syncAccount(user.address)
+        const caipAddress = `${caipNetwork.id}:${user.address}`
+        this.appKit?.setCaipNetwork(caipNetwork)
+        this.appKit?.setCaipAddress(caipAddress as CaipAddress, this.chainNamespace)
+        if (caipNetwork.chainNamespace === 'solana') {
+          this.syncAccount(user.address)
+        }
       }
     } else {
       this.appKit?.setCaipNetwork(caipNetwork)

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -601,7 +601,14 @@ export class WagmiAdapter implements ChainAdapter {
     >
   >) {
     const isConnected = ChainController.state.activeCaipAddress
-
+    console.log('>> SyncAccount - ', {
+      address,
+      chainId,
+      connector,
+      addresses,
+      status,
+      isConnected
+    })
     if (status === 'disconnected' && !isConnected) {
       this.appKit?.resetAccount(this.chainNamespace)
       this.appKit?.resetWcConnection()
@@ -614,7 +621,9 @@ export class WagmiAdapter implements ChainAdapter {
 
     if (this.wagmiConfig) {
       if (connector) {
+        console.log('>> SyncAccount - Connector', connector)
         if (connector && connector.name === 'WalletConnect' && connector.getProvider && address) {
+          console.log('>> SyncAccount - WalletConnect')
           const currentChainId =
             chainId || Number(NetworkUtil.caipNetworkIdToNumber(this.appKit?.getCaipNetwork()?.id))
           const provider = (await connector.getProvider()) as UniversalProvider
@@ -635,7 +644,7 @@ export class WagmiAdapter implements ChainAdapter {
             this.appKit?.setCaipAddress(caipAddress, chainNamespace)
           })
           if (this.appKit?.getCaipNetwork()?.chainNamespace !== 'solana') {
-            this.syncNetwork(address, currentChainId, true)
+            await this.syncNetwork(address, currentChainId, true)
             await Promise.all([
               this.syncProfile(address, currentChainId),
               this.syncBalance(address, currentChainId),
@@ -644,15 +653,18 @@ export class WagmiAdapter implements ChainAdapter {
             ])
           }
         } else if (status === 'connected' && address && chainId) {
+          console.log('>> SyncAccount - Connected', address, chainId)
           const caipAddress = `eip155:${chainId}:${address}` as CaipAddress
           this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
           await this.syncNetwork(address, chainId, true)
+          console.log('>> SyncAccount - synced Network')
           await Promise.all([
             this.syncProfile(address, chainId),
             this.syncBalance(address, chainId),
             this.syncConnectedWalletInfo(connector),
             this.appKit?.setApprovedCaipNetworksData(this.chainNamespace)
           ])
+          console.log('>> SyncAccount - Connected')
           if (connector) {
             this.syncConnectedWalletInfo(connector)
           }

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -645,8 +645,8 @@ export class WagmiAdapter implements ChainAdapter {
           }
         } else if (status === 'connected' && address && chainId) {
           const caipAddress = `eip155:${chainId}:${address}` as CaipAddress
-          this.syncNetwork(address, chainId, true)
           this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
+          await this.syncNetwork(address, chainId, true)
           await Promise.all([
             this.syncProfile(address, chainId),
             this.syncBalance(address, chainId),
@@ -683,7 +683,6 @@ export class WagmiAdapter implements ChainAdapter {
 
   private async syncNetwork(address?: Hex, chainId?: number, isConnected?: boolean) {
     const chain = this.caipNetworks.find((c: CaipNetwork) => c.chainId === chainId)
-
     if (chain && chainId) {
       this.appKit?.setCaipNetwork({
         chainId: chain.chainId,

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -601,14 +601,6 @@ export class WagmiAdapter implements ChainAdapter {
     >
   >) {
     const isConnected = ChainController.state.activeCaipAddress
-    console.log('>> SyncAccount - ', {
-      address,
-      chainId,
-      connector,
-      addresses,
-      status,
-      isConnected
-    })
     if (status === 'disconnected' && !isConnected) {
       this.appKit?.resetAccount(this.chainNamespace)
       this.appKit?.resetWcConnection()
@@ -621,9 +613,7 @@ export class WagmiAdapter implements ChainAdapter {
 
     if (this.wagmiConfig) {
       if (connector) {
-        console.log('>> SyncAccount - Connector', connector)
         if (connector && connector.name === 'WalletConnect' && connector.getProvider && address) {
-          console.log('>> SyncAccount - WalletConnect')
           const currentChainId =
             chainId || Number(NetworkUtil.caipNetworkIdToNumber(this.appKit?.getCaipNetwork()?.id))
           const provider = (await connector.getProvider()) as UniversalProvider
@@ -653,18 +643,15 @@ export class WagmiAdapter implements ChainAdapter {
             ])
           }
         } else if (status === 'connected' && address && chainId) {
-          console.log('>> SyncAccount - Connected', address, chainId)
           const caipAddress = `eip155:${chainId}:${address}` as CaipAddress
           this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
           await this.syncNetwork(address, chainId, true)
-          console.log('>> SyncAccount - synced Network')
           await Promise.all([
             this.syncProfile(address, chainId),
             this.syncBalance(address, chainId),
             this.syncConnectedWalletInfo(connector),
             this.appKit?.setApprovedCaipNetworksData(this.chainNamespace)
           ])
-          console.log('>> SyncAccount - Connected')
           if (connector) {
             this.syncConnectedWalletInfo(connector)
           }

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -68,7 +68,11 @@ export function authConnector(parameters: AuthParameters) {
 
     async getAccounts() {
       const provider = await this.getProvider()
-      const { address } = await provider.connect()
+      let chainId = provider.getLastUsedChainId()
+      if (!chainId) {
+        chainId = await this.getChainId()
+      }
+      const { address } = await provider.connect({ chainId })
       config.emitter.emit('change', { accounts: [address as Address] })
 
       return [address as Address]

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -68,11 +68,7 @@ export function authConnector(parameters: AuthParameters) {
 
     async getAccounts() {
       const provider = await this.getProvider()
-      let chainId = provider.getLastUsedChainId()
-      if (!chainId) {
-        chainId = await this.getChainId()
-      }
-      const { address } = await provider.connect({ chainId })
+      const { address } = await provider.connect()
       config.emitter.emit('change', { accounts: [address as Address] })
 
       return [address as Address]

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -92,17 +92,11 @@ describe('Wagmi Client', () => {
       expect(mockAppKit.getIsConnectedState()).toBe(false)
       expect(mockAppKit.getCaipAddress()).toBeUndefined()
 
-      const setApprovedCaipNetworksData = vi
-        .spyOn(mockAppKit, 'setApprovedCaipNetworksData')
-        .mockResolvedValue()
-
       expect(mockWagmiClient.wagmiConfig).toBeDefined()
 
       await connect(mockWagmiClient.wagmiConfig, {
         connector: mockWagmiClient.wagmiConfig.connectors[0]!
       })
-
-      expect(setApprovedCaipNetworksData).toHaveBeenCalledOnce()
 
       expect(mockAppKit.getCaipAddress()).toBe(
         `${ConstantsUtil.EIP155}:${mainnet.chainId}:${mockAccount.address}`

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -293,7 +293,7 @@ export class AppKit {
     AccountController.resetAccount(chain)
   }
 
-  public setCaipNetwork: (typeof NetworkController)['setCaipNetwork'] = caipNetwork => {
+  public setCaipNetwork: (typeof ChainController)['setActiveCaipNetwork'] = caipNetwork => {
     ChainController.setActiveCaipNetwork(caipNetwork)
   }
 

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -257,11 +257,9 @@ export class AppKit {
   }
 
   public getAddress = (chainNamespace?: ChainNamespace) => {
-    if (ChainController.state.activeChain === chainNamespace || !chainNamespace) {
-      return AccountController.state.address
-    }
+    const caipAddress = this.getCaipAddress(chainNamespace)
 
-    return ChainController.getAccountProp('address', chainNamespace)
+    return caipAddress?.split(':')[2]
   }
 
   public getProvider = () => AccountController.state.provider

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -274,29 +274,6 @@ export const ChainController = {
       this.setActiveNamespace(caipNetwork.chainNamespace, caipNetwork)
     }
   },
-
-  /**
-   * The setCaipNetwork function is being called for different purposes and it needs to be controlled if it should replace the NetworkController state or not.
-   * While we initializing the adapters, we need to set the caipNetwork without replacing the state.
-   * But when we switch the network, we need to replace the state.
-   * @param chain
-   * @param caipNetwork
-   * @param shouldReplace - if true, it will replace the NetworkController state
-   */
-  setCaipNetwork(
-    chain: ChainNamespace | undefined,
-    caipNetwork: NetworkControllerState['caipNetwork'],
-    shouldReplace = false
-  ) {
-    state.activeChain = caipNetwork?.chainNamespace
-    state.activeCaipNetwork = caipNetwork
-    PublicStateController.set({
-      activeChain: state.activeChain,
-      selectedNetworkId: state.activeCaipNetwork?.id
-    })
-    this.setChainNetworkData(chain, { caipNetwork }, shouldReplace)
-  },
-
   setActiveConnector(connector: ChainControllerState['activeConnector']) {
     if (connector) {
       state.activeConnector = ref(connector)

--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -98,7 +98,6 @@ export const ConnectionController = {
   async connectExternal(options: ConnectExternalOptions, chain: ChainNamespace, setChain = true) {
     await this._getClient(chain).connectExternal?.(options)
     if (setChain) {
-      ChainController.setActiveNamespace(chain)
       StorageUtil.setConnectedConnector(options.type)
     }
   },

--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -16,7 +16,6 @@ import { ModalController } from './ModalController.js'
 import { ConnectorController } from './ConnectorController.js'
 import { EventsController } from './EventsController.js'
 import type { ChainNamespace } from '@reown/appkit-common'
-import { RouterController } from './RouterController.js'
 
 // -- Types --------------------------------------------- //
 export interface ConnectExternalOptions {
@@ -166,10 +165,6 @@ export const ConnectionController = {
     state.recentWallet = undefined
     TransactionsController.resetTransactions()
     StorageUtil.deleteWalletConnectDeepLink()
-    if (ModalController.state.open) {
-      ModalController.close()
-      RouterController.reset('Connect')
-    }
   },
 
   setWcLinking(wcLinking: ConnectionControllerState['wcLinking']) {

--- a/packages/core/src/controllers/NetworkController.ts
+++ b/packages/core/src/controllers/NetworkController.ts
@@ -84,18 +84,6 @@ export const NetworkController = {
     }
   },
 
-  setCaipNetwork(caipNetwork: NetworkControllerState['caipNetwork']) {
-    if (!caipNetwork) {
-      return
-    }
-
-    if (!caipNetwork?.chainNamespace) {
-      throw new Error('chain is required to set active network')
-    }
-
-    ChainController.setCaipNetwork(caipNetwork?.chainNamespace, caipNetwork)
-  },
-
   setRequestedCaipNetworks(
     requestedNetworks: NetworkControllerState['requestedCaipNetworks'],
     chain: ChainNamespace | undefined

--- a/packages/core/tests/controllers/SwapController.test.ts
+++ b/packages/core/tests/controllers/SwapController.test.ts
@@ -5,7 +5,6 @@ import {
   BlockchainApiController,
   ChainController,
   ConnectionController,
-  NetworkController,
   SwapController,
   type NetworkControllerClient
 } from '../../exports/index.js'
@@ -56,7 +55,7 @@ beforeAll(async () => {
     }
   ])
 
-  NetworkController.setCaipNetwork(caipNetwork)
+  ChainController.setActiveCaipNetwork(caipNetwork)
   AccountController.setCaipAddress(caipAddress, chain)
 
   vi.spyOn(BlockchainApiController, 'fetchSwapTokens').mockResolvedValue(tokensResponse)


### PR DESCRIPTION
# Description

- Removes .only 
- Fixes issue where `connectExternal`  would set the activeNamespace causing strange behaviors. `setActiveNamespace` should be called only internally. Clients already update state internally via `setCaipNetwork`

## Type of change

- [X] Bug Fix


# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
