### PR TITLE
fix: add deprecated caip network ids for solana chains as a workaround

### DIFF
--- a/packages/appkit/src/networks/solana/solana.ts
+++ b/packages/appkit/src/networks/solana/solana.ts
@@ -11,5 +11,6 @@ export const solana = defineChain({
   blockExplorers: { default: { name: 'Solscan', url: 'https://solscan.io' } },
   testnet: false,
   chainNamespace: 'solana',
-  caipNetworkId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+  caipNetworkId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  deprecatedCaipNetworkId: 'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ'
 })

--- a/packages/appkit/src/networks/solana/solanaDevnet.ts
+++ b/packages/appkit/src/networks/solana/solanaDevnet.ts
@@ -11,5 +11,6 @@ export const solanaDevnet = defineChain({
   blockExplorers: { default: { name: 'Solscan', url: 'https://solscan.io' } },
   testnet: true,
   chainNamespace: 'solana',
-  caipNetworkId: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'
+  caipNetworkId: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+  deprecatedCaipNetworkId: 'solana:8E9rvCKLFQia2Y35HXjjpWzj8weVo44K'
 })

--- a/packages/appkit/src/tests/mocks/UniversalProvider.ts
+++ b/packages/appkit/src/tests/mocks/UniversalProvider.ts
@@ -33,7 +33,10 @@ export const mockProvider = {
       }
     },
     solana: {
-      chains: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+      chains: [
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ'
+      ],
       methods: [
         'solana_signMessage',
         'solana_signTransaction',

--- a/packages/appkit/src/tests/utils/HelpersUtil.test.ts
+++ b/packages/appkit/src/tests/utils/HelpersUtil.test.ts
@@ -139,7 +139,10 @@ describe('WcHelpersUtil', () => {
             'solana_signAndSendTransaction'
           ],
           events: ['accountsChanged', 'chainChanged'],
-          chains: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+          chains: [
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ'
+          ],
           rpcMap: {
             '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'https://api.mainnet-beta.solana.com'
           }

--- a/packages/appkit/src/utils/HelpersUtil.ts
+++ b/packages/appkit/src/utils/HelpersUtil.ts
@@ -1,6 +1,7 @@
 import type { NamespaceConfig, Namespace } from '@walletconnect/universal-provider'
 import type { CaipNetwork, CaipNetworkId, ChainNamespace } from '@reown/appkit-common'
 import type { SessionTypes } from '@walletconnect/types'
+import { solana, solanaDevnet } from '../networks/index.js'
 
 export const WcHelpersUtil = {
   getMethodsByChainNamespace(chainNamespace: ChainNamespace): string[] {
@@ -59,6 +60,17 @@ export const WcHelpersUtil = {
       const namespace = acc[chainNamespace] as Namespace
 
       namespace.chains.push(caipNetworkId)
+
+      // Workaround for wallets that only support deprecated Solana network ID
+      switch (caipNetworkId) {
+        case solana.caipNetworkId:
+          namespace.chains.push(solana.deprecatedCaipNetworkId)
+          break
+        case solanaDevnet.deprecatedCaipNetworkId:
+          namespace.chains.push(solanaDevnet.deprecatedCaipNetworkId)
+          break
+        default:
+      }
 
       if (namespace?.rpcMap && rpcUrl) {
         namespace.rpcMap[id] = rpcUrl


### PR DESCRIPTION
# Description

Add the workaround for deprecated solana chain ids in Universal Provider Adapter.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
