### PR TITLE
fix: siwe modal not opening for some wallets

### DIFF
--- a/.changeset/giant-moons-guess.md
+++ b/.changeset/giant-moons-guess.md
@@ -1,0 +1,26 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@apps/laboratory': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-ethers': patch
+'@reown/appkit-ethers5': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-solana': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wagmi': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixed an issue where SIWE modal wasn't showing up for some mobile wallets.

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -189,31 +189,37 @@ export class W3mModal extends LitElement {
   }
 
   private async onNewAddress(caipAddress?: CaipAddress) {
-    const prevConnected = this.caipAddress
-      ? CoreHelperUtil.getPlainAddress(this.caipAddress)
+    const prevCaipAddress = this.caipAddress
+    const prevConnected = prevCaipAddress
+      ? CoreHelperUtil.getPlainAddress(prevCaipAddress)
       : undefined
     const nextConnected = caipAddress ? CoreHelperUtil.getPlainAddress(caipAddress) : undefined
     const isSameAddress = prevConnected === nextConnected
 
-    if (nextConnected && !isSameAddress && this.isSiweEnabled) {
-      const { SIWEController } = await import('@reown/appkit-siwe')
-      const signed = AccountController.state.siweStatus === 'success'
+    this.caipAddress = caipAddress
 
-      if (!prevConnected && nextConnected) {
-        this.onSiweNavigation()
-      } else if (signed && prevConnected && nextConnected && prevConnected !== nextConnected) {
-        if (SIWEController.state._client?.options.signOutOnAccountChange) {
-          await SIWEController.signOut()
+    if (nextConnected && !isSameAddress && this.isSiweEnabled) {
+      try {
+        const { SIWEController } = await import('@reown/appkit-siwe')
+        const signed = AccountController.state.siweStatus === 'success'
+
+        if (!prevConnected && nextConnected) {
           this.onSiweNavigation()
+        } else if (signed && prevConnected && nextConnected && prevConnected !== nextConnected) {
+          if (SIWEController.state._client?.options.signOutOnAccountChange) {
+            await SIWEController.signOut()
+            this.onSiweNavigation()
+          }
         }
+      } catch (err) {
+        this.caipAddress = prevCaipAddress
+        throw err
       }
     }
 
     if (!nextConnected) {
       ModalController.close()
     }
-
-    this.caipAddress = caipAddress
   }
 
   private async onNewNetwork(nextCaipNetwork: CaipNetwork | undefined) {

--- a/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
@@ -28,6 +28,8 @@ export class W3mConnectingWcView extends LitElement {
 
   @state() private platforms: Platform[] = []
 
+  @state() private isSiweEnabled = OptionsController.state.isSiweEnabled
+
   public constructor() {
     super()
     this.determinePlatforms()
@@ -72,7 +74,7 @@ export class W3mConnectingWcView extends LitElement {
           OptionsController.state.hasMultipleAddresses
         ) {
           RouterController.push('SelectAddresses')
-        } else {
+        } else if (!this.isSiweEnabled) {
           ModalController.close()
         }
       }


### PR DESCRIPTION
# Description

There was an issue where if you used SIWE and connected with your mobile wallet, the SIWE modal never showed up.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1254

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
