### PR TITLE
fix: multichain connectors not working

### DIFF
--- a/.changeset/tidy-turtles-jump.md
+++ b/.changeset/tidy-turtles-jump.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where multichain connectors weren't working.

--- a/packages/core/src/controllers/ConnectorController.ts
+++ b/packages/core/src/controllers/ConnectorController.ts
@@ -58,7 +58,7 @@ export const ConnectorController = {
       )
     })
 
-    state.allConnectors = [...state.connectors, ...newConnectors]
+    state.allConnectors = [...state.allConnectors, ...newConnectors]
     state.connectors = this.mergeMultiChainConnectors(state.allConnectors)
   },
 

--- a/packages/core/tests/controllers/ConnectorController.test.ts
+++ b/packages/core/tests/controllers/ConnectorController.test.ts
@@ -24,6 +24,13 @@ const walletConnectConnector = {
   chain: ConstantsUtil.CHAIN.EVM,
   name: 'WalletConnect'
 } as const
+const walletConnectSolanaConnector = {
+  id: 'walletConnect-solana',
+  explorerId: 'walletConnectId-slo',
+  type: 'WALLET_CONNECT',
+  chain: ConstantsUtil.CHAIN.SOLANA,
+  name: 'WalletConnect'
+} as const
 const externalConnector = {
   id: 'external',
   type: 'EXTERNAL',
@@ -98,7 +105,23 @@ describe('ConnectorController', () => {
     expect(ConnectorController.state.connectors).toEqual([])
   })
 
+  it('should update state correctly on setConnectors() with multichain', () => {
+    ConnectorController.setConnectors([walletConnectConnector, walletConnectSolanaConnector])
+    expect(ConnectorController.state.connectors).toStrictEqual([
+      {
+        id: 'walletConnect',
+        name: 'WalletConnect',
+        chain: 'eip155',
+        imageId: undefined,
+        imageUrl: undefined,
+        type: 'MULTI_CHAIN',
+        connectors: [walletConnectConnector, walletConnectSolanaConnector]
+      }
+    ])
+  })
+
   it('should update state correctly on setConnectors()', () => {
+    ConnectorController.state.allConnectors = []
     ConnectorController.setConnectors([walletConnectConnector])
     expect(ConnectorController.state.connectors).toEqual([walletConnectConnector])
   })


### PR DESCRIPTION
# Description

When using multichain the evm connectors aren't working at the moment.

For example if you use multichain and try to connect with phantom (ethereum) you'll get an error. This happens because the wagmi connector cannot be found [here](https://github.com/reown-com/appkit/blob/main/packages/adapters/wagmi/src/client.ts#L391-L393).

We're mixing the wagmi connector id with solana connector id which results into getting this error.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1286

# Showcase (Optional)

**Before:**

https://github.com/user-attachments/assets/e411f482-6009-4387-ac8b-37b14a9a3950

**After:**

https://github.com/user-attachments/assets/6f032623-6a05-4eb9-bd46-4a8bdc32d935

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
