### PR TITLE
fix: ethers/ethers5 `accountsChanged` handler not working

### DIFF
--- a/.changeset/dull-parents-turn.md
+++ b/.changeset/dull-parents-turn.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes issue where ethers and ethers5 adapters didn't set the proper caip address when switching accounts manually.

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -732,9 +732,13 @@ export class EthersAdapter {
     }
 
     const accountsChangedHandler = (accounts: string[]) => {
-      const currentAccount = accounts?.[0] as CaipAddress | undefined
+      const currentAccount = accounts?.[0] as Address | undefined
+
       if (currentAccount) {
-        this.appKit?.setCaipAddress(currentAccount, this.chainNamespace)
+        const chainId = this.appKit?.getCaipNetwork()?.id
+        const caipAddress = `${this.chainNamespace}:${chainId}:${currentAccount}` as CaipAddress
+
+        this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
 
         if (providerId === ConstantsUtil.EIP6963_CONNECTOR_ID) {
           this.appKit?.setAllAccounts(

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -368,6 +368,7 @@ export class EthersAdapter {
         // Common cleanup actions
         SafeLocalStorage.removeItem(SafeLocalStorageKeys.WALLET_ID)
         this.appKit?.resetAccount(this.chainNamespace)
+        this.removeListeners(provider as Provider)
       },
       signMessage: async (message: string) => {
         const provider = ProviderUtil.getProvider<Provider>(this.chainNamespace)
@@ -624,7 +625,6 @@ export class EthersAdapter {
     }
 
     const activeConfig = providerConfigs[walletId as unknown as keyof typeof providerConfigs]
-
     if (activeConfig?.provider) {
       this.setProvider(activeConfig.provider, walletId as ProviderIdType)
       this.setupProviderListeners(activeConfig.provider, walletId as ProviderIdType)

--- a/packages/adapters/ethers/src/tests/client.test.ts
+++ b/packages/adapters/ethers/src/tests/client.test.ts
@@ -593,12 +593,14 @@ describe('EthersAdapter', () => {
     it('should handle accountsChanged event', async () => {
       client['setupProviderListeners'](mockProvider, 'injected')
 
+      const address = '0x1234567890123456789012345678901234567890'
       const accountsChangedHandler = mockProvider.on.mock.calls.find(
         (call: string[]) => call[0] === 'accountsChanged'
       )[1]
-      await accountsChangedHandler(['0x1234567890123456789012345678901234567890'])
+      await accountsChangedHandler([address])
 
       expect(mockAppKit.setCaipAddress).toHaveBeenCalled()
+      expect(mockAppKit.setCaipAddress).toHaveBeenCalledWith(`eip155:1:${address}`, 'eip155')
     })
 
     it('should handle chainChanged event', async () => {

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -368,6 +368,7 @@ export class Ethers5Adapter {
         // Common cleanup actions
         SafeLocalStorage.removeItem(SafeLocalStorageKeys.WALLET_ID)
         this.appKit?.resetAccount(this.chainNamespace)
+        this.removeListeners(provider as Provider)
       },
       signMessage: async (message: string) => {
         const provider = ProviderUtil.getProvider<Provider>(this.chainNamespace)

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -720,7 +720,10 @@ export class Ethers5Adapter {
     const accountsChangedHandler = (accounts: string[]) => {
       const currentAccount = accounts?.[0] as CaipAddress | undefined
       if (currentAccount) {
-        this.appKit?.setCaipAddress(currentAccount, this.chainNamespace)
+        const chainId = this.appKit?.getCaipNetwork()?.id
+        const caipAddress = `${this.chainNamespace}:${chainId}:${currentAccount}` as CaipAddress
+
+        this.appKit?.setCaipAddress(caipAddress, this.chainNamespace)
 
         if (providerId === ConstantsUtil.EIP6963_CONNECTOR_ID) {
           this.appKit?.setAllAccounts(

--- a/packages/adapters/ethers5/src/tests/client.test.ts
+++ b/packages/adapters/ethers5/src/tests/client.test.ts
@@ -596,12 +596,14 @@ describe('EthersAdapter', () => {
     it('should handle accountsChanged event', async () => {
       client['setupProviderListeners'](mockProvider, 'injected')
 
+      const address = '0x1234567890123456789012345678901234567890'
       const accountsChangedHandler = mockProvider.on.mock.calls.find(
         (call: string[]) => call[0] === 'accountsChanged'
       )[1]
-      await accountsChangedHandler(['0x1234567890123456789012345678901234567890'])
+      await accountsChangedHandler([address])
 
       expect(mockAppKit.setCaipAddress).toHaveBeenCalled()
+      expect(mockAppKit.setCaipAddress).toHaveBeenCalledWith(`eip155:1:${address}`, 'eip155')
     })
 
     it('should handle chainChanged event', async () => {


### PR DESCRIPTION
# Description

There is a bug where if you connected your wallet and try to switch address manually you'll see that there is no address being shown in the connect button.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1393

# Showcase (Optional)

**Before:**

https://github.com/user-attachments/assets/8c9b17b6-e55b-43c5-96b1-488d2cce2c9e

**After:**

https://github.com/user-attachments/assets/3709d1a0-02e3-40dc-9760-0f230b883322
 
# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
