### PR TITLE
refactor: sa gas availability check logics for swaps

### DIFF
--- a/.changeset/silver-laws-buy.md
+++ b/.changeset/silver-laws-buy.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-core': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes swap gas availability check for smart accounts

--- a/packages/core/src/controllers/SwapController.ts
+++ b/packages/core/src/controllers/SwapController.ts
@@ -186,13 +186,6 @@ export const SwapController = {
       !state.sourceToken?.decimals ||
       !NumberUtil.bigNumber(state.sourceTokenAmount).isGreaterThan(0)
     const invalidSourceTokenAmount = !state.sourceTokenAmount
-    console.log(
-      '>>> SWAP',
-      caipAddress,
-      invalidToToken,
-      invalidSourceToken,
-      invalidSourceTokenAmount
-    )
 
     return {
       networkAddress,

--- a/packages/core/src/controllers/SwapController.ts
+++ b/packages/core/src/controllers/SwapController.ts
@@ -186,6 +186,13 @@ export const SwapController = {
       !state.sourceToken?.decimals ||
       !NumberUtil.bigNumber(state.sourceTokenAmount).isGreaterThan(0)
     const invalidSourceTokenAmount = !state.sourceTokenAmount
+    console.log(
+      '>>> SWAP',
+      caipAddress,
+      invalidToToken,
+      invalidSourceToken,
+      invalidSourceTokenAmount
+    )
 
     return {
       networkAddress,
@@ -815,18 +822,19 @@ export const SwapController = {
       state.myTokensWithBalance
     )
 
-    // Smart Accounts may pay gas in any ERC20 token
+    let insufficientNetworkTokenForGas = true
     if (
       AccountController.state.preferredAccountType ===
       W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT
     ) {
-      return true
+      // Smart Accounts may pay gas in any ERC20 token
+      insufficientNetworkTokenForGas = false
+    } else {
+      insufficientNetworkTokenForGas = SwapCalculationUtil.isInsufficientNetworkTokenForGas(
+        state.networkBalanceInUSD,
+        state.gasPriceInUSD
+      )
     }
-
-    const insufficientNetworkTokenForGas = SwapCalculationUtil.isInsufficientNetworkTokenForGas(
-      state.networkBalanceInUSD,
-      state.gasPriceInUSD
-    )
 
     return insufficientNetworkTokenForGas || isInsufficientSourceTokenForSwap
   },


### PR DESCRIPTION
# Description

In swaps, we have logic to check if user have enough balance to pay the gas; `SwapController.hasInsufficientToken`. For specifically to smart accounts, we've returning direct value for gas availability if the account is smart account.

This logic directly returning `true` and it have two issues:
- Bypasses the balance check for swap (not for paying gas)
- It should be return `false` to make the swap available, returning `true` means user has insufficient token as function name describes. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1288
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
