### PR TITLE
fix: email input breaking styles of button

### DIFF
--- a/.changeset/six-scissors-remember.md
+++ b/.changeset/six-scissors-remember.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where the submit/loading icons were overflowing when entering a wrong email address.

--- a/.changeset/six-scissors-remember.md
+++ b/.changeset/six-scissors-remember.md
@@ -21,4 +21,4 @@
 '@reown/appkit-wallet': patch
 ---
 
-Fixes an issue where the submit/loading icons were overflowing when entering a wrong email address.
+Fixes an issue where email input validation errors broke the button styles.

--- a/packages/scaffold-ui/src/partials/w3m-email-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-email-login-widget/index.ts
@@ -72,14 +72,13 @@ export class W3mEmailLoginWidget extends LitElement {
           @focus=${this.onFocusEvent.bind(this)}
           .disabled=${this.loading}
           @inputChange=${this.onEmailInputChange.bind(this)}
-          .errorMessage=${this.error}
         >
         </wui-email-input>
 
         ${this.submitButtonTemplate()}${this.loadingTemplate()}
         <input type="submit" hidden />
       </form>
-      ${this.separatorTemplate()}
+      ${this.templateError()} ${this.separatorTemplate()}
     `
   }
 
@@ -130,6 +129,14 @@ export class W3mEmailLoginWidget extends LitElement {
     return this.loading
       ? html`<wui-loading-spinner size="md" color="accent-100"></wui-loading-spinner>`
       : null
+  }
+
+  private templateError() {
+    if (this.error) {
+      return html`<wui-text variant="tiny-500" color="error-100">${this.error}</wui-text>`
+    }
+
+    return null
   }
 
   private onEmailInputChange(event: CustomEvent<string>) {

--- a/packages/scaffold-ui/src/partials/w3m-email-login-widget/styles.ts
+++ b/packages/scaffold-ui/src/partials/w3m-email-login-widget/styles.ts
@@ -19,15 +19,19 @@ export default css`
   wui-icon-link,
   wui-loading-spinner {
     position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   wui-icon-link {
-    top: 13px;
     right: var(--wui-spacing-xs);
   }
 
   wui-loading-spinner {
-    top: 19px;
     right: var(--wui-spacing-m);
+  }
+
+  wui-text {
+    margin: var(--wui-spacing-xxs) var(--wui-spacing-m) var(--wui-spacing-0) var(--wui-spacing-m);
   }
 `

--- a/packages/scaffold-ui/src/partials/w3m-email-login-widget/styles.ts
+++ b/packages/scaffold-ui/src/partials/w3m-email-login-widget/styles.ts
@@ -19,15 +19,15 @@ export default css`
   wui-icon-link,
   wui-loading-spinner {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
   }
 
   wui-icon-link {
+    top: 13px;
     right: var(--wui-spacing-xs);
   }
 
   wui-loading-spinner {
+    top: 19px;
     right: var(--wui-spacing-m);
   }
 `


### PR DESCRIPTION
# Description

When entering an email to something like "example@" and then clicking Enter, you'll see that it breaks the button styles that's on the right side of the input field.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1212

# Showcase (Optional)

**Before:**

<img width="360" alt="before" src="https://github.com/user-attachments/assets/e7e6d07e-7f6a-4957-9797-a6bc98b2d5c3">


**After:**

<img width="362" alt="after" src="https://github.com/user-attachments/assets/81f31705-c50f-4ef6-8e0b-ed084e72de62">

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
