### PR TITLE
fix: double `eth_getBalance` request

### DIFF
--- a/.changeset/funny-carrots-shake.md
+++ b/.changeset/funny-carrots-shake.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where `eth_getBalance` was being called twice after connection.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -751,7 +751,7 @@ export class WagmiAdapter implements ChainAdapter {
     }
   }
 
-  private async syncNetwork(address?: Hex, chainId?: number, isConnected?: boolean) {
+  private syncNetwork(address?: Hex, chainId?: number, isConnected?: boolean) {
     const caipNetwork = this.caipNetworks.find((c: CaipNetwork) => c.id === chainId)
 
     if (caipNetwork && chainId) {
@@ -766,8 +766,6 @@ export class WagmiAdapter implements ChainAdapter {
         } else {
           this.appKit?.setAddressExplorerUrl(undefined, this.chainNamespace)
         }
-
-        await this.syncBalance(address, chainId)
       }
     }
   }

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -42,6 +42,8 @@ describe('Wagmi Client', () => {
     vi.clearAllMocks()
     ;(getEnsName as any).mockResolvedValue('mock.eth')
     ;(getBalance as any).mockResolvedValue({ formatted: '1.0', symbol: 'ETH' })
+    vi.spyOn(mockAppKit, 'fetchIdentity').mockResolvedValue({ name: 'example.eth', avatar: '' })
+    vi.spyOn(mockAppKit, 'getReownName').mockImplementation(() => Promise.resolve([]))
   })
 
   afterEach(() => {
@@ -187,9 +189,17 @@ describe('Wagmi Client', () => {
         `eip155:${mockChainId}:${mockAddress}`,
         'eip155'
       )
+
+      expect(syncNetworkSpy).toHaveBeenCalledOnce()
       expect(syncNetworkSpy).toHaveBeenCalledWith(mockAddress, mockChainId, true)
+
+      expect(syncProfileSpy).toHaveBeenCalledOnce()
       expect(syncProfileSpy).toHaveBeenCalledWith(mockAddress, mockChainId)
+
+      expect(syncBalanceSpy).toHaveBeenCalledOnce()
       expect(syncBalanceSpy).toHaveBeenCalledWith(mockAddress, mockChainId)
+
+      expect(syncConnectedWalletInfoSpy).toHaveBeenCalledOnce
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith(mockConnector)
     })
   })
@@ -203,7 +213,6 @@ describe('Wagmi Client', () => {
       const setCaipNetworkSpy = vi.spyOn(mockAppKit, 'setCaipNetwork')
       const setCaipAddressSpy = vi.spyOn(mockAppKit, 'setCaipAddress')
       const setAddressExplorerUrlSpy = vi.spyOn(mockAppKit, 'setAddressExplorerUrl')
-      const syncBalanceSpy = vi.spyOn(mockWagmiClient as any, 'syncBalance')
 
       await (mockWagmiClient as any).syncNetwork(mockAddress, mainnet.id, true)
 
@@ -224,7 +233,6 @@ describe('Wagmi Client', () => {
         'https://etherscan.io/address/0x1234567890123456789012345678901234567890',
         'eip155'
       )
-      expect(syncBalanceSpy).toHaveBeenCalledWith(mockAddress, mainnet.id)
     })
 
     it('should not sync network if chain is not found', async () => {


### PR DESCRIPTION
# Description

In wagmi adapter the `this.syncNetwork` method was calling `this.syncBalance` method. This wasn't needed because once user is connected we already fetch the balance ([here](https://github.com/reown-com/appkit/blob/main/packages/adapters/wagmi/src/client.ts#L733) is a line of code).

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1356

# Showcase (Optional)

![image](https://github.com/user-attachments/assets/9a9052fa-e7d1-421e-8138-0a17d536ab85)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
