### PR TITLE
refactor: pass wagmi params to createConfig method

### DIFF
--- a/.changeset/old-llamas-crash.md
+++ b/.changeset/old-llamas-crash.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Passes Wagmi adapter params to createConfig method

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -75,6 +75,7 @@ export class WagmiAdapter extends AdapterBlueprint {
     })
     this.namespace = CommonConstantsUtil.CHAIN.EVM
     this.createConfig({
+      ...configParams,
       networks: CaipNetworksUtil.extendCaipNetworks(configParams.networks, {
         projectId: configParams.projectId,
         customNetworkImageUrls: {}

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -14,11 +14,13 @@ import {
   getEnsAddress as wagmiGetEnsAddress,
   writeContract as wagmiWriteContract,
   waitForTransactionReceipt,
-  getAccount
+  getAccount,
+  createConfig
 } from '@wagmi/core'
 import { mainnet } from '@wagmi/core/chains'
 import { CaipNetworksUtil } from '@reown/appkit-utils'
 import type UniversalProvider from '@walletconnect/universal-provider'
+import type { HttpTransport } from 'viem'
 
 vi.mock('@wagmi/core', async () => {
   const actual = await vi.importActual('@wagmi/core')
@@ -107,6 +109,41 @@ describe('WagmiAdapter', () => {
       const injectedConnector = mockConnectors.filter((c: any) => c.id === 'injected')[0]
 
       expect(injectedConnector?.info).toBeUndefined()
+    })
+
+    it('should pass WagmiAdapter constructor params to createConfig', () => {
+      new WagmiAdapter({
+        networks: mockNetworks,
+        projectId: mockProjectId,
+        ssr: true
+      })
+
+      expect(vi.mocked(createConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chains: expect.any(Array),
+          projectId: mockProjectId,
+          ssr: true
+        })
+      )
+    })
+
+    it('should merge provided transports with default network transports', () => {
+      const mockCustomTransport = {} as HttpTransport
+      const mockTransports = { 1: mockCustomTransport }
+
+      new WagmiAdapter({
+        networks: mockNetworks,
+        projectId: mockProjectId,
+        transports: mockTransports
+      })
+
+      expect(vi.mocked(createConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          transports: expect.objectContaining({
+            1: mockCustomTransport
+          })
+        })
+      )
     })
   })
 


### PR DESCRIPTION
# Description

Passes given WagmiAdapter constructor parameters to `createConfig` method. Adds related unit tests. @svenvoskamp's [changes](https://github.com/reown-com/appkit/pull/3310/files#r1855952236) in #3310

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
