### PR TITLE
Add missing setProvider call

### DIFF
--- a/.changeset/fair-wombats-move.md
+++ b/.changeset/fair-wombats-move.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@apps/laboratory': patch
+'@reown/appkit': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+fix: add missing setProvider and setProviderId call for connector other than walletconnect on syncAccount

--- a/.changeset/spotty-buses-think.md
+++ b/.changeset/spotty-buses-think.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+---
+
+fix: add missing setProvider call for connector other than walletconnect on syncAccount

--- a/.changeset/spotty-buses-think.md
+++ b/.changeset/spotty-buses-think.md
@@ -1,5 +1,0 @@
----
-'@reown/appkit-adapter-wagmi': patch
----
-
-fix: add missing setProvider call for connector other than walletconnect on syncAccount

--- a/apps/laboratory/src/components/Wagmi/WagmiRequestPermissionsAsyncTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiRequestPermissionsAsyncTest.tsx
@@ -14,10 +14,10 @@ import {
 } from '@reown/appkit-experimental/smart-session'
 
 export function WagmiRequestPermissionsAsyncTest() {
-  const { address, isConnected } = useAppKitAccount()
+  const { address, isConnected, status } = useAppKitAccount()
 
   const { chainId } = useAppKitNetwork()
-  const isSupported = useMemo(() => isSmartSessionSupported(), [address])
+  const isSupported = useMemo(() => isSmartSessionSupported(), [status])
 
   if (!isConnected || !address || !chainId) {
     return (

--- a/apps/laboratory/src/components/Wagmi/WagmiRequestPermissionsSyncTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiRequestPermissionsSyncTest.tsx
@@ -15,9 +15,9 @@ import {
 } from '@reown/appkit-experimental/smart-session'
 
 export function WagmiRequestPermissionsSyncTest() {
-  const { address, isConnected } = useAppKitAccount()
+  const { address, isConnected, status } = useAppKitAccount()
   const { chainId } = useAppKitNetwork()
-  const isSupported = useMemo(() => isSmartSessionSupported(), [address])
+  const isSupported = useMemo(() => isSmartSessionSupported(), [status])
 
   if (!isConnected || !address || !chainId) {
     return (

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -20,7 +20,6 @@ import {
   EthersHelpersUtil,
   type Provider,
   type ProviderType,
-  type ProviderId,
   type Address
 } from '@reown/appkit-utils/ethers'
 import type { AppKit } from '@reown/appkit'
@@ -45,7 +44,7 @@ import { WcConstantsUtil } from '@reown/appkit'
 import { EthersMethods } from './utils/EthersMethods.js'
 import { formatEther, InfuraProvider, JsonRpcProvider } from 'ethers'
 import type { PublicStateControllerState } from '@reown/appkit-core'
-import { ProviderUtil } from '@reown/appkit/store'
+import { ProviderUtil, type ProviderIdType } from '@reown/appkit/store'
 import { CoinbaseWalletSDK, type ProviderInterface } from '@coinbase/wallet-sdk'
 import { W3mFrameProviderSingleton } from '@reown/appkit/auth-provider'
 
@@ -301,7 +300,7 @@ export class EthersAdapter {
           }
           await this.setProvider(
             selectedProvider,
-            selectedConnector.providerType as ProviderId,
+            selectedConnector.providerType as ProviderIdType,
             info?.name
           )
         } catch (error) {
@@ -613,12 +612,12 @@ export class EthersAdapter {
     const activeConfig = providerConfigs[walletId as unknown as keyof typeof providerConfigs]
 
     if (activeConfig?.provider) {
-      this.setProvider(activeConfig.provider, walletId as ProviderId)
-      this.setupProviderListeners(activeConfig.provider, walletId as ProviderId)
+      this.setProvider(activeConfig.provider, walletId as ProviderIdType)
+      this.setupProviderListeners(activeConfig.provider, walletId as ProviderIdType)
     }
   }
 
-  private async setProvider(provider: Provider, providerId: ProviderId, name?: string) {
+  private async setProvider(provider: Provider, providerId: ProviderIdType, name?: string) {
     if (providerId === 'w3mAuth') {
       this.setAuthProvider()
     } else {
@@ -685,7 +684,7 @@ export class EthersAdapter {
         )
         this.appKit?.setSmartAccountDeployed(Boolean(smartAccountDeployed), this.chainNamespace)
         ProviderUtil.setProvider<Provider>('eip155', this.authProvider as unknown as Provider)
-        ProviderUtil.setProviderId('eip155', ConstantsUtil.AUTH_CONNECTOR_ID as ProviderId)
+        ProviderUtil.setProviderId('eip155', ConstantsUtil.AUTH_CONNECTOR_ID as ProviderIdType)
         this.setupProviderListeners(this.authProvider as unknown as Provider, 'w3mAuth')
         this.watchModal()
       }
@@ -703,7 +702,7 @@ export class EthersAdapter {
     }
   }
 
-  private setupProviderListeners(provider: Provider, providerId: ProviderId) {
+  private setupProviderListeners(provider: Provider, providerId: ProviderIdType) {
     const disconnectHandler = () => {
       SafeLocalStorage.removeItem(SafeLocalStorageKeys.WALLET_ID)
       this.removeListeners(provider)

--- a/packages/adapters/ethers/src/tests/client.test.ts
+++ b/packages/adapters/ethers/src/tests/client.test.ts
@@ -5,7 +5,7 @@ import { mockOptions } from './mocks/Options'
 import { mockCreateEthersConfig } from './mocks/EthersConfig'
 import mockAppKit from './mocks/AppKit'
 import { mockAuthConnector } from './mocks/AuthConnector'
-import { EthersHelpersUtil, type ProviderId, type ProviderType } from '@reown/appkit-utils/ethers'
+import { EthersHelpersUtil, type ProviderType } from '@reown/appkit-utils/ethers'
 import { CaipNetworksUtil, ConstantsUtil } from '@reown/appkit-utils'
 import {
   arbitrum as AppkitArbitrum,
@@ -14,7 +14,7 @@ import {
   optimism as AppkitOptimism,
   bsc as AppkitBsc
 } from '@reown/appkit/networks'
-import { ProviderUtil } from '@reown/appkit/store'
+import { ProviderUtil, type ProviderIdType } from '@reown/appkit/store'
 import { SafeLocalStorage, SafeLocalStorageKeys } from '@reown/appkit-common'
 import { type BlockchainApiLookupEnsName } from '@reown/appkit'
 import { InfuraProvider, JsonRpcProvider } from 'ethers'
@@ -813,7 +813,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.EIP6963_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       client['EIP6963Providers'] = [
         {
           info: { name: 'MetaMask', icon: 'icon-url', uuid: 'test-uuid', rdns: 'com.metamask' },
@@ -833,7 +833,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       const mockProvider = {
         session: {
           peer: {
@@ -862,7 +862,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.COINBASE_SDK_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       vi.spyOn(mockAppKit, 'getConnectors').mockReturnValue([
         {
           id: ConstantsUtil.COINBASE_SDK_CONNECTOR_ID,

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -20,7 +20,6 @@ import {
   EthersHelpersUtil,
   type Provider,
   type ProviderType,
-  type ProviderId,
   type Address
 } from '@reown/appkit-utils/ethers'
 import type { AppKit } from '@reown/appkit'
@@ -45,7 +44,7 @@ import { WcConstantsUtil } from '@reown/appkit'
 import { Ethers5Methods } from './utils/Ethers5Methods.js'
 import { ethers } from 'ethers'
 import type { PublicStateControllerState } from '@reown/appkit-core'
-import { ProviderUtil } from '@reown/appkit/store'
+import { ProviderUtil, type ProviderIdType } from '@reown/appkit/store'
 import { CoinbaseWalletSDK, type ProviderInterface } from '@coinbase/wallet-sdk'
 import { W3mFrameProviderSingleton } from '@reown/appkit/auth-provider'
 
@@ -301,7 +300,7 @@ export class Ethers5Adapter {
           }
           await this.setProvider(
             selectedProvider,
-            selectedConnector.providerType as ProviderId,
+            selectedConnector.providerType as ProviderIdType,
             info?.name
           )
         } catch (error) {
@@ -589,12 +588,12 @@ export class Ethers5Adapter {
     const activeConfig = providerConfigs[walletId as unknown as keyof typeof providerConfigs]
 
     if (activeConfig?.provider) {
-      this.setProvider(activeConfig.provider, walletId as ProviderId)
-      this.setupProviderListeners(activeConfig.provider, walletId as ProviderId)
+      this.setProvider(activeConfig.provider, walletId as ProviderIdType)
+      this.setupProviderListeners(activeConfig.provider, walletId as ProviderIdType)
     }
   }
 
-  private async setProvider(provider: Provider, providerId: ProviderId, name?: string) {
+  private async setProvider(provider: Provider, providerId: ProviderIdType, name?: string) {
     if (providerId === 'w3mAuth') {
       this.setAuthProvider()
     } else {
@@ -661,7 +660,7 @@ export class Ethers5Adapter {
         )
         this.appKit?.setSmartAccountDeployed(Boolean(smartAccountDeployed), this.chainNamespace)
         ProviderUtil.setProvider<Provider>('eip155', this.authProvider as unknown as Provider)
-        ProviderUtil.setProviderId('eip155', ConstantsUtil.AUTH_CONNECTOR_ID as ProviderId)
+        ProviderUtil.setProviderId('eip155', ConstantsUtil.AUTH_CONNECTOR_ID as ProviderIdType)
         this.setupProviderListeners(this.authProvider as unknown as Provider, 'w3mAuth')
         this.watchModal()
       }
@@ -679,7 +678,7 @@ export class Ethers5Adapter {
     }
   }
 
-  private setupProviderListeners(provider: Provider, providerId: ProviderId) {
+  private setupProviderListeners(provider: Provider, providerId: ProviderIdType) {
     const disconnectHandler = () => {
       SafeLocalStorage.removeItem(SafeLocalStorageKeys.WALLET_ID)
       this.removeListeners(provider)

--- a/packages/adapters/ethers5/src/tests/client.test.ts
+++ b/packages/adapters/ethers5/src/tests/client.test.ts
@@ -5,7 +5,7 @@ import { mockOptions } from './mocks/Options'
 import { mockCreateEthersConfig } from './mocks/EthersConfig'
 import mockAppKit from './mocks/AppKit'
 import { mockAuthConnector } from './mocks/AuthConnector'
-import { EthersHelpersUtil, type ProviderId, type ProviderType } from '@reown/appkit-utils/ethers'
+import { EthersHelpersUtil, type ProviderType } from '@reown/appkit-utils/ethers'
 import { CaipNetworksUtil, ConstantsUtil } from '@reown/appkit-utils'
 import {
   arbitrum as AppkitArbitrum,
@@ -14,7 +14,7 @@ import {
   optimism as AppkitOptimism,
   bsc as AppkitBsc
 } from '@reown/appkit/networks'
-import { ProviderUtil } from '@reown/appkit/store'
+import { ProviderUtil, type ProviderIdType } from '@reown/appkit/store'
 import { SafeLocalStorage, SafeLocalStorageKeys } from '@reown/appkit-common'
 import { type BlockchainApiLookupEnsName } from '@reown/appkit'
 import { ethers } from 'ethers'
@@ -824,7 +824,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.EIP6963_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       client['EIP6963Providers'] = [
         {
           info: { name: 'MetaMask', icon: 'icon-url', uuid: 'test-uuid', rdns: 'com.metamask' },
@@ -844,7 +844,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.WALLET_CONNECT_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       const mockProvider = {
         session: {
           peer: {
@@ -873,7 +873,7 @@ describe('EthersAdapter', () => {
       vi.spyOn(ProviderUtil.state, 'providerIds', 'get').mockReturnValue({
         eip155: ConstantsUtil.COINBASE_SDK_CONNECTOR_ID,
         solana: undefined
-      } as Record<ChainNamespace, ProviderId | undefined>)
+      } as Record<ChainNamespace, ProviderIdType | undefined>)
       vi.spyOn(mockAppKit, 'getConnectors').mockReturnValue([
         {
           id: ConstantsUtil.COINBASE_SDK_CONNECTOR_ID,

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -726,6 +726,7 @@ export class WagmiAdapter implements ChainAdapter {
           ])
           if (connector) {
             this.syncConnectedWalletInfo(connector)
+            ProviderUtil.setProvider(this.chainNamespace, await connector.getProvider())
           }
 
           // Set by authConnector.onIsConnectedHandler as we need the account type

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -147,7 +147,11 @@ describe('Wagmi Client', () => {
     it('should sync account correctly when connected', async () => {
       const mockAddress = '0x1234567890123456789012345678901234567890'
       const mockChainId = 1
-      const mockConnector = { id: 'mockConnector', name: 'Mock Connector' }
+      const mockConnector = {
+        id: 'mockConnector',
+        name: 'Mock Connector',
+        getProvider: vi.fn().mockResolvedValue({})
+      }
 
       const setCaipAddressSpy = vi.spyOn(mockAppKit, 'setCaipAddress')
 

--- a/packages/appkit-utils/src/ethers/EthersTypesUtil.ts
+++ b/packages/appkit-utils/src/ethers/EthersTypesUtil.ts
@@ -65,11 +65,3 @@ export type Chain = {
   chain: string
   imageId: string | undefined
 }
-
-export type ProviderId =
-  | 'walletConnect'
-  | 'injected'
-  | 'coinbaseWallet'
-  | 'eip6963'
-  | 'w3mAuth'
-  | 'coinbaseWalletSDK'

--- a/packages/appkit/src/store/ProviderUtil.ts
+++ b/packages/appkit/src/store/ProviderUtil.ts
@@ -11,7 +11,7 @@ export interface ProviderStoreUtilState {
   providerIds: Record<ChainNamespace, ProviderIdType | undefined>
 }
 
-type ProviderIdType =
+export type ProviderIdType =
   | 'walletConnect'
   | 'injected'
   | 'coinbaseWallet'

--- a/packages/appkit/src/store/index.ts
+++ b/packages/appkit/src/store/index.ts
@@ -1,2 +1,2 @@
 export { ProviderUtil } from './ProviderUtil.js'
-export type { ProviderStoreUtilState } from './ProviderUtil.js'
+export type { ProviderStoreUtilState, ProviderIdType } from './ProviderUtil.js'


### PR DESCRIPTION
# Description

For Embedded wallet, on successful connection, provider returns undefined for below code.  
`ProviderUtil.getProvider(CommonConstantsUtil.CHAIN.EVM)`
This PR is to fix this issue.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
