### PR TITLE
fix: publish canary workflow. add danger rule

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -1,4 +1,4 @@
-ame: Publish Canary Image
+name: Publish Canary Image
 on:
   workflow_dispatch:
   push:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -388,3 +388,18 @@ async function checkChangesetFiles() {
   }
 }
 checkChangesetFiles()
+
+// -- Check Workflows ------------------------------------------------------------
+function checkWorkflows() {
+  const updatedWorkflows = updated_files.filter(f => f.includes('.github/workflows/'))
+  const deletedWorkflows = deleted_files.filter(f => f.includes('.github/workflows/'))
+
+  for (const f of deletedWorkflows) {
+    fail(`Workflow file(s) ${f} has been deleted`)
+  }
+
+  for (const f of updatedWorkflows) {
+    warn(`Workflow file ${f} has been modified`)
+  }
+}
+checkWorkflows()


### PR DESCRIPTION

# Description
- Fix publish canary action
- Add danger rule to warn about modified workflows and to fail on deleted ones

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
- [X] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
