### PR TITLE
feat: solana sign all transactions

### DIFF
--- a/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
+++ b/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
@@ -17,6 +17,7 @@ import {
 } from '@solana/web3.js'
 import { isVersionedTransaction } from '@solana/wallet-adapter-base'
 import { withSolanaNamespace } from '../utils/withSolanaNamespace.js'
+import { WalletConnectMethodNotSupportedError } from './shared/Errors.js'
 
 export type WalletConnectProviderConfig = {
   provider: UniversalProvider
@@ -91,7 +92,8 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
             methods: [
               'solana_signMessage',
               'solana_signTransaction',
-              'solana_signAndSendTransaction'
+              'solana_signAndSendTransaction',
+              'solana_signAllTransactions'
             ],
             events: [],
             rpcMap
@@ -114,6 +116,8 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
   }
 
   public async signMessage(message: Uint8Array) {
+    this.checkIfMethodIsSupported('solana_signMessage')
+
     const signedMessage = await this.request('solana_signMessage', {
       message: base58.encode(message),
       pubkey: this.getAccount(true).address
@@ -123,6 +127,8 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
   }
 
   public async signTransaction<T extends AnyTransaction>(transaction: T) {
+    this.checkIfMethodIsSupported('solana_signTransaction')
+
     const serializedTransaction = this.serializeTransaction(transaction)
 
     const result = await this.request('solana_signTransaction', {
@@ -154,6 +160,8 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
     transaction: T,
     sendOptions?: SendOptions
   ) {
+    this.checkIfMethodIsSupported('solana_signAndSendTransaction')
+
     const serializedTransaction = this.serializeTransaction(transaction)
 
     const result = await this.request('solana_signAndSendTransaction', {
@@ -177,9 +185,42 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
   }
 
   public async signAllTransactions<T extends AnyTransaction[]>(transactions: T): Promise<T> {
-    return (await Promise.all(
-      transactions.map(transaction => this.signTransaction(transaction))
-    )) as T
+    try {
+      this.checkIfMethodIsSupported('solana_signAllTransactions')
+
+      const result = await this.request('solana_signAllTransactions', {
+        transactions: transactions.map(transaction => this.serializeTransaction(transaction))
+      })
+
+      return result.transactions.map((serializedTransaction, index) => {
+        const transaction = transactions[index]
+
+        if (!transaction) {
+          throw new Error('Invalid transactions response')
+        }
+
+        const decodedTransaction = base58.decode(serializedTransaction)
+
+        if (isVersionedTransaction(transaction)) {
+          return VersionedTransaction.deserialize(decodedTransaction)
+        }
+
+        return Transaction.from(decodedTransaction)
+      }) as T
+    } catch (error) {
+      if (error instanceof WalletConnectMethodNotSupportedError) {
+        const signedTransactions = [] as AnyTransaction[] as T
+
+        for (const transaction of transactions) {
+          // eslint-disable-next-line no-await-in-loop
+          signedTransactions.push(await this.signTransaction(transaction))
+        }
+
+        return signedTransactions
+      }
+
+      throw error
+    }
   }
 
   // -- Private ------------------------------------------ //
@@ -315,6 +356,12 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
       recentBlockhash: transaction.recentBlockhash ?? ''
     }
   }
+
+  private checkIfMethodIsSupported(method: WalletConnectProvider.RequestMethod) {
+    if (!this.session?.namespaces['solana']?.methods.includes(method)) {
+      throw new WalletConnectMethodNotSupportedError(method)
+    }
+  }
 }
 
 export namespace WalletConnectProvider {
@@ -333,6 +380,7 @@ export namespace WalletConnectProvider {
       { transaction: string; pubkey: string; sendOptions?: SendOptions },
       { signature: string }
     >
+    solana_signAllTransactions: Request<{ transactions: string[] }, { transactions: string[] }>
   }
 
   export type RequestMethod = keyof RequestMethods

--- a/packages/base/adapters/solana/web3js/providers/shared/Errors.ts
+++ b/packages/base/adapters/solana/web3js/providers/shared/Errors.ts
@@ -1,5 +1,13 @@
+/* eslint-disable max-classes-per-file */
+
 export class WalletStandardFeatureNotSupportedError extends Error {
   constructor(feature: string) {
     super(`The wallet does not support the "${feature}" feature`)
+  }
+}
+
+export class WalletConnectMethodNotSupportedError extends Error {
+  constructor(method: string) {
+    super(`The method "${method}" is not supported by the wallet`)
   }
 }

--- a/packages/base/adapters/solana/web3js/tests/WalletConnectProvider.test.ts
+++ b/packages/base/adapters/solana/web3js/tests/WalletConnectProvider.test.ts
@@ -4,6 +4,7 @@ import { WalletConnectProvider } from '../providers/WalletConnectProvider.js'
 import { TestConstants } from './util/TestConstants.js'
 import { mockLegacyTransaction, mockVersionedTransaction } from './mocks/Transaction.js'
 import { type Chain } from '@web3modal/scaffold-utils/solana'
+import { WalletConnectMethodNotSupportedError } from '../providers/shared/Errors.js'
 
 describe('WalletConnectProvider specific tests', () => {
   let provider = mockUniversalProvider()
@@ -315,5 +316,142 @@ describe('WalletConnectProvider specific tests', () => {
     await walletConnectProvider.connect()
 
     expect(walletConnectProvider.chains).toEqual([TestConstants.chains[0]])
+  })
+
+  it('should throw an error if the wallet does not support the signMessage method', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: [],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    await expect(() =>
+      walletConnectProvider.signMessage(new Uint8Array([1, 2, 3, 4, 5]))
+    ).rejects.toThrow(WalletConnectMethodNotSupportedError)
+  })
+
+  it('should throw an error if the wallet does not support the signTransaction method', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: ['solana_signMessage'],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    await expect(() =>
+      walletConnectProvider.signTransaction(mockLegacyTransaction())
+    ).rejects.toThrow(WalletConnectMethodNotSupportedError)
+  })
+
+  it('should throw an error if the wallet does not support the signAndSendTransaction method', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: ['solana_signMessage'],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    await expect(() =>
+      walletConnectProvider.signAndSendTransaction(mockLegacyTransaction())
+    ).rejects.toThrow(WalletConnectMethodNotSupportedError)
+  })
+
+  it('should throw an error if the wallet does not support the signAllTransactions method', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: ['solana_signMessage'],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    await expect(() =>
+      walletConnectProvider.signAllTransactions([mockLegacyTransaction()])
+    ).rejects.toThrow(WalletConnectMethodNotSupportedError)
+  })
+
+  it('should request signAllTransactions with batched transactions', async () => {
+    vi.spyOn(provider, 'connect').mockImplementationOnce(() =>
+      Promise.resolve(
+        mockUniversalProviderSession({
+          namespaces: {
+            solana: {
+              chains: undefined,
+              methods: ['solana_signAllTransactions'],
+              events: [],
+              accounts: [
+                `solana:${TestConstants.chains[0]?.chainId}:${TestConstants.accounts[0].address}`
+              ]
+            }
+          }
+        })
+      )
+    )
+
+    await walletConnectProvider.connect()
+
+    const transactions = [mockLegacyTransaction(), mockVersionedTransaction()]
+    await walletConnectProvider.signAllTransactions(transactions)
+
+    expect(provider.request).toHaveBeenCalledWith(
+      {
+        method: 'solana_signAllTransactions',
+        params: {
+          transactions: [
+            'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAECFj6WhBP/eepC4T4bDgYuJMiSVXNh9IvPWv1ZDUV52gYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMmaU6FiJxS/swxct+H8Iree7FERP/8vrGuAdF90ANelAQECAAAMAgAAAICWmAAAAAAA',
+            'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAQABAhY+loQT/3nqQuE+Gw4GLiTIklVzYfSLz1r9WQ1FedoGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADJmlOhYicUv7MMXLfh/CK3nuxRET//L6xrgHRfdADXpQEBAgAADAIAAACAlpgAAAAAAAA='
+          ]
+        }
+      },
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+    )
   })
 })

