### PR TITLE
chore: add max timeouts for frame requests

### DIFF
--- a/.changeset/cool-walls-fix.md
+++ b/.changeset/cool-walls-fix.md
@@ -20,4 +20,4 @@
 '@reown/appkit-siwe': patch
 ---
 
-Added maximum timeout for frame requests
+Added maximum timeouts for frame requests

--- a/.changeset/cool-walls-fix.md
+++ b/.changeset/cool-walls-fix.md
@@ -1,0 +1,23 @@
+---
+'@apps/laboratory': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-ui': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+---
+
+Added maximum timeout for frame requests

--- a/apps/laboratory/playwright.config.ts
+++ b/apps/laboratory/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig<ModalFixture>({
   expect: {
     timeout: getValue(60, 15) * 1000
   },
-  timeout: 60 * 1000,
+  timeout: 90 * 1000,
 
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -22,6 +22,8 @@ const emailTest = test.extend<{ library: string }>({
 emailTest.describe.configure({ mode: 'serial' })
 
 emailTest.beforeAll(async ({ browser, library }) => {
+  await page.page.context().setOffline(false)
+
   context = await browser.newContext()
   browserPage = await context.newPage()
 

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -22,14 +22,13 @@ const emailTest = test.extend<{ library: string }>({
 emailTest.describe.configure({ mode: 'serial' })
 
 emailTest.beforeAll(async ({ browser, library }) => {
-  await page.page.context().setOffline(false)
-
   context = await browser.newContext()
   browserPage = await context.newPage()
 
   page = new ModalWalletPage(browserPage, library, 'default')
   validator = new ModalWalletValidator(browserPage)
 
+  await page.page.context().setOffline(false)
   await page.load()
 
   const mailsacApiKey = process.env['MAILSAC_API_KEY']

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -179,7 +179,7 @@ export class ModalPage {
     await this.enterOTP(otp)
   }
 
-  async loginWithEmail(email: string) {
+  async loginWithEmail(email: string, validate = true) {
     // Connect Button doesn't have a proper `disabled` attribute so we need to wait for the button to change the text
     await this.page
       .getByTestId('connect-button')
@@ -188,12 +188,14 @@ export class ModalPage {
     await this.page.getByTestId('wui-email-input').locator('input').focus()
     await this.page.getByTestId('wui-email-input').locator('input').fill(email)
     await this.page.getByTestId('wui-email-input').locator('input').press('Enter')
-    await expect(
-      this.page.getByText(email),
-      `Expected current email: ${email} to be visible on the notification screen`
-    ).toBeVisible({
-      timeout: 20_000
-    })
+    if (validate) {
+      await expect(
+        this.page.getByText(email),
+        `Expected current email: ${email} to be visible on the notification screen`
+      ).toBeVisible({
+        timeout: 20_000
+      })
+    }
   }
 
   async loginWithSocial(socialOption: 'github', socialMail: string, socialPass: string) {

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -284,4 +284,10 @@ export class ModalValidator {
     const modal = this.page.getByTestId('w3m-modal')
     await expect(modal).toBeHidden()
   }
+
+  async expectSnackbar(message: string) {
+    await expect(this.page.getByTestId('wui-snackbar-message')).toHaveText(message, {
+      timeout: MAX_WAIT
+    })
+  }
 }

--- a/packages/ui/src/composites/wui-snackbar/index.ts
+++ b/packages/ui/src/composites/wui-snackbar/index.ts
@@ -36,7 +36,7 @@ export class WuiSnackbar extends LitElement {
             icon=${this.icon}
             background="opaque"
           ></wui-icon-box>`}
-      <wui-text variant="paragraph-500" color="fg-100">${this.message}</wui-text>
+      <wui-text variant="paragraph-500" color="fg-100" data-testid="wui-snackbar-message">${this.message}</wui-text>
     `
   }
 }

--- a/packages/ui/src/composites/wui-snackbar/index.ts
+++ b/packages/ui/src/composites/wui-snackbar/index.ts
@@ -36,7 +36,9 @@ export class WuiSnackbar extends LitElement {
             icon=${this.icon}
             background="opaque"
           ></wui-icon-box>`}
-      <wui-text variant="paragraph-500" color="fg-100" data-testid="wui-snackbar-message">${this.message}</wui-text>
+      <wui-text variant="paragraph-500" color="fg-100" data-testid="wui-snackbar-message"
+        >${this.message}</wui-text
+      >
     `
   }
 }

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -471,6 +471,8 @@ export class W3mFrameProvider {
       return type.replace('@w3m-app/', '')
     }
 
+    const abortController = new AbortController()
+
     const type = replaceEventType(event.type)
 
     const shouldCheckForTimeout = [
@@ -484,16 +486,18 @@ export class W3mFrameProvider {
       .map(replaceEventType)
       .includes(type)
 
-    if (shouldCheckForTimeout && this.onTimeout) {
-      // 15 seconds timeout
-      timer = setTimeout(this.onTimeout, 15_000)
+    if (shouldCheckForTimeout) {
+      timer = setTimeout(() => {
+        this.onTimeout?.()
+        abortController.abort()
+      }, 30_000)
     }
 
     return new Promise((resolve, reject) => {
       const id = Math.random().toString(36).substring(7)
       this.w3mLogger.logger.info?.({ event, id }, 'Sending app event')
       this.w3mFrame.events.postAppEvent({ ...event, id } as W3mFrameTypes.AppEvent)
-      const abortController = new AbortController()
+
       if (type === 'RPC_REQUEST') {
         const rpcEvent = event as Extract<W3mFrameTypes.AppEvent, { type: '@w3m-app/RPC_REQUEST' }>
         this.openRpcRequests = [...this.openRpcRequests, { ...rpcEvent.payload, abortController }]
@@ -501,6 +505,8 @@ export class W3mFrameProvider {
       abortController.signal.addEventListener('abort', () => {
         if (type === 'RPC_REQUEST') {
           reject(new Error('Request was aborted'))
+        } else {
+          reject(new Error('Something went wrong'))
         }
       })
 


### PR DESCRIPTION
# Description

Edited maximum timeouts for frame requests. We currently have our timeout duration on 15 seconds, but we don't throw an error and the timeout duration is low as well. We instead decided to increase the timeout duration to 25 - 30 seconds and also abort the request if it takes that long.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1147

# Showcase (Optional)

Here is an example if the request takes more than 30 seconds.

![image](https://github.com/user-attachments/assets/3bc516df-62f4-446d-8aec-2383aaf75d33)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
