### PR TITLE
refactor: update snackbar logics to prevent closing when new one added before previous is closed

### DIFF
--- a/.changeset/unlucky-walls-turn.md
+++ b/.changeset/unlucky-walls-turn.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Refactor toast/snackbar component to be able to call sequentially

--- a/packages/core/src/controllers/SnackController.ts
+++ b/packages/core/src/controllers/SnackController.ts
@@ -27,25 +27,34 @@ export const SnackController = {
   },
 
   showLoading(message: SnackControllerState['message']) {
-    state.message = message
-    state.variant = 'loading'
-    state.open = true
+    this._showMessage(message, 'loading')
   },
 
   showSuccess(message: SnackControllerState['message']) {
-    state.message = message
-    state.variant = 'success'
-    state.open = true
+    this._showMessage(message, 'success')
   },
 
   showError(message: unknown) {
     const errorMessage = CoreHelperUtil.parseError(message)
-    state.message = errorMessage
-    state.variant = 'error'
-    state.open = true
+    this._showMessage(errorMessage, 'error')
   },
 
   hide() {
     state.open = false
+  },
+
+  _showMessage(message: SnackControllerState['message'], variant: SnackControllerState['variant']) {
+    if (state.open) {
+      state.open = false
+      setTimeout(() => {
+        state.message = message
+        state.variant = variant
+        state.open = true
+      }, 150)
+    } else {
+      state.message = message
+      state.variant = variant
+      state.open = true
+    }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-snackbar/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-snackbar/index.ts
@@ -77,6 +77,9 @@ export class W3mSnackBar extends LitElement {
           easing: 'ease'
         }
       )
+      if (this.timeout) {
+        clearTimeout(this.timeout)
+      }
       this.timeout = setTimeout(() => SnackController.hide(), 2500)
     } else {
       this.animate(


### PR DESCRIPTION
# Description

When we call Snackbar before the previous one is become hidden, this causing unexpected behaviour. This PR introduces changes to make sure they can be called one after other.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

Before:

https://github.com/user-attachments/assets/c7bd958c-6563-4a65-a414-ed43526b91c3

After:

https://github.com/user-attachments/assets/f9c4b161-6b48-4df7-9e2f-49b39054531c

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
