### PR TITLE
fix: metadata values weren't included in the universal provider

### DIFF
--- a/.changeset/large-lemons-heal.md
+++ b/.changeset/large-lemons-heal.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where metadata values weren't included in the universal provider.

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -447,6 +447,12 @@ export class AppKit {
 
     this.adapters = options.adapters
 
+    const defaultMetaData = this.getDefaultMetaData()
+
+    if (!options.metadata && defaultMetaData) {
+      options.metadata = defaultMetaData
+    }
+
     this.initializeUniversalAdapter(options)
     this.initializeAdapters(options)
     this.setDefaultNetwork()
@@ -466,10 +472,8 @@ export class AppKit {
     OptionsController.setEnableWalletConnect(options.enableWalletConnect !== false)
     OptionsController.setEnableWallets(options.enableWallets !== false)
 
-    const metadata = options.metadata ?? this.getDefaultMetaData()
-
-    if (metadata) {
-      OptionsController.setMetadata(metadata)
+    if (options.metadata) {
+      OptionsController.setMetadata(options.metadata)
     }
 
     if (options.themeMode) {

--- a/packages/appkit/src/tests/appkit.test.ts
+++ b/packages/appkit/src/tests/appkit.test.ts
@@ -39,6 +39,12 @@ describe('Base', () => {
       expect(OptionsController.setSdkVersion).toHaveBeenCalledWith(mockOptions.sdkVersion)
       expect(OptionsController.setProjectId).toHaveBeenCalledWith(mockOptions.projectId)
       expect(OptionsController.setMetadata).toHaveBeenCalledWith(mockOptions.metadata)
+      expect(appKit.universalAdapter?.construct).toHaveBeenCalledWith(
+        appKit,
+        expect.objectContaining({
+          metadata: mockOptions.metadata
+        })
+      )
     })
 
     it('should initialize adapters in ChainController', () => {


### PR DESCRIPTION
# Description

When universal provider was initialised it had no metadata included.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
