### PR TITLE
fix: v5 default options

### DIFF
--- a/apps/laboratory/src/pages/library/solana-no-email.tsx
+++ b/apps/laboratory/src/pages/library/solana-no-email.tsx
@@ -25,7 +25,6 @@ const modal = createWeb3Modal({
   metadata: ConstantsUtil.Metadata,
   defaultChain: solana,
   chains,
-  enableAnalytics: false,
   termsConditionsUrl: 'https://walletconnect.com/terms',
   privacyPolicyUrl: 'https://walletconnect.com/privacy',
   customWallets: ConstantsUtil.CustomWallets,

--- a/apps/laboratory/src/pages/library/solana-no-socials.tsx
+++ b/apps/laboratory/src/pages/library/solana-no-socials.tsx
@@ -25,7 +25,6 @@ const modal = createWeb3Modal({
   metadata: ConstantsUtil.Metadata,
   defaultChain: solana,
   chains,
-  enableAnalytics: false,
   termsConditionsUrl: 'https://walletconnect.com/terms',
   privacyPolicyUrl: 'https://walletconnect.com/privacy',
   customWallets: ConstantsUtil.CustomWallets,

--- a/apps/laboratory/src/pages/library/solana.tsx
+++ b/apps/laboratory/src/pages/library/solana.tsx
@@ -20,7 +20,6 @@ const modal = createWeb3Modal({
   projectId: ConstantsUtil.ProjectId,
   metadata: ConstantsUtil.Metadata,
   chains,
-  enableAnalytics: false,
   termsConditionsUrl: 'https://walletconnect.com/terms',
   privacyPolicyUrl: 'https://walletconnect.com/privacy',
   customWallets: ConstantsUtil.CustomWallets,

--- a/packages/base/src/client.ts
+++ b/packages/base/src/client.ts
@@ -390,8 +390,8 @@ export class AppKit<AdapterStoreState = unknown, SwitchNetworkParam = unknown> {
     OptionsController.setPrivacyPolicyUrl(options.privacyPolicyUrl)
     OptionsController.setCustomWallets(options.customWallets)
     OptionsController.setEnableAnalytics(options.enableAnalytics)
-    OptionsController.setOnrampEnabled(options.enableOnramp !== false)
-    OptionsController.setEnableSwaps(options.enableSwaps !== false)
+    OptionsController.setOnrampEnabled(options.enableOnramp)
+    OptionsController.setEnableSwaps(options.enableSwaps)
 
     if (options.metadata) {
       OptionsController.setMetadata(options.metadata)

--- a/packages/core/src/controllers/ApiController.ts
+++ b/packages/core/src/controllers/ApiController.ts
@@ -267,7 +267,7 @@ export const ApiController = {
       ApiController.fetchNetworkImages(),
       ApiController.fetchConnectorImages()
     ]
-    if (OptionsController.state.enableAnalytics === undefined) {
+    if (OptionsController.state.enableAnalytics) {
       promises.push(ApiController.fetchAnalyticsConfig())
     }
     state.prefetchPromise = Promise.race([Promise.allSettled(promises)])

--- a/packages/core/src/controllers/OptionsController.ts
+++ b/packages/core/src/controllers/OptionsController.ts
@@ -2,6 +2,7 @@ import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { proxy } from 'valtio/vanilla'
 import type { CustomWallet, Metadata, ProjectId, SdkVersion, Tokens } from '../utils/TypeUtil.js'
 import { ApiController } from './ApiController.js'
+import { ConstantsUtil } from '../utils/ConstantsUtil.js'
 
 // -- Types --------------------------------------------- //
 export interface OptionsControllerState {
@@ -62,7 +63,7 @@ export interface OptionsControllerState {
   isSiweEnabled?: boolean
   /**
    * Enable analytics to get more insights on your users activity within your WalletConnect Cloud's dashboard.
-   * @default false
+   * @default true
    * @see https://cloud.walletconnect.com/
    */
   enableAnalytics?: boolean
@@ -102,7 +103,13 @@ type StateKey = keyof OptionsControllerState
 const state = proxy<OptionsControllerState>({
   projectId: '',
   sdkType: 'w3m',
-  sdkVersion: 'html-wagmi-undefined'
+  sdkVersion: 'html-wagmi-undefined',
+  enableAnalytics: ConstantsUtil.DEFAULT_FEATURES.analytics,
+  enableOnramp: ConstantsUtil.DEFAULT_FEATURES.onramp,
+  enableSwaps: ConstantsUtil.DEFAULT_FEATURES.swaps,
+  allWallets: ConstantsUtil.DEFAULT_FEATURES.allWallets,
+  disableAppend: ConstantsUtil.DEFAULT_FEATURES.disableAppend,
+  enableEIP6963: ConstantsUtil.DEFAULT_FEATURES.enableEIP6963
 })
 
 // -- Controller ---------------------------------------- //
@@ -121,7 +128,9 @@ export const OptionsController = {
     state.projectId = projectId
   },
 
-  setAllWallets(allWallets: OptionsControllerState['allWallets']) {
+  setAllWallets(
+    allWallets: OptionsControllerState['allWallets'] = ConstantsUtil.DEFAULT_FEATURES.allWallets
+  ) {
     state.allWallets = allWallets
   },
 
@@ -164,7 +173,10 @@ export const OptionsController = {
     state.isUniversalProvider = isUniversalProvider
   },
 
-  setEnableAnalytics(enableAnalytics: OptionsControllerState['enableAnalytics']) {
+  setEnableAnalytics(
+    enableAnalytics: OptionsControllerState['enableAnalytics'] = ConstantsUtil.DEFAULT_FEATURES
+      .analytics
+  ) {
     state.enableAnalytics = enableAnalytics
   },
 
@@ -176,15 +188,23 @@ export const OptionsController = {
     state.metadata = metadata
   },
 
-  setOnrampEnabled(enableOnramp: OptionsControllerState['enableOnramp']) {
+  setOnrampEnabled(
+    enableOnramp: OptionsControllerState['enableOnramp'] = ConstantsUtil.DEFAULT_FEATURES.onramp
+  ) {
     state.enableOnramp = enableOnramp
   },
 
-  setDisableAppend(disableAppend: OptionsControllerState['disableAppend']) {
+  setDisableAppend(
+    disableAppend: OptionsControllerState['disableAppend'] = ConstantsUtil.DEFAULT_FEATURES
+      .disableAppend
+  ) {
     state.disableAppend = disableAppend
   },
 
-  setEIP6963Enabled(enableEIP6963: OptionsControllerState['enableEIP6963']) {
+  setEIP6963Enabled(
+    enableEIP6963: OptionsControllerState['enableEIP6963'] = ConstantsUtil.DEFAULT_FEATURES
+      .enableEIP6963
+  ) {
     state.enableEIP6963 = enableEIP6963
   },
 
@@ -192,7 +212,9 @@ export const OptionsController = {
     state.hasMultipleAddresses = hasMultipleAddresses
   },
 
-  setEnableSwaps(enableSwaps: OptionsControllerState['enableSwaps']) {
+  setEnableSwaps(
+    enableSwaps: OptionsControllerState['enableSwaps'] = ConstantsUtil.DEFAULT_FEATURES.swaps
+  ) {
     state.enableSwaps = enableSwaps
   }
 }

--- a/packages/core/src/utils/ConstantsUtil.ts
+++ b/packages/core/src/utils/ConstantsUtil.ts
@@ -199,7 +199,16 @@ export const ConstantsUtil = {
     solana: 'So11111111111111111111111111111111111111111'
   } as const satisfies Record<Chain, string>,
 
-  CONVERT_SLIPPAGE_TOLERANCE: 1
+  CONVERT_SLIPPAGE_TOLERANCE: 1,
+
+  DEFAULT_FEATURES: {
+    swaps: true,
+    onramp: true,
+    analytics: true,
+    allWallets: 'SHOW',
+    disableAppend: false,
+    enableEIP6963: false
+  } as const
 }
 
 export type CoinbasePaySDKChainNameValues =

--- a/packages/core/tests/controllers/ApiController.test.ts
+++ b/packages/core/tests/controllers/ApiController.test.ts
@@ -566,7 +566,7 @@ describe('ApiController', () => {
   })
 
   it('should prefetch with analytics', () => {
-    OptionsController.state.enableAnalytics = undefined
+    OptionsController.state.enableAnalytics = true
     const fetchSpy = vi.spyOn(ApiController, 'fetchFeaturedWallets').mockResolvedValue()
     const fetchNetworkImagesSpy = vi.spyOn(ApiController, 'fetchNetworkImages').mockResolvedValue()
     const recommendedWalletsSpy = vi

--- a/packages/core/tests/controllers/OptionsController.test.ts
+++ b/packages/core/tests/controllers/OptionsController.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { OptionsController } from '../../index.js'
+import { ConstantsUtil, OptionsController } from '../../index.js'
 
 // -- Tests --------------------------------------------------------------------
 describe('OptionsController', () => {
@@ -7,7 +7,13 @@ describe('OptionsController', () => {
     expect(OptionsController.state).toEqual({
       projectId: '',
       sdkType: 'w3m',
-      sdkVersion: 'html-wagmi-undefined'
+      sdkVersion: 'html-wagmi-undefined',
+      allWallets: ConstantsUtil.DEFAULT_FEATURES.allWallets,
+      disableAppend: ConstantsUtil.DEFAULT_FEATURES.disableAppend,
+      enableAnalytics: ConstantsUtil.DEFAULT_FEATURES.analytics,
+      enableEIP6963: ConstantsUtil.DEFAULT_FEATURES.enableEIP6963,
+      enableOnramp: ConstantsUtil.DEFAULT_FEATURES.onramp,
+      enableSwaps: ConstantsUtil.DEFAULT_FEATURES.swaps
     })
   })
 


### PR DESCRIPTION
# Description

This PR sets default AppKit options into a constant and changes `enableAnalytics` to true by default.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
