### PR TITLE
fix: v5 solana walletconnetprovider response encoding

### DIFF
--- a/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
+++ b/packages/base/adapters/solana/web3js/providers/WalletConnectProvider.ts
@@ -147,7 +147,7 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
       return transaction
     }
 
-    const decodedTransaction = base58.decode(result.transaction)
+    const decodedTransaction = Buffer.from(result.transaction, 'base64')
 
     if (isVersionedTransaction(transaction)) {
       return VersionedTransaction.deserialize(decodedTransaction) as T
@@ -199,7 +199,7 @@ export class WalletConnectProvider extends ProviderEventEmitter implements Provi
           throw new Error('Invalid transactions response')
         }
 
-        const decodedTransaction = base58.decode(serializedTransaction)
+        const decodedTransaction = Buffer.from(serializedTransaction, 'base64')
 
         if (isVersionedTransaction(transaction)) {
           return VersionedTransaction.deserialize(decodedTransaction)

--- a/packages/base/adapters/solana/web3js/tests/mocks/UniversalProvider.ts
+++ b/packages/base/adapters/solana/web3js/tests/mocks/UniversalProvider.ts
@@ -23,7 +23,7 @@ export function mockUniversalProvider() {
       case 'solana_signTransaction':
         return Promise.resolve({
           transaction:
-            '4zZMC2ddAFY1YHcA2uFCqbuTHmD1xvB5QLzgNnT3dMb4aQT98md8jVm1YRGUsKJkYkLPYarnkobvESUpjqEUnDmoG76e9cgNJzLuFXBW1i6njs2Sy1Lnr9TZmLnhif5CYjh1agVJEvjfYpTq1QbTnLS3rBt4yKVjQ6FcV3x22Vm3XBPqodTXz17o1YcHMcvYQbHZfVUyikQ3Nmv6ktZzWe36D6ceKCVBV88VvYkkFhwWUWkA5ErPvsHWQU64VvbtENaJXFUUnuqTFSX4q3ccHuHdmtnhWQ7Mv8Xkb'
+            'AbtgOVOy/IOH3BOPyZ8/hu1pi0NQqO1mV13HnoWEvRDCpGKO6/8yTfuJmDgQet+S1iFeIos+2EQLJNee0l561AEBAAEDEYu60W1iZPqZxekvWxHW9/B92on2Sa8LAUEGjV1el9d1oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyVZNp39crMNo5bEpnmL7eM8r98bZA5VoGNHFLu7CvL4BAgIAAQwCAAAAQEIPAAAAAAA='
         } satisfies WalletConnectProvider.RequestMethods['solana_signTransaction']['returns'])
       case 'solana_signAndSendTransaction':
         return Promise.resolve({
@@ -33,8 +33,8 @@ export function mockUniversalProvider() {
       case 'solana_signAllTransactions':
         return Promise.resolve({
           transactions: [
-            '4zZMC2ddAFY1YHcA2uFCqbuTHmD1xvB5QLzgNnT3dMb4aQT98md8jVm1YRGUsKJkYkLPYarnkobvESUpjqEUnDmoG76e9cgNJzLuFXBW1i6njs2Sy1Lnr9TZmLnhif5CYjh1agVJEvjfYpTq1QbTnLS3rBt4yKVjQ6FcV3x22Vm3XBPqodTXz17o1YcHMcvYQbHZfVUyikQ3Nmv6ktZzWe36D6ceKCVBV88VvYkkFhwWUWkA5ErPvsHWQU64VvbtENaJXFUUnuqTFSX4q3ccHuHdmtnhWQ7Mv8Xkb',
-            '4zZMC2ddAFY1YHcA2uFCqbuTHmD1xvB5QLzgNnT3dMb4aQT98md8jVm1YRGUsKJkYkLPYarnkobvESUpjqEUnDmoG76e9cgNJzLuFXBW1i6njs2Sy1Lnr9TZmLnhif5CYjh1agVJEvjfYpTq1QbTnLS3rBt4yKVjQ6FcV3x22Vm3XBPqodTXz17o1YcHMcvYQbHZfVUyikQ3Nmv6ktZzWe36D6ceKCVBV88VvYkkFhwWUWkA5ErPvsHWQU64VvbtENaJXFUUnuqTFSX4q3ccHuHdmtnhWQ7Mv8Xkb'
+            'AbtgOVOy/IOH3BOPyZ8/hu1pi0NQqO1mV13HnoWEvRDCpGKO6/8yTfuJmDgQet+S1iFeIos+2EQLJNee0l561AEBAAEDEYu60W1iZPqZxekvWxHW9/B92on2Sa8LAUEGjV1el9d1oyGFaAZ/9w4srgx9KoqiHtPM6Vur7h4D6XVoSgrEhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAyVZNp39crMNo5bEpnmL7eM8r98bZA5VoGNHFLu7CvL4BAgIAAQwCAAAAQEIPAAAAAAA=',
+            'AYDXAnLcl7IT+zEK9L+oOT/dY9etmSEznxAHfo4EZbdeJ/COPqARQCAfu+5Lbbrc26g3qWGRd4YHL8Uf2KDoAgqAAQABAxGLutFtYmT6mcXpL1sR1vfwfdqJ9kmvCwFBBo1dXpfXdaMhhWgGf/cOLK4MfSqKoh7TzOlbq+4eA+l1aEoKxIQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALKkO9Sy+d4Zr/s5Vn5b6BI7ltSc5at4aMPQjxrk+ibOAQICAAEMAgAAAEBCDwAAAAAAAA=='
           ]
         })
       default:


### PR DESCRIPTION
# Description

Changes `base58` encoding from Solana WalletConnectProvider responses to `base64`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
