### PR TITLE
fix: client Id not being set

### DIFF
--- a/.changeset/six-pumpkins-suffer.md
+++ b/.changeset/six-pumpkins-suffer.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-scaffold-ui': patch
+'@apps/laboratory': patch
+'@reown/appkit': patch
+'@reown/appkit-ui': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-wallet': patch
+---
+
+Adds clientId to all blockchain api requests on a relay connection

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -95,9 +95,7 @@ smartAccountTest('it should switch to smart account and sign', async () => {
   await page.togglePreferredAccountType()
   await validator.expectChangePreferredAccountToShow(EOA)
   await page.closeModal()
-
-  // Need some time for Lab UI to refresh state
-  await page.page.waitForTimeout(1000)
+  await validator.expectAccountButtonReady()
 
   await page.sign()
   await page.approveSign()
@@ -115,9 +113,7 @@ smartAccountTest('it should switch to eoa and sign', async () => {
   await page.togglePreferredAccountType()
   await validator.expectChangePreferredAccountToShow(SMART_ACCOUNT)
   await page.closeModal()
-
-  // Need some time for Lab UI to refresh state
-  await page.page.waitForTimeout(1000)
+  await validator.expectAccountButtonReady()
 
   await page.sign()
   await page.approveSign()

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -311,8 +311,12 @@ export class WagmiAdapter implements ChainAdapter {
           ReturnType<(typeof UniversalProvider)['init']>
         >
 
-        const siweParams = await this.options?.siweConfig?.getMessageParams?.()
+        const clientId = await provider?.client?.core?.crypto?.getClientId()
+        if (clientId) {
+          this.appKit?.setClientId(clientId)
+        }
 
+        const siweParams = await this.options?.siweConfig?.getMessageParams?.()
         const isSiweEnabled = this.options?.siweConfig?.options?.enabled
         const isProviderSupported = typeof provider?.authenticate === 'function'
         const isSiweParamsValid = siweParams && Object.keys(siweParams || {}).length > 0

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.2.0'
+export const PACKAGE_VERSION = '1.2.1'

--- a/packages/appkit/src/tests/mocks/AppKit.ts
+++ b/packages/appkit/src/tests/mocks/AppKit.ts
@@ -19,7 +19,8 @@ export const mockAppKit = {
   getPreferredAccountType: vi.fn().mockReturnValue('eoa'),
   getCaipNetwork: vi.fn().mockReturnValue(mainnet),
   setApprovedCaipNetworksData: vi.fn(),
-  getAddress: vi.fn().mockReturnValue('0xE62a3eD41B21447b67a63880607CD2E746A0E35d')
+  getAddress: vi.fn().mockReturnValue('0xE62a3eD41B21447b67a63880607CD2E746A0E35d'),
+  setClientId: vi.fn()
 } as unknown as AppKit
 
 export default mockAppKit

--- a/packages/appkit/src/tests/mocks/UniversalProvider.ts
+++ b/packages/appkit/src/tests/mocks/UniversalProvider.ts
@@ -96,7 +96,8 @@ export const mockProvider = {
         keychain: {
           has: vi.fn().mockResolvedValue(true),
           set: vi.fn()
-        }
+        },
+        getClientId: vi.fn().mockReturnValue('mock_client_id')
       },
       relayer: {
         subscriber: {

--- a/packages/appkit/src/tests/universal-adapter.test.ts
+++ b/packages/appkit/src/tests/universal-adapter.test.ts
@@ -105,6 +105,15 @@ describe('UniversalAdapter', () => {
       })
     })
 
+    it('should set the clientId in AppKit when connectionControllerClient.connectWalletConnect is invoked', async () => {
+      const mockOnUri = vi.fn()
+      await universalAdapter?.connectionControllerClient?.connectWalletConnect?.(mockOnUri)
+
+      expect(mockAppKit.setClientId).toHaveBeenCalledWith(
+        mockProvider.client?.core?.crypto?.getClientId()
+      )
+    })
+
     it('should update AppKit state when connectionControllerClient.connectWalletConnect is invoked', async () => {
       const mockOnUri = vi.fn()
       await universalAdapter?.connectionControllerClient?.connectWalletConnect?.(mockOnUri)

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -148,7 +148,10 @@ export class UniversalAdapterClient {
           const isSiweEnabled = siweConfig?.options?.enabled
           const isProviderSupported = typeof WalletConnectProvider?.authenticate === 'function'
           const isSiweParamsValid = siweParams && Object.keys(siweParams || {}).length > 0
-
+          const clientId = await WalletConnectProvider?.client?.core?.crypto?.getClientId()
+          if (clientId) {
+            this.appKit?.setClientId(clientId)
+          }
           if (
             siweConfig &&
             isSiweEnabled &&


### PR DESCRIPTION
# Description
We require the `clientId` of the relay connections to be serialized on BlockchainApi requests 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
