### PR TITLE
fix: remove browser wallet when injected provider is not detected

### DIFF
--- a/.changeset/twelve-kings-jog.md
+++ b/.changeset/twelve-kings-jog.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixes an issue where the connect modal on mobile was always showing 'Browser Wallet' option when the injected provider wasn't detected.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -939,6 +939,8 @@ export class WagmiAdapter implements ChainAdapter {
       // Auth connector is initialized separately
       const shouldSkip = ConstantsUtil.AUTH_CONNECTOR_ID === id
       if (!shouldSkip) {
+        const injectedConnector = id === ConstantsUtil.INJECTED_CONNECTOR_ID
+
         w3mConnectors.push({
           id,
           explorerId: PresetsUtil.ConnectorExplorerIds[id],
@@ -946,9 +948,7 @@ export class WagmiAdapter implements ChainAdapter {
           name: PresetsUtil.ConnectorNamesMap[id] ?? name,
           imageId: PresetsUtil.ConnectorImageIds[id],
           type: PresetsUtil.ConnectorTypesMap[type] ?? 'EXTERNAL',
-          info: {
-            rdns: id
-          },
+          info: injectedConnector ? undefined : { rdns: id },
           chain: this.chainNamespace
         })
       }

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -481,6 +481,20 @@ describe('Wagmi Client', () => {
         mockAuthConnector
       )
     })
+
+    it('should not set info property for injected connector', () => {
+      const mockConnectors = [
+        { id: 'injected', name: 'Injected Connector', type: 'injected', info: { rdns: 'injected' } }
+      ]
+
+      ;(mockWagmiClient as any).syncConnectors(mockConnectors)
+
+      const setConnectorsCalls = (mockAppKit.setConnectors as any).mock.calls
+      const syncedConnectors = setConnectorsCalls[0][0]
+      const injectedConnector = syncedConnectors.filter((c: any) => c.id === 'injected')[0]
+
+      expect(injectedConnector.info).toBeUndefined()
+    })
   })
   describe('Wagmi Client - Listen Auth Connector', () => {
     let mockProvider: any


### PR DESCRIPTION
# Description

Fixes an issue where the connect modal on mobile was always showing 'Browser Wallet' option when the injected provider wasn't detected. This happened because we included `info.rdns` field for the injected connector which caused the logic to not work [here](https://github.com/reown-com/appkit/blob/main/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts#L61-L64).

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1432

# Showcase (Optional)

This shouldn't appear if injected provider is not detected on mobile.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ab10dbc1-6f1e-4f40-89bf-0c161e9a7ac8">


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
