### PR TITLE
chore: add error, warning and accent primary text color options

### DIFF
--- a/apps/gallery-new/utils/PresetUtils.ts
+++ b/apps/gallery-new/utils/PresetUtils.ts
@@ -32,7 +32,15 @@ import type {
 } from '@reown/appkit-ui-new/src/utils/TypeUtil'
 import type { TransactionStatus, TransactionDirection } from '@reown/appkit-common'
 
-export const textColorOptions: TextColorType[] = ['primary', 'secondary', 'tertiary', 'invert']
+export const textColorOptions: TextColorType[] = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'invert',
+  'error',
+  'warning',
+  'accent-primary'
+]
 
 export const colorOptions = []
 

--- a/packages/ui-new/src/components/wui-text/index.ts
+++ b/packages/ui-new/src/components/wui-text/index.ts
@@ -43,10 +43,9 @@ export class WuiText extends LitElement {
       [`wui-line-clamp-${this.lineClamp}`]: this.lineClamp ? true : false
     }
 
-    // @TODO: Add variables if used by other components
     this.style.cssText = `
-      --local-color: ${this.align};
-      --local-align: ${
+      --local-align: ${this.align};
+      --local-color: ${
         this.color === 'inherit' ? 'inherit' : TEXT_VARS_BY_COLOR[this.color ?? 'primary']
       };
       `

--- a/packages/ui-new/src/components/wui-text/styles.ts
+++ b/packages/ui-new/src/components/wui-text/styles.ts
@@ -15,6 +15,8 @@ export default css`
       'case' on;
     overflow: inherit;
     text-overflow: inherit;
+    text-align: var(--local-align);
+    color: var(--local-color);
   }
 
   .wui-line-clamp-1 {

--- a/packages/ui-new/src/utils/TypeUtil.ts
+++ b/packages/ui-new/src/utils/TypeUtil.ts
@@ -8,6 +8,7 @@ export type TextColorType =
   | 'invert'
   | 'error'
   | 'warning'
+  | 'accent-primary'
 
 export type FontFamilyType = 'regular' | 'mono'
 


### PR DESCRIPTION
…ith wui-text component

# Description

- Added error, warning and accent-primary text color options
- Fixed a bug where inline css variables weren't working in `<wui-text>` component

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Showcase (Optional)

<img width="608" alt="image" src="https://github.com/user-attachments/assets/fc169f94-97c6-4965-b01d-a474d925462f">

<img width="583" alt="image" src="https://github.com/user-attachments/assets/284bc106-a852-4c63-a6de-bf2f71854054">

<img width="612" alt="image" src="https://github.com/user-attachments/assets/a6d27c9c-02cb-45f9-8fa9-1cef39d4bc16">

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
