### PR TITLE
fix: web app wallets not working

### DIFF
--- a/.changeset/dry-rivers-cover.md
+++ b/.changeset/dry-rivers-cover.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@apps/laboratory': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where web app wallets weren't working.

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -486,7 +486,6 @@ export class ModalPage {
         const lastTab = pages[pages.length - 1]
 
         if (lastTab) {
-          await lastTab.waitForLoadState('load')
           url = lastTab.url()
           break
         }

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -441,6 +441,44 @@ export class ModalPage {
     await allWalletsListSearchItem.click()
   }
 
+  async clickTabWebApp() {
+    const tabWebApp = this.page.getByTestId('tab-webapp')
+    await expect(tabWebApp).toBeVisible()
+    await tabWebApp.click()
+  }
+
+  async expectCopiedText(text: string) {
+    const clipboardText = await this.page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText).toBe(text)
+  }
+
+  async clickCopyLink() {
+    const copyLink = this.page.getByTestId('wui-link-copy')
+    await expect(copyLink).toBeVisible()
+    await copyLink.click()
+  }
+
+  async clickOpen() {
+    const openButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
+
+    await expect(openButton).toBeVisible()
+    await expect(openButton).toHaveText('Open')
+    await openButton.click()
+    await openButton.waitFor()
+
+    // Wait for the navigation to complete
+    await this.page.waitForNavigation({ waitUntil: 'domcontentloaded' })
+
+    // Get the current URL
+    const currentUrl = this.page.url()
+    console.log(currentUrl)
+
+    const url = new URL(currentUrl)
+    const queryParams = Object.fromEntries(url.searchParams.entries())
+
+    console.log(queryParams)
+  }
+
   async search(value: string) {
     const searchInput = this.page.getByTestId('wui-input-text')
     await expect(searchInput, 'Search input should be visible').toBeVisible()

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -447,11 +447,6 @@ export class ModalPage {
     await tabWebApp.click()
   }
 
-  async expectCopiedText(text: string) {
-    const clipboardText = await this.page.evaluate(() => navigator.clipboard.readText())
-    expect(clipboardText).toBe(text)
-  }
-
   async clickCopyLink() {
     const copyLink = this.page.getByTestId('wui-link-copy')
     await expect(copyLink).toBeVisible()
@@ -470,7 +465,7 @@ export class ModalPage {
       }
     }
 
-    return await this.page.evaluate(() => navigator.clipboard.readText())
+    return this.page.evaluate(() => navigator.clipboard.readText())
   }
 
   async clickOpenWebApp() {

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -139,6 +139,12 @@ export class ModalValidator {
     expect(secureSiteIframe).toBeNull()
   }
 
+  expectQueryParameterFromUrl({ url, key, value }: { url: string; key: string; value: string }) {
+    const _url = new URL(url)
+    const queryParameters = Object.fromEntries(_url.searchParams.entries())
+    expect(queryParameters[key]).toBe(value)
+  }
+
   async expectNoSocials() {
     const socialList = this.page.getByTestId('wui-list-social')
     await expect(socialList).toBeHidden()

--- a/apps/laboratory/tests/wallet-features.spec.ts
+++ b/apps/laboratory/tests/wallet-features.spec.ts
@@ -9,6 +9,8 @@ let validator: ModalWalletValidator
 let context: BrowserContext
 /* eslint-enable init-declarations */
 
+const WEB3_AUTH_WALLET_ID = '78aaedfb74f2f4737134f2aaa78871f15ff0a2828ecb0ddc5b068a1f57bb4213'
+
 // -- Setup --------------------------------------------------------------------
 const walletFeaturesTest = test.extend<{ library: string }>({
   library: ['wagmi', { option: true }]
@@ -75,4 +77,20 @@ walletFeaturesTest('it should find account name as expected', async () => {
   await validator.expectHeaderText('Approve Transaction')
   await validator.expectAccountNameApproveTransaction('test-ens-check.reown.id')
   await page.closeModal()
+})
+
+walletFeaturesTest('it should open web app wallet', async () => {
+  await page.goToSettings()
+  await page.disconnect()
+  await page.openConnectModal()
+  await validator.expectAllWallets()
+  await page.openAllWallets()
+  await page.page.waitForTimeout(500)
+  await page.search('web3auth')
+  await page.clickAllWalletsListSearchItem(WEB3_AUTH_WALLET_ID)
+  await page.page.waitForTimeout(500)
+  await page.clickTabWebApp()
+  await page.clickCopyLink()
+  
+  await page.clickOpen()
 })

--- a/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
+++ b/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
@@ -161,7 +161,7 @@ export class W3mConnectingWidget extends LitElement {
       ${this.isWalletConnect
         ? html`
             <wui-flex .padding=${['0', 'xl', 'xl', 'xl'] as const} justifyContent="center">
-              <wui-link @click=${this.onCopyUri} color="fg-200">
+              <wui-link @click=${this.onCopyUri} color="fg-200" data-testid="wui-link-copy">
                 <wui-icon size="xs" color="fg-200" slot="iconLeft" name="copy"></wui-icon>
                 Copy link
               </wui-link>

--- a/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
@@ -162,15 +162,12 @@ export class W3mConnectingWcView extends LitElement {
     switch (this.platform) {
       case 'browser':
         return html`<w3m-connecting-wc-browser></w3m-connecting-wc-browser>`
+      case 'web':
+        return html`<w3m-connecting-wc-web></w3m-connecting-wc-web>`
       case 'desktop':
         return html`
           <w3m-connecting-wc-desktop .onRetry=${() => this.initializeConnection(true)}>
           </w3m-connecting-wc-desktop>
-        `
-      case 'web':
-        return html`
-          <w3m-connecting-wc-web .onRetry=${() => this.initializeConnection(true)}>
-          </w3m-connecting-wc-web>
         `
       case 'mobile':
         return html`


### PR DESCRIPTION
# Description

Whenever we're choosing a web app wallet and click the "Open", for some reason we fetch the URI again instead of redirecting. This was causing some unsubscribe events to appear by the universal provider which led to a few issues with web app wallets.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1302

# Showcase (Optional)

**Before:**

<img width="1623" alt="image" src="https://github.com/user-attachments/assets/540e4165-a42a-48ef-bf8e-b2d270120cf3">


**After:**

<img width="1630" alt="image" src="https://github.com/user-attachments/assets/47530ea0-0b51-4f14-8a68-9a85eac29f7b">


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
