### PR TITLE
fix: show single account screen if one account connected

### DIFF
--- a/apps/laboratory/tests/shared/pages/WalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/WalletPage.ts
@@ -9,6 +9,8 @@ export class WalletPage {
   private gotoHome: Locator
   private vercelPreview: Locator
 
+  public connectToSingleAccount = false
+
   constructor(public page: Page) {
     this.gotoHome = this.page.getByTestId('wc-connect')
     this.vercelPreview = this.page.locator('css=vercel-live-feedback')
@@ -33,7 +35,15 @@ export class WalletPage {
     if (isVercelPreview) {
       await this.vercelPreview.evaluate((iframe: HTMLIFrameElement) => iframe.remove())
     }
-    await this.gotoHome.click()
+    /*
+     * If connecting to a single account manually navigate.
+     * Otherwise click the home button.
+     */
+    if (this.connectToSingleAccount) {
+      await this.page.goto(`${this.baseURL}/walletconnect?addressesToApprove=1`)
+    } else {
+      await this.gotoHome.click()
+    }
     const input = this.page.getByTestId('uri-input')
     await input.waitFor({
       state: 'visible',
@@ -112,5 +122,13 @@ export class WalletPage {
     await sessionCard.click()
     const disconnectButton = this.page.getByText('Delete')
     await disconnectButton.click()
+  }
+
+  /**
+   * Sets a flag to indicate whether to connect to a single account
+   * @param connectToSingleAccount boolean flag to set
+   */
+  setConnectToSingleAccount(connectToSingleAccount: boolean) {
+    this.connectToSingleAccount = connectToSingleAccount
   }
 }

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -63,7 +63,7 @@ export class ModalValidator {
 
   async expectSingleAccount() {
     await expect(
-      this.page.getByTestId('single-account-widget'),
+      this.page.getByTestId('single-account-avatar'),
       'Single account widget should be present'
     ).toBeVisible({
       timeout: MAX_WAIT

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -60,6 +60,15 @@ export class ModalValidator {
     })
   }
 
+  async expectSingleAccount() {
+    await expect(
+      this.page.getByTestId('single-account-widget'),
+      'Single account widget should be present'
+    ).toBeVisible({
+      timeout: MAX_WAIT
+    })
+  }
+
   async expectConnectScreen() {
     await expect(this.page.getByText('Connect Wallet')).toBeVisible({
       timeout: MAX_WAIT

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -128,6 +128,21 @@ sampleWalletTest('it should show multiple accounts', async ({ library }) => {
   await modalPage.closeModal()
 })
 
+sampleWalletTest('it should disconnect and connect to a single account', async ({ library }) => {
+  if (library === 'solana') {
+    return
+  }
+
+  await walletPage.disconnectConnection()
+  await modalValidator.expectDisconnected()
+  walletPage.setConnectToSingleAccount(true)
+  await modalPage.qrCodeFlow(modalPage, walletPage)
+  await modalPage.openAccount()
+  await modalValidator.expectSingleAccount()
+  walletPage.setConnectToSingleAccount(false)
+  await modalPage.closeModal()
+})
+
 sampleWalletTest(
   'it should show switch network modal if network is not supported',
   async ({ library }) => {
@@ -135,6 +150,9 @@ sampleWalletTest(
       return
     }
 
+    await walletPage.disconnectConnection()
+    await modalValidator.expectDisconnected()
+    await modalPage.qrCodeFlow(modalPage, walletPage)
     await walletPage.enableTestnets()
     await walletPage.switchNetwork('eip155:5')
     await modalValidator.expectNetworkNotSupportedVisible()

--- a/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
@@ -271,7 +271,6 @@ export class W3mAccountDefaultWidget extends LitElement {
         avatarSrc=${ifDefined(this.profileImage ? this.profileImage : undefined)}
         profileName=${ifDefined(label ? label : this.profileName)}
         .onCopyClick=${this.onCopyAddress.bind(this)}
-        data-testid="multi-account-profile-button"
       ></wui-profile-button-v2>
     `
   }

--- a/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
@@ -86,7 +86,6 @@ export class W3mAccountDefaultWidget extends LitElement {
         .padding=${['0', 'xl', 'm', 'xl'] as const}
         alignItems="center"
         gap="l"
-        data-testid=${shouldShowMultiAccount ? 'multi-account-widget' : 'single-account-widget'}
       >
         ${shouldShowMultiAccount ? this.multiAccountTemplate() : this.singleAccountTemplate()}
         <wui-flex flexDirection="column" alignItems="center">
@@ -224,6 +223,7 @@ export class W3mAccountDefaultWidget extends LitElement {
         alt=${ifDefined(this.caipAddress)}
         address=${ifDefined(CoreHelperUtil.getPlainAddress(this.caipAddress))}
         imageSrc=${ifDefined(this.profileImage === null ? undefined : this.profileImage)}
+        data-testid="single-account-avatar"
       ></wui-avatar>
       <wui-flex flexDirection="column" alignItems="center">
         <wui-flex gap="3xs" alignItems="center" justifyContent="center">
@@ -271,6 +271,7 @@ export class W3mAccountDefaultWidget extends LitElement {
         avatarSrc=${ifDefined(this.profileImage ? this.profileImage : undefined)}
         profileName=${ifDefined(label ? label : this.profileName)}
         .onCopyClick=${this.onCopyAddress.bind(this)}
+        data-testid="multi-account-profile-button"
       ></wui-profile-button-v2>
     `
   }

--- a/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
@@ -10,7 +10,8 @@ import {
   SnackController,
   ConstantsUtil as CommonConstantsUtil,
   OptionsController,
-  ChainController
+  ChainController,
+  type AccountType
 } from '@reown/appkit-core'
 import { customElement, UiHelperUtil } from '@reown/appkit-ui'
 import { LitElement, html } from 'lit'
@@ -32,6 +33,8 @@ export class W3mAccountDefaultWidget extends LitElement {
   @state() public caipAddress = AccountController.state.caipAddress
 
   @state() public address = CoreHelperUtil.getPlainAddress(AccountController.state.caipAddress)
+
+  @state() public allAccounts: AccountType[] = AccountController.state.allAccounts
 
   @state() private profileImage = AccountController.state.profileImage
 
@@ -57,7 +60,10 @@ export class W3mAccountDefaultWidget extends LitElement {
         AccountController.subscribeKey('balanceSymbol', val => (this.balanceSymbol = val)),
         AccountController.subscribeKey('profileName', val => (this.profileName = val)),
         AccountController.subscribeKey('profileImage', val => (this.profileImage = val)),
-        OptionsController.subscribeKey('features', val => (this.features = val))
+        OptionsController.subscribeKey('features', val => (this.features = val)),
+        AccountController.subscribeKey('allAccounts', allAccounts => {
+          this.allAccounts = allAccounts
+        })
       ]
     )
   }
@@ -78,7 +84,8 @@ export class W3mAccountDefaultWidget extends LitElement {
         alignItems="center"
         gap="l"
       >
-        ${ChainController.state.activeChain === ConstantsUtil.CHAIN.EVM
+        ${ChainController.state.activeChain === ConstantsUtil.CHAIN.EVM &&
+        this.allAccounts.length > 1
           ? this.multiAccountTemplate()
           : this.singleAccountTemplate()}
         <wui-flex flexDirection="column" alignItems="center">
@@ -249,7 +256,7 @@ export class W3mAccountDefaultWidget extends LitElement {
       throw new Error('w3m-account-view: No account provided')
     }
 
-    const account = AccountController.state.allAccounts?.find(acc => acc.address === this.address)
+    const account = this.allAccounts.find(acc => acc.address === this.address)
     const label = AccountController.state.addressLabels.get(this.address)
 
     return html`

--- a/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-default-widget/index.ts
@@ -78,16 +78,17 @@ export class W3mAccountDefaultWidget extends LitElement {
       throw new Error('w3m-account-view: No account provided')
     }
 
+    const shouldShowMultiAccount =
+      ChainController.state.activeChain === ConstantsUtil.CHAIN.EVM && this.allAccounts.length > 1
+
     return html`<wui-flex
         flexDirection="column"
         .padding=${['0', 'xl', 'm', 'xl'] as const}
         alignItems="center"
         gap="l"
+        data-testid=${shouldShowMultiAccount ? 'multi-account-widget' : 'single-account-widget'}
       >
-        ${ChainController.state.activeChain === ConstantsUtil.CHAIN.EVM &&
-        this.allAccounts.length > 1
-          ? this.multiAccountTemplate()
-          : this.singleAccountTemplate()}
+        ${shouldShowMultiAccount ? this.multiAccountTemplate() : this.singleAccountTemplate()}
         <wui-flex flexDirection="column" alignItems="center">
           <wui-text variant="paragraph-500" color="fg-200">
             ${CoreHelperUtil.formatBalance(this.balance, this.balanceSymbol)}


### PR DESCRIPTION
# Description

Removing multi-account screen when one account connected.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1042

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