--- a/packages/base/adapters/solana/web3js/tests/mocks/UniversalProvider.ts
+++ b/packages/base/adapters/solana/web3js/tests/mocks/UniversalProvider.ts
@@ -30,6 +30,13 @@ export function mockUniversalProvider() {
           signature:
             '2Lb1KQHWfbV3pWMqXZveFWqneSyhH95YsgCENRWnArSkLydjN1M42oB82zSd6BBdGkM9pE6sQLQf1gyBh8KWM2c4'
         } satisfies WalletConnectProvider.RequestMethods['solana_signAndSendTransaction']['returns'])
+      case 'solana_signAllTransactions':
+        return Promise.resolve({
+          transactions: [
+            '4zZMC2ddAFY1YHcA2uFCqbuTHmD1xvB5QLzgNnT3dMb4aQT98md8jVm1YRGUsKJkYkLPYarnkobvESUpjqEUnDmoG76e9cgNJzLuFXBW1i6njs2Sy1Lnr9TZmLnhif5CYjh1agVJEvjfYpTq1QbTnLS3rBt4yKVjQ6FcV3x22Vm3XBPqodTXz17o1YcHMcvYQbHZfVUyikQ3Nmv6ktZzWe36D6ceKCVBV88VvYkkFhwWUWkA5ErPvsHWQU64VvbtENaJXFUUnuqTFSX4q3ccHuHdmtnhWQ7Mv8Xkb',
+            '4zZMC2ddAFY1YHcA2uFCqbuTHmD1xvB5QLzgNnT3dMb4aQT98md8jVm1YRGUsKJkYkLPYarnkobvESUpjqEUnDmoG76e9cgNJzLuFXBW1i6njs2Sy1Lnr9TZmLnhif5CYjh1agVJEvjfYpTq1QbTnLS3rBt4yKVjQ6FcV3x22Vm3XBPqodTXz17o1YcHMcvYQbHZfVUyikQ3Nmv6ktZzWe36D6ceKCVBV88VvYkkFhwWUWkA5ErPvsHWQU64VvbtENaJXFUUnuqTFSX4q3ccHuHdmtnhWQ7Mv8Xkb'
+          ]
+        })
       default:
         return Promise.reject(new Error('not implemented'))
     }


### PR DESCRIPTION
# Description

- Adds batched call for `solana_signAllTransactions` RPC call on Solana WalletConnectProvider;
- Updates logic of parallel requests to chained when falling back to `solana_signTransaction` for `signAllTransactions` call.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
