### PR TITLE
refactor: frame timeouts

### DIFF
--- a/.changeset/calm-phones-joke.md
+++ b/.changeset/calm-phones-joke.md
@@ -20,4 +20,4 @@
 '@reown/appkit-ui': patch
 ---
 
-Refactored frame timeout error handling
+Refactored frame timeouts

--- a/.changeset/calm-phones-joke.md
+++ b/.changeset/calm-phones-joke.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-wallet': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+---
+
+Refactored frame timeout error handling

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -517,10 +517,11 @@ export class W3mFrameProvider {
 
         logger.logger.info?.({ framEvent, id }, 'Received frame response')
 
+        if (timer) {
+          clearTimeout(timer)
+        }
+
         if (framEvent.type === `@w3m-frame/${type}_SUCCESS`) {
-          if (timer) {
-            clearTimeout(timer)
-          }
           if ('payload' in framEvent) {
             resolve(framEvent.payload)
           }

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -517,16 +517,18 @@ export class W3mFrameProvider {
 
         logger.logger.info?.({ framEvent, id }, 'Received frame response')
 
-        if (timer) {
-          clearTimeout(timer)
-        }
-
         if (framEvent.type === `@w3m-frame/${type}_SUCCESS`) {
+          if (timer) {
+            clearTimeout(timer)
+          }
           if ('payload' in framEvent) {
             resolve(framEvent.payload)
           }
           resolve(undefined as unknown as W3mFrameTypes.Responses[`Frame${T}Response`])
         } else if (framEvent.type === `@w3m-frame/${type}_ERROR`) {
+          if (timer) {
+            clearTimeout(timer)
+          }
           if ('payload' in framEvent) {
             reject(new Error(framEvent.payload?.message || 'An error occurred'))
           }

--- a/packages/wallet/tests/W3mFrameProvider.test.ts
+++ b/packages/wallet/tests/W3mFrameProvider.test.ts
@@ -8,11 +8,13 @@ import { SecureSiteMock } from './mocks/SecureSite.mock.js'
 import { W3mFrameConstants } from '../src/W3mFrameConstants.js'
 
 describe('W3mFrameProvider', () => {
+  const mockTimeout = vi.fn
+
   const projectId = 'test-project-id'
-  let provider = new W3mFrameProvider(projectId)
+  let provider = new W3mFrameProvider({ projectId, onTimeout: mockTimeout })
 
   beforeEach(() => {
-    provider = new W3mFrameProvider(projectId)
+    provider = new W3mFrameProvider({ projectId })
     provider['w3mFrame'].frameLoadPromise = Promise.resolve()
     window.postMessage = vi.fn()
   })
@@ -98,5 +100,17 @@ describe('W3mFrameProvider', () => {
 
     expect(response).toEqual(responsePayload)
     expect(postAppEventSpy).toHaveBeenCalled()
+  })
+
+  it('should timeout after 30 seconds', async () => {
+    const postAppEventSpy = vi.spyOn(provider['w3mFrame'].events, 'postAppEvent')
+
+    const mockTimeoutSpyOn = vi.spyOn(provider, 'onTimeout')
+
+    await expect(provider.getFarcasterUri()).rejects.toThrow()
+
+    expect(postAppEventSpy).toHaveBeenCalled()
+
+    expect(mockTimeoutSpyOn).toHaveBeenCalled()
   })
 })

--- a/packages/wallet/vitest.config.ts
+++ b/packages/wallet/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     ...configDefaults,
     globals: true,
-    environment: 'jsdom'
+    environment: 'jsdom',
+    testTimeout: 60_000
   }
 })


### PR DESCRIPTION
# Description

Noticed that we only clear the timeout when the frame returns a response, but we also want to clear the timeout if the frame returns an error.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1148
For GH issues: closes #...

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
