### PR TITLE
chore: optimize connection handling for connectors

### DIFF
--- a/.changeset/orange-melons-divide.md
+++ b/.changeset/orange-melons-divide.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-wagmi': patch
+'@apps/laboratory': patch
+'@reown/appkit': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Optimized connection handling for connectors.

--- a/apps/laboratory/src/components/AppKitButtons.tsx
+++ b/apps/laboratory/src/components/AppKitButtons.tsx
@@ -12,7 +12,7 @@ import {
 
 export function AppKitButtons() {
   const { open } = useAppKit()
-  const { caipAddress } = useAppKitAccount()
+  const { isConnected } = useAppKitAccount()
   const { disconnect } = useDisconnect()
 
   return (
@@ -44,11 +44,13 @@ export function AppKitButtons() {
                 Open
               </Button>
 
-              {caipAddress && (
-                <Button data-testid="disconnect-hook-button" onClick={() => disconnect()}>
-                  Disconnect
-                </Button>
-              )}
+              <Button
+                data-testid="disconnect-hook-button"
+                isDisabled={!isConnected}
+                onClick={() => disconnect()}
+              >
+                Disconnect
+              </Button>
             </Box>
           </Box>
         </Stack>

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -293,6 +293,13 @@ export class ModalValidator {
     await expect(disabledNetwork.locator('button')).toBeDisabled()
   }
 
+  async expectToBeConnectedInstantly() {
+    const accountButton = this.page.locator('w3m-account-button')
+    await expect(accountButton, 'Account button should be present').toBeAttached({
+      timeout: 1000
+    })
+  }
+
   async expectConnectButtonLoading() {
     const connectButton = this.page.getByTestId('connect-button')
     await expect(connectButton).toContainText('Connecting...')

--- a/apps/laboratory/tests/wallet.spec.ts
+++ b/apps/laboratory/tests/wallet.spec.ts
@@ -51,6 +51,11 @@ sampleWalletTest('it should show onramp button accordingly', async () => {
   await modalPage.closeModal()
 })
 
+sampleWalletTest('it should be connected instantly after page refresh', async () => {
+  await modalPage.page.reload()
+  await modalValidator.expectToBeConnectedInstantly()
+})
+
 sampleWalletTest('it should show disabled networks', async ({ library }) => {
   const disabledNetworks = library === 'solana' ? 'Solana Unsupported' : 'Gnosis'
 

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -1176,11 +1176,13 @@ export class EthersAdapter {
       this.appKit?.setLoading(true)
       const isLoginEmailUsed = this.authProvider.getLoginEmailUsed()
       this.appKit?.setLoading(isLoginEmailUsed)
-      const { isConnected } = await this.authProvider.isConnected()
-      if (isConnected) {
-        await this.setAuthProvider()
-      } else {
-        this.appKit?.setLoading(false)
+      if (isLoginEmailUsed) {
+        const { isConnected } = await this.authProvider.isConnected()
+        if (isConnected) {
+          await this.setAuthProvider()
+        } else {
+          this.appKit?.setLoading(false)
+        }
       }
     }
   }

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -1165,11 +1165,13 @@ export class Ethers5Adapter {
       this.appKit?.setLoading(true)
       const isLoginEmailUsed = this.authProvider.getLoginEmailUsed()
       this.appKit?.setLoading(isLoginEmailUsed)
-      const { isConnected } = await this.authProvider.isConnected()
-      if (isConnected) {
-        await this.setAuthProvider()
-      } else {
-        this.appKit?.setLoading(false)
+      if (isLoginEmailUsed) {
+        const { isConnected } = await this.authProvider.isConnected()
+        if (isConnected) {
+          await this.setAuthProvider()
+        } else {
+          this.appKit?.setLoading(false)
+        }
       }
     }
   }

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -974,11 +974,7 @@ export class WagmiAdapter implements ChainAdapter {
     bypassWindowCheck = false
   ) {
     if (bypassWindowCheck || (typeof window !== 'undefined' && connector)) {
-      this.appKit?.setLoading(true)
       const provider = (await connector.getProvider()) as W3mFrameProvider
-      const isLoginEmailUsed = provider.getLoginEmailUsed()
-
-      this.appKit?.setLoading(isLoginEmailUsed)
 
       provider.onRpcRequest((request: W3mFrameTypes.RPCRequest) => {
         if (W3mFrameHelpers.checkIfRequestExists(request)) {

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -759,6 +759,7 @@ export class WagmiAdapter implements ChainAdapter {
               this.appKit?.setApprovedCaipNetworksData(this.chainNamespace)
             ])
           }
+          this.appKit?.setLoading(false)
         } else if (status === 'connected' && address && chainId) {
           ProviderUtil.setProvider(this.chainNamespace, await connector.getProvider())
           ProviderUtil.setProviderId(this.chainNamespace, connector.id as ProviderIdType)

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -105,9 +105,8 @@ export function authConnector(parameters: AuthParameters) {
 
     async isAuthorized() {
       const provider = await this.getProvider()
-      const { isConnected } = await provider.isConnected()
 
-      return isConnected
+      return Promise.resolve(provider.getLoginEmailUsed())
     },
 
     async switchChain({ chainId }) {

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.1.6'
+export const PACKAGE_VERSION = '1.1.7'


### PR DESCRIPTION
# Description

There is an issue where if you refresh your page even tho you've connected with e.g metamask it'll take too much time to finish loading. This is because we're always reconnecting to auth connector even tho we haven't connected with it before.

For this change we'll make sure that we're only reconnecting to auth connector if a user has already connected before.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1358

# Showcase (Optional)

**Before:**

https://github.com/user-attachments/assets/e5ca1521-e18b-4e10-ba5c-8cfb8a0b8abb

**After:**


https://github.com/user-attachments/assets/8a2600da-98d3-4197-a424-ded5678b048f



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
