### PR TITLE
fix: non announced connectors filtered as repeated

### DIFF
--- a/.changeset/polite-dogs-search.md
+++ b/.changeset/polite-dogs-search.md
@@ -1,0 +1,38 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@examples/html-ethers': patch
+'@examples/html-ethers5': patch
+'@examples/html-wagmi': patch
+'@examples/next-ethers': patch
+'@examples/next-wagmi': patch
+'@examples/react-ethers': patch
+'@examples/react-ethers5': patch
+'@examples/react-solana': patch
+'@examples/react-wagmi': patch
+'@examples/vue-ethers5': patch
+'@examples/vue-solana': patch
+'@examples/vue-wagmi': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-ethers': patch
+'@reown/appkit-ethers5': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-solana': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wagmi': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes issue where featured wallet ids were being filtered out if their connector was present but not displayed. eg. SDK Connectors.

--- a/packages/scaffold-ui/src/utils/WalletUtil.ts
+++ b/packages/scaffold-ui/src/utils/WalletUtil.ts
@@ -29,7 +29,9 @@ export const WalletUtil = {
   },
 
   filterOutDuplicatesByIds(wallets: WcWallet[]) {
-    const connectors = ConnectorController.state.connectors
+    const connectors = ConnectorController.state.connectors.filter(
+      connector => connector.type === 'ANNOUNCED' || connector.type === 'INJECTED'
+    )
     const recent = StorageUtil.getRecentWallets()
 
     const connectorIds = connectors.map(connector => connector.explorerId)


### PR DESCRIPTION
# Description
- Non-announced connectors were being filtered as duplicates even when they are not present on the screen in the first place.
- Adds fix to only filter announced/injected connectors

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1072

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
