### PR TITLE
fix: wagmi siwe reconnect on refresh

### DIFF
--- a/.changeset/rude-wasps-shake.md
+++ b/.changeset/rude-wasps-shake.md
@@ -1,0 +1,24 @@
+---
+'@apps/demo': patch
+'@apps/gallery': patch
+'@apps/laboratory': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fix wagmi not reconnecting with siwe on page refresh

--- a/apps/laboratory/tests/siwe.spec.ts
+++ b/apps/laboratory/tests/siwe.spec.ts
@@ -60,13 +60,15 @@ siweWalletTest('it should disconnect when cancel siwe from AppKit', async () => 
   await walletValidator.expectSessionCard({ visible: false })
 })
 
-// WARNING: refreshing on wagmi-siwe doesn't auto connect
-siweWalletTest.skip('it should be authenticated when refresh page', async () => {
+siweWalletTest('it should be authenticated when refresh page', async () => {
   await modalPage.qrCodeFlow(modalPage, walletPage)
   await modalValidator.expectConnected()
   await modalPage.page.reload()
   await modalValidator.expectConnected()
   await modalValidator.expectAuthenticated()
+  await modalPage.sign()
+  await walletPage.handleRequest({ accept: true })
+  await modalValidator.expectAcceptedSign()
 })
 
 siweWalletTest('it should be unauthenticated when disconnect', async () => {

--- a/apps/laboratory/tests/siwe.spec.ts
+++ b/apps/laboratory/tests/siwe.spec.ts
@@ -69,6 +69,10 @@ siweWalletTest('it should be authenticated when refresh page', async () => {
   await modalPage.sign()
   await walletPage.handleRequest({ accept: true })
   await modalValidator.expectAcceptedSign()
+  await modalPage.disconnect()
+  await modalValidator.expectDisconnected()
+  await modalValidator.expectUnauthenticated()
+  await walletValidator.expectSessionCard({ visible: false })
 })
 
 siweWalletTest('it should be unauthenticated when disconnect', async () => {

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -63,7 +63,6 @@ export function walletConnect(
   }
 
   let provider_: Provider | undefined
-  let providerPromise: Promise<typeof provider_>
 
   let accountsChanged: UniversalConnector['onAccountsChanged'] | undefined
   let chainChanged: UniversalConnector['onChainChanged'] | undefined
@@ -209,28 +208,8 @@ export function walletConnect(
       return accounts as `0x${string}`[]
     },
     async getProvider({ chainId } = {}) {
-      async function initProvider() {
-        const optionalChains = caipNetworks.map(x => Number(x.id))
-
-        if (!optionalChains.length) {
-          return undefined
-        }
-
-        const provider = await appKit.getUniversalProvider()
-
-        if (!provider) {
-          throw new Error('Provider not found')
-        }
-
-        return provider
-      }
-
       if (!provider_) {
-        if (!providerPromise) {
-          providerPromise = initProvider()
-        }
-        provider_ = await providerPromise
-        provider_?.events.setMaxListeners(Number.POSITIVE_INFINITY)
+        provider_ = await appKit.getUniversalProvider()
       }
 
       const currentChainId = appKit.getCaipNetwork()?.id
@@ -368,6 +347,7 @@ export function walletConnect(
     async onConnect(connectInfo) {
       const chainId = Number(connectInfo.chainId)
       const accounts = await this.getAccounts()
+      this.setRequestedChainsIds(caipNetworks.map(x => Number(x.id)))
       config.emitter.emit('connect', { accounts, chainId })
     },
     async onDisconnect(_error) {

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -210,9 +210,8 @@ export function walletConnect(
     async getProvider({ chainId } = {}) {
       if (!provider_) {
         provider_ = await appKit.getUniversalProvider()
+        provider_?.events.setMaxListeners(Number.POSITIVE_INFINITY)
       }
-
-      provider_?.events.setMaxListeners(Number.POSITIVE_INFINITY)
 
       const currentChainId = appKit.getCaipNetwork()?.id
 

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -212,6 +212,8 @@ export function walletConnect(
         provider_ = await appKit.getUniversalProvider()
       }
 
+      provider_?.events.setMaxListeners(Number.POSITIVE_INFINITY)
+
       const currentChainId = appKit.getCaipNetwork()?.id
 
       if (chainId && currentChainId !== chainId) {


### PR DESCRIPTION
# Description

Fix wagmi siwe not reconnecting on page refresh and re-enable test.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
