### PR TITLE
refactor: handle custom transport objects for wagmi adapter

### DIFF
--- a/.changeset/warm-toes-unite.md
+++ b/.changeset/warm-toes-unite.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Refactors wagmi constructor to handle custom transpor objects

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -48,7 +48,7 @@ import type {
   WriteContractArgs
 } from '@reown/appkit-core'
 import { formatUnits, parseUnits } from 'viem'
-import type { Hex } from 'viem'
+import type { Hex, HttpTransport } from 'viem'
 import {
   ConstantsUtil,
   PresetsUtil,
@@ -169,8 +169,17 @@ export class WagmiAdapter implements ChainAdapter {
 
     const transportsArr = this.wagmiChains.map(chain => [
       chain.id,
-      getTransport({ chain: chain as Chain, projectId: configParams.projectId })
+      CaipNetworksUtil.getViemTransport(chain as CaipNetwork)
     ])
+
+    Object.entries(configParams.transports ?? {}).forEach(([chainId, transport]) => {
+      const index = transportsArr.findIndex(([id]) => id === Number(chainId))
+      if (index !== -1) {
+        transportsArr[index] = [Number(chainId), transport as HttpTransport]
+      } else {
+        transportsArr.push([Number(chainId), transport as HttpTransport])
+      }
+    })
 
     const transports = Object.fromEntries(transportsArr)
     const connectors: CreateConnectorFn[] = [...(configParams.connectors ?? [])]

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -59,7 +59,6 @@ import {
 import { isReownName, SafeLocalStorage, SafeLocalStorageKeys } from '@reown/appkit-common'
 import {
   getEmailCaipNetworks,
-  getTransport,
   getWalletConnectCaipNetworks,
   parseWalletCapabilities,
   requireCaipAddress
@@ -174,10 +173,10 @@ export class WagmiAdapter implements ChainAdapter {
 
     Object.entries(configParams.transports ?? {}).forEach(([chainId, transport]) => {
       const index = transportsArr.findIndex(([id]) => id === Number(chainId))
-      if (index !== -1) {
-        transportsArr[index] = [Number(chainId), transport as HttpTransport]
-      } else {
+      if (index === -1) {
         transportsArr.push([Number(chainId), transport as HttpTransport])
+      } else {
+        transportsArr[index] = [Number(chainId), transport as HttpTransport]
       }
     })
 

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -11,6 +11,8 @@ import {
 import { connect, disconnect, getAccount, getChainId, getEnsName, getBalance } from '@wagmi/core'
 import { CaipNetworksUtil, ConstantsUtil } from '@reown/appkit-utils'
 import type { CaipNetwork } from '@reown/appkit-common'
+import { http } from 'viem'
+import { WagmiAdapter } from '../client'
 
 const [mainnet, arbitrum] = CaipNetworksUtil.extendCaipNetworks(
   [AppkitMainnet, AppkitArbitrum, AppkitPolygon, AppkitOptimism, AppkitBsc],
@@ -493,6 +495,69 @@ describe('Wagmi Client', () => {
       callback({ method: 'eth_sendTransaction' })
 
       expect(mockAppKit.redirect).toHaveBeenCalledWith('ApproveTransaction')
+    })
+  })
+
+  describe('Wagmi Client - Transports', () => {
+    it('should use default transports for networks without custom transports', () => {
+      const client = new WagmiAdapter({
+        projectId: '123',
+        networks: [mainnet, arbitrum]
+      })
+
+      expect(client.wagmiConfig._internal.transports).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[mainnet.id as number]).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[arbitrum.id as number]).toBeDefined()
+    })
+
+    it('should merge user-provided transports with default transports', () => {
+      const customTransport = http('https://custom-rpc.example.com')
+      const client = new WagmiAdapter({
+        projectId: '123',
+        networks: [mainnet, arbitrum],
+        transports: {
+          [mainnet.id]: customTransport
+        }
+      })
+
+      expect(client.wagmiConfig._internal.transports).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[mainnet.id as number]).toBe(customTransport)
+      expect(client.wagmiConfig._internal.transports[arbitrum.id as number]).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[arbitrum.id as number]).not.toBe(
+        customTransport
+      )
+    })
+
+    it('should prioritize user-provided transports over default ones', () => {
+      const customTransport1 = http('https://custom-rpc1.example.com')
+      const customTransport2 = http('https://custom-rpc2.example.com')
+      const client = new WagmiAdapter({
+        projectId: '123',
+        networks: [mainnet, arbitrum],
+        transports: {
+          [mainnet.id]: customTransport1,
+          [arbitrum.id]: customTransport2
+        }
+      })
+
+      expect(client.wagmiConfig._internal.transports).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[mainnet.id as number]).toBe(customTransport1)
+      expect(client.wagmiConfig._internal.transports[arbitrum.id as number]).toBe(customTransport2)
+    })
+
+    it('should handle transports for networks not in the provided networks array', () => {
+      const customTransport = http('https://custom-rpc.example.com')
+      const client = new WagmiAdapter({
+        projectId: '123',
+        networks: [mainnet],
+        transports: {
+          [arbitrum.id]: customTransport
+        }
+      })
+
+      expect(client.wagmiConfig._internal.transports).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[mainnet.id as number]).toBeDefined()
+      expect(client.wagmiConfig._internal.transports[arbitrum.id as number]).toBe(customTransport)
     })
   })
 })

