### PR TITLE
fix: message event handler

### DIFF
--- a/packages/wallet/src/W3mFrame.ts
+++ b/packages/wallet/src/W3mFrame.ts
@@ -107,7 +107,10 @@ export class W3mFrame {
       signal: AbortSignal
     ) => {
       function eventHandler({ data }: MessageEvent) {
-        if (!data.type?.includes(W3mFrameConstants.FRAME_EVENT_KEY)) {
+        if (
+          typeof data.type !== 'string' ||
+          !data.type.includes(W3mFrameConstants.FRAME_EVENT_KEY)
+        ) {
           return
         }
         const frameEvent = W3mFrameSchema.frameEvent.parse(data)
@@ -127,7 +130,10 @@ export class W3mFrame {
     onFrameEvent: (callback: (event: W3mFrameTypes.FrameEvent) => void) => {
       if (W3mFrameHelpers.isClient) {
         window.addEventListener('message', ({ data }) => {
-          if (!data.type?.includes(W3mFrameConstants.FRAME_EVENT_KEY)) {
+          if (
+            typeof data.type !== 'string' ||
+            !data.type.includes(W3mFrameConstants.FRAME_EVENT_KEY)
+          ) {
             return
           }
           const frameEvent = W3mFrameSchema.frameEvent.parse(data)
@@ -139,7 +145,10 @@ export class W3mFrame {
     onAppEvent: (callback: (event: W3mFrameTypes.AppEvent) => void) => {
       if (W3mFrameHelpers.isClient) {
         window.addEventListener('message', ({ data }) => {
-          if (!data.type?.includes(W3mFrameConstants.APP_EVENT_KEY)) {
+          if (
+            typeof data.type !== 'string' ||
+            !data.type.includes(W3mFrameConstants.APP_EVENT_KEY)
+          ) {
             return
           }
           const appEvent = W3mFrameSchema.appEvent.parse(data)


### PR DESCRIPTION
# Description

Fixes issue where error is throw for `message` event if `data.type` is not a string (mostly due to event being emitted from completely different sdk, as 'message' is very generic)

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For GH issues: closes #2773 

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
