### PR TITLE
chore: add unichain to wc rpc supported chains

### DIFF
--- a/.changeset/perfect-walls-count.md
+++ b/.changeset/perfect-walls-count.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-utils': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Adds Unichain support to the RPC supported networks array

--- a/packages/appkit-utils/src/CaipNetworkUtil.ts
+++ b/packages/appkit-utils/src/CaipNetworkUtil.ts
@@ -52,7 +52,8 @@ const WC_HTTP_RPC_SUPPORTED_CHAINS = [
   'eip155:97',
   'eip155:43113',
   'eip155:137',
-  'eip155:10'
+  'eip155:10',
+  'eip155:1301'
 ]
 
 type ExtendCaipNetworkParams = {


### PR DESCRIPTION
# Description

Unichain support has been added to our RPC supported networks. This PR adds Unichain's CAIP id to the list of supported networks to use Reown's RPC URLs.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