--- a/packages/adapters/wagmi/src/utils/helpers.ts
+++ b/packages/adapters/wagmi/src/utils/helpers.ts
@@ -1,11 +1,9 @@
 import { type CaipNetworkId } from '@reown/appkit-common'
 import { ConstantsUtil, PresetsUtil } from '@reown/appkit-utils'
 import { UniversalProvider } from '@walletconnect/universal-provider'
-import { fallback, http, type Hex } from 'viem'
+import { type Hex } from 'viem'
 
-import type { Chain } from '@wagmi/core/chains'
 import type { Connector } from '@wagmi/core'
-import { CoreHelperUtil } from '@reown/appkit-core'
 import { WcHelpersUtil } from '@reown/appkit'
 
 export async function getWalletConnectCaipNetworks(connector?: Connector) {
@@ -33,30 +31,6 @@ export function getEmailCaipNetworks() {
       id => `${ConstantsUtil.EIP155}:${id}`
     ) as CaipNetworkId[]
   }
-}
-
-export function getTransport({ chain, projectId }: { chain: Chain; projectId: string }) {
-  const RPC_URL = CoreHelperUtil.getBlockchainApiUrl()
-  const chainDefaultUrl = chain.rpcUrls.default.http?.[0]
-
-  if (!PresetsUtil.WalletConnectRpcChainIds.includes(chain.id)) {
-    return http(chainDefaultUrl)
-  }
-
-  return fallback([
-    http(`${RPC_URL}/v1/?chainId=${ConstantsUtil.EIP155}:${chain.id}&projectId=${projectId}`, {
-      /*
-       * The Blockchain API uses "Content-Type: text/plain" to avoid OPTIONS preflight requests
-       * It will only work for viem >= 2.17.7
-       */
-      fetchOptions: {
-        headers: {
-          'Content-Type': 'text/plain'
-        }
-      }
-    }),
-    http(chainDefaultUrl)
-  ])
 }
 
 export function requireCaipAddress(caipAddress: string) {

--- a/packages/appkit-utils/package.json
+++ b/packages/appkit-utils/package.json
@@ -50,7 +50,8 @@
     "@reown/appkit-wallet": "workspace:*",
     "@walletconnect/logger": "2.1.2",
     "@walletconnect/universal-provider": "2.17.0",
-    "valtio": "1.11.2"
+    "valtio": "1.11.2",
+    "viem": "2.x"
   },
   "devDependencies": {
     "@coinbase/wallet-sdk": "4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,7 +712,7 @@ importers:
         version: 5.2.11(@types/node@20.11.5)(terser@5.33.0)
       wagmi:
         specifier: 2.12.9
-        version: 2.12.9(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.24.8(react@18.2.0))(@types/react@18.2.62)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react-native@0.75.3(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.62)(bufferutil@4.0.8)(react@18.2.0)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.2.0)(rollup@4.22.4)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.21.4(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
+        version: 2.12.9(@tanstack/query-core@5.56.2)(@tanstack/react-query@5.24.8(react@18.2.0))(@types/react@18.2.62)(bufferutil@4.0.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.22.4)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.21.4(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     devDependencies:
       '@types/react':
         specifier: 18.2.62
@@ -1189,6 +1189,9 @@ importers:
       valtio:
         specifier: 1.11.2
         version: 1.11.2(@types/react@18.2.62)(react@18.2.0)
+      viem:
+        specifier: 2.x
+        version: 2.21.4(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.22.4)
     devDependencies:
       '@coinbase/wallet-sdk':
         specifier: 4.0.3


### PR DESCRIPTION
# Description

Refactors Wagmi adapter's constructor to handle custom transport arrays for Wagmi configs.

Previously we were using only given network's RPC urls to create transport objects for Wagmi configs. Users should be able to override those.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1293
For GH issues: closes https://github.com/reown-com/appkit/issues/3056 closes https://github.com/reown-com/appkit/issues/2910

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
