### PR TITLE
refactor: add subscribe account and network methods for plain js use case

### DIFF
--- a/.changeset/short-pumas-change.md
+++ b/.changeset/short-pumas-change.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Adds listeners for account and network states for plain JS users

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -6,7 +6,9 @@ import type {
   ConnectedWalletInfo,
   RouterControllerState,
   ChainAdapter,
-  SdkVersion
+  SdkVersion,
+  UseAppKitAccountReturn,
+  UseAppKitNetworkReturn
 } from '@reown/appkit-core'
 import {
   AccountController,
@@ -40,9 +42,6 @@ import { UniversalAdapterClient } from './universal-adapter/client.js'
 import { CaipNetworksUtil, ErrorUtil } from '@reown/appkit-utils'
 import type { W3mFrameTypes } from '@reown/appkit-wallet'
 import { ProviderUtil } from './store/ProviderUtil.js'
-import type { CaipAddress } from '@reown/appkit'
-import type { AccountControllerState } from '@reown/appkit'
-import type { CaipNetworkId } from '@reown/appkit'
 
 // -- Export Controllers -------------------------------------------------------
 export { AccountController }
@@ -50,17 +49,6 @@ export { AccountController }
 // -- Types --------------------------------------------------------------------
 export interface OpenOptions {
   view: 'Account' | 'Connect' | 'Networks' | 'ApproveTransaction' | 'OnRampProviders'
-}
-type AccountState = {
-  caipAddress: CaipAddress | undefined
-  address: string | undefined
-  isConnected: boolean
-  status: AccountControllerState['status']
-}
-type NetworkState = {
-  caipNetwork: CaipNetwork | undefined
-  chainId: number | string | undefined
-  caipNetworkId: CaipNetworkId | undefined
 }
 
 // -- Helpers -------------------------------------------------------------------
@@ -174,7 +162,7 @@ export class AppKit {
     return AccountController.state.connectedWalletInfo
   }
 
-  public subscribeAccount(callback: (newState: AccountState) => void) {
+  public subscribeAccount(callback: (newState: UseAppKitAccountReturn) => void) {
     function updateVal() {
       callback({
         caipAddress: ChainController.state.activeCaipAddress,
@@ -188,7 +176,7 @@ export class AppKit {
     AccountController.subscribe(updateVal)
   }
 
-  public subscribeNetwork(callback: (newState: NetworkState) => void) {
+  public subscribeNetwork(callback: (newState: UseAppKitNetworkReturn) => void) {
     return ChainController.subscribe(({ activeCaipNetwork }) => {
       callback({
         caipNetwork: activeCaipNetwork,

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -160,6 +160,30 @@ export class AppKit {
     return AccountController.state.connectedWalletInfo
   }
 
+  public subscribeAccount(callback: (newState: any) => void) {
+    function updateVal() {
+      callback({
+        caipAddress: ChainController.state.activeCaipAddress,
+        address: CoreHelperUtil.getPlainAddress(ChainController.state.activeCaipAddress),
+        isConnected: Boolean(ChainController.state.activeCaipAddress),
+        status: AccountController.state.status
+      })
+    }
+
+    ChainController.subscribe(updateVal)
+    AccountController.subscribe(updateVal)
+  }
+
+  public subscribeNetwork(callback: (newState: ConnectedWalletInfo) => void) {
+    return ChainController.subscribe(({ activeCaipNetwork }) => {
+      callback({
+        caipNetwork: activeCaipNetwork,
+        chainId: activeCaipNetwork?.id,
+        caipNetworkId: activeCaipNetwork?.caipNetworkId
+      })
+    })
+  }
+
   public subscribeWalletInfo(callback: (newState: ConnectedWalletInfo) => void) {
     return AccountController.subscribeKey('connectedWalletInfo', callback)
   }

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -40,6 +40,9 @@ import { UniversalAdapterClient } from './universal-adapter/client.js'
 import { CaipNetworksUtil, ErrorUtil } from '@reown/appkit-utils'
 import type { W3mFrameTypes } from '@reown/appkit-wallet'
 import { ProviderUtil } from './store/ProviderUtil.js'
+import type { CaipAddress } from '@reown/appkit'
+import type { AccountControllerState } from '@reown/appkit'
+import type { CaipNetworkId } from '@reown/appkit'
 
 // -- Export Controllers -------------------------------------------------------
 export { AccountController }
@@ -47,6 +50,17 @@ export { AccountController }
 // -- Types --------------------------------------------------------------------
 export interface OpenOptions {
   view: 'Account' | 'Connect' | 'Networks' | 'ApproveTransaction' | 'OnRampProviders'
+}
+type AccountState = {
+  caipAddress: CaipAddress | undefined
+  address: string | undefined
+  isConnected: boolean
+  status: AccountControllerState['status']
+}
+type NetworkState = {
+  caipNetwork: CaipNetwork | undefined
+  chainId: number | string | undefined
+  caipNetworkId: CaipNetworkId | undefined
 }
 
 // -- Helpers -------------------------------------------------------------------
@@ -160,7 +174,7 @@ export class AppKit {
     return AccountController.state.connectedWalletInfo
   }
 
-  public subscribeAccount(callback: (newState: any) => void) {
+  public subscribeAccount(callback: (newState: AccountState) => void) {
     function updateVal() {
       callback({
         caipAddress: ChainController.state.activeCaipAddress,
@@ -174,7 +188,7 @@ export class AppKit {
     AccountController.subscribe(updateVal)
   }
 
-  public subscribeNetwork(callback: (newState: ConnectedWalletInfo) => void) {
+  public subscribeNetwork(callback: (newState: NetworkState) => void) {
     return ChainController.subscribe(({ activeCaipNetwork }) => {
       callback({
         caipNetwork: activeCaipNetwork,

--- a/packages/core/src/utils/TypeUtil.ts
+++ b/packages/core/src/utils/TypeUtil.ts
@@ -978,3 +978,16 @@ export type Features = {
 export type FeaturesKeys = keyof Features
 
 export type WalletGuideType = 'get-started' | 'explore'
+
+export type UseAppKitAccountReturn = {
+  caipAddress: CaipAddress | undefined
+  address: string | undefined
+  isConnected: boolean
+  status: AccountControllerState['status']
+}
+
+export type UseAppKitNetworkReturn = {
+  caipNetwork: CaipNetwork | undefined
+  chainId: number | string | undefined
+  caipNetworkId: CaipNetworkId | undefined
+}


### PR DESCRIPTION
# Description

For plain JS users we are not providing expected listeners as we do with the hooks (`useAppKitAccount` and `useAppKitNetwork`). This PR introduces changes to AppKit client to have the same listener for plain JS users to subscribe account and network state.

*The testing of these will be handled in another PR specific to CDN updates

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
