### PR TITLE
fix: add check for missing address or chainId when getting siwe session

### DIFF
--- a/.changeset/curly-cameras-call.md
+++ b/.changeset/curly-cameras-call.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-siwe': patch
+'@apps/demo': patch
+'@apps/gallery': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-polkadot': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Adds check for missing address or chainId when getting siwe session for guarantee of backwards compatibility.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -127,14 +127,14 @@ export class WagmiAdapter extends AdapterBlueprint {
 
   private setupWatchers() {
     watchAccount(this.wagmiConfig, {
-      onChange: (accountData, prevData) => {
-        if (accountData.address && accountData.address !== prevData.address) {
+      onChange: accountData => {
+        if (accountData.address) {
           this.emit('accountChanged', {
             address: accountData.address,
             chainId: accountData.chainId
           })
         }
-        if (accountData.chainId && accountData.chainId !== prevData.chainId) {
+        if (accountData.chainId) {
           this.emit('switchNetwork', {
             address: accountData.address,
             chainId: accountData.chainId

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -127,14 +127,14 @@ export class WagmiAdapter extends AdapterBlueprint {
 
   private setupWatchers() {
     watchAccount(this.wagmiConfig, {
-      onChange: accountData => {
-        if (accountData.address) {
+      onChange: (accountData, prevData) => {
+        if (accountData.address && accountData.address !== prevData.address) {
           this.emit('accountChanged', {
             address: accountData.address,
             chainId: accountData.chainId
           })
         }
-        if (accountData.chainId) {
+        if (accountData.chainId && accountData.chainId !== prevData.chainId) {
           this.emit('switchNetwork', {
             address: accountData.address,
             chainId: accountData.chainId

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -345,11 +345,8 @@ export function walletConnect(
 
       config.emitter.emit('change', { chainId })
     },
-    async onConnect(connectInfo) {
-      const chainId = Number(connectInfo.chainId)
-      const accounts = await this.getAccounts()
+    onConnect(_connectInfo) {
       this.setRequestedChainsIds(caipNetworks.map(x => Number(x.id)))
-      config.emitter.emit('connect', { accounts, chainId })
     },
     async onDisconnect(_error) {
       this.setRequestedChainsIds([])

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -22,6 +22,7 @@ import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { ConstantsUtil } from '../utils/ConstantsUtil.js'
 import { ModalController } from './ModalController.js'
 import { EventsController } from './EventsController.js'
+import { SIWXUtil } from '../utils/SIWXUtil.js'
 
 // -- Constants ----------------------------------------- //
 const accountState: AccountControllerState = {
@@ -250,6 +251,8 @@ export const ChainController = {
         event: 'SWITCH_NETWORK',
         properties: { network: network.caipNetworkId }
       })
+
+      await SIWXUtil.initializeIfEnabled()
     }
   },
 

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -22,7 +22,6 @@ import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { ConstantsUtil } from '../utils/ConstantsUtil.js'
 import { ModalController } from './ModalController.js'
 import { EventsController } from './EventsController.js'
-import { SIWXUtil } from '../utils/SIWXUtil.js'
 
 // -- Constants ----------------------------------------- //
 const accountState: AccountControllerState = {
@@ -206,7 +205,12 @@ export const ChainController = {
     const newAdapter = state.chains.get(caipNetwork.chainNamespace)
     state.activeChain = caipNetwork.chainNamespace
     state.activeCaipNetwork = caipNetwork
-    state.activeCaipAddress = newAdapter?.accountState?.caipAddress
+
+    if (newAdapter?.accountState?.address) {
+      state.activeCaipAddress = `${caipNetwork.chainNamespace}:${caipNetwork.id}:${newAdapter?.accountState?.address}`
+    } else {
+      state.activeCaipAddress = undefined
+    }
 
     if (newAdapter) {
       AccountController.replaceState(newAdapter.accountState)
@@ -251,8 +255,6 @@ export const ChainController = {
         event: 'SWITCH_NETWORK',
         properties: { network: network.caipNetworkId }
       })
-
-      await SIWXUtil.initializeIfEnabled()
     }
   },
 

--- a/packages/core/src/utils/SIWXUtil.ts
+++ b/packages/core/src/utils/SIWXUtil.ts
@@ -191,7 +191,7 @@ export const SIWXUtil = {
 
     // Ignores chainId and account address to get other message data
     const siwxMessage = await siwx.createMessage({
-      chainId: '' as CaipNetworkId,
+      chainId: ChainController.getActiveCaipNetwork()?.caipNetworkId || ('' as CaipNetworkId),
       accountAddress: ''
     })
 
@@ -206,6 +206,7 @@ export const SIWXUtil = {
       version: siwxMessage.version,
       resources: siwxMessage.resources,
       statement: siwxMessage.statement,
+      chainId: siwxMessage.chainId,
 
       methods,
       chains

--- a/packages/core/src/utils/SIWXUtil.ts
+++ b/packages/core/src/utils/SIWXUtil.ts
@@ -1,4 +1,4 @@
-import type { CaipNetworkId } from '@reown/appkit-common'
+import type { CaipNetworkId, ChainNamespace } from '@reown/appkit-common'
 import { OptionsController } from '../controllers/OptionsController.js'
 import { CoreHelperUtil } from './CoreHelperUtil.js'
 import { ChainController } from '../controllers/ChainController.js'
@@ -23,10 +23,14 @@ export const SIWXUtil = {
     if (!(siwx && caipAddress)) {
       return
     }
-    const [network, chainId, address] = caipAddress.split(':') as [string, string, string]
+    const [namespace, chainId, address] = caipAddress.split(':') as [ChainNamespace, string, string]
+
+    if (!ChainController.checkIfSupportedNetwork(namespace)) {
+      return
+    }
 
     try {
-      const sessions = await siwx.getSessions(`${network}:${chainId}` as CaipNetworkId, address)
+      const sessions = await siwx.getSessions(`${namespace}:${chainId}`, address)
 
       if (sessions.length) {
         return

--- a/packages/siwe/src/mapToSIWX.ts
+++ b/packages/siwe/src/mapToSIWX.ts
@@ -15,6 +15,10 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
     try {
       const response = await siwe.methods.getSession()
 
+      if (!response) {
+        return undefined
+      }
+
       if (!response?.address) {
         throw new Error('SIWE session is missing address')
       }

--- a/packages/siwe/src/mapToSIWX.ts
+++ b/packages/siwe/src/mapToSIWX.ts
@@ -151,8 +151,11 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
           console.warn('AppKit:SIWE:setSessions - signOut error', error)
         }
       } else {
-        const addingSessions = sessions.map(session => this.addSession(session))
-        await Promise.all(addingSessions)
+        /*
+         * The default SIWE implementation would only support one session
+         * So we only add the first session to keep backwards compatibility
+         */
+        await this.addSession(sessions[0] as SIWXSession)
       }
     },
 

--- a/packages/siwe/src/mapToSIWX.ts
+++ b/packages/siwe/src/mapToSIWX.ts
@@ -159,7 +159,10 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
          * The default SIWE implementation would only support one session
          * So we only add the first session to keep backwards compatibility
          */
-        await this.addSession(sessions[0] as SIWXSession)
+        const session = (sessions.find(
+          s => s.data.chainId === ChainController.getActiveCaipNetwork()?.caipNetworkId
+        ) || sessions[0]) as SIWXSession
+        await this.addSession(session)
       }
     },
 

--- a/packages/siwe/src/mapToSIWX.ts
+++ b/packages/siwe/src/mapToSIWX.ts
@@ -13,7 +13,17 @@ const subscriptions: (() => void)[] = []
 export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
   async function getSession() {
     try {
-      return await siwe.methods.getSession()
+      const response = await siwe.methods.getSession()
+
+      if (!response?.address) {
+        throw new Error('SIWE session is missing address')
+      }
+
+      if (!response?.chainId) {
+        throw new Error('SIWE session is missing chainId')
+      }
+
+      return response
     } catch (error) {
       console.warn('AppKit:SIWE:getSession - error:', error)
 
@@ -55,7 +65,7 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
       if (siwe.options.signOutOnAccountChange) {
         const session = await getSession()
 
-        const lowercaseSessionAddress = session?.address.toLowerCase()
+        const lowercaseSessionAddress = session?.address?.toLowerCase()
         const lowercaseCaipAddress =
           CoreHelperUtil?.getPlainAddress(activeCaipAddress)?.toLowerCase()
 
@@ -164,7 +174,7 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
 
         const siweSession = await getSession()
         const siweCaipNetworkId = `eip155:${siweSession?.chainId}`
-        const lowercaseSessionAddress = siweSession?.address.toLowerCase()
+        const lowercaseSessionAddress = siweSession?.address?.toLowerCase()
         const lowercaseCaipAddress = address?.toLowerCase()
 
         if (

--- a/packages/siwe/tests/mapToSIWX.test.ts
+++ b/packages/siwe/tests/mapToSIWX.test.ts
@@ -203,6 +203,23 @@ describe('SIWE: mapToSIWX', () => {
       expect(addSessionSpy).not.toBeCalled()
       expect(signOutSpy).toBeCalled()
     })
+
+    it('should only use the first session', async () => {
+      const siwx = mapToSIWX(siweConfig)
+
+      const addSessionSpy = vi.spyOn(siwx, 'addSession')
+
+      const firstSessionMock = { ...sessionMock }
+      const secondSessionMock = {
+        ...sessionMock,
+        data: { ...sessionMock.data, chainId: 'eip155:2' as const }
+      }
+
+      await expect(siwx.setSessions([firstSessionMock, secondSessionMock])).resolves.not.toThrow()
+
+      expect(addSessionSpy).toBeCalledWith(firstSessionMock)
+      expect(addSessionSpy).not.toBeCalledWith(secondSessionMock)
+    })
   })
 
   describe('getSessions', () => {

--- a/packages/siwe/tests/mapToSIWX.test.ts
+++ b/packages/siwe/tests/mapToSIWX.test.ts
@@ -243,6 +243,24 @@ describe('SIWE: mapToSIWX', () => {
 
       await expect(siwx.getSessions('eip155:1', 'mock-address')).resolves.toMatchObject([])
     })
+
+    it('should accept undefined address or chain', async () => {
+      const siwx = mapToSIWX(siweConfig)
+
+      vi.spyOn(siweConfig.methods, 'getSession').mockResolvedValueOnce({
+        address: undefined as any,
+        chainId: 1
+      })
+
+      await expect(siwx.getSessions('eip155:1', 'mock-address')).resolves.toMatchObject([])
+
+      vi.spyOn(siweConfig.methods, 'getSession').mockResolvedValueOnce({
+        address: 'mock-address',
+        chainId: undefined as any
+      })
+
+      await expect(siwx.getSessions('eip155:1', 'mock-address')).resolves.toMatchObject([])
+    })
   })
 
   describe('siwe.options.signOutOnNetworkChange', () => {

--- a/packages/siwe/tests/mapToSIWX.test.ts
+++ b/packages/siwe/tests/mapToSIWX.test.ts
@@ -204,7 +204,7 @@ describe('SIWE: mapToSIWX', () => {
       expect(signOutSpy).toBeCalled()
     })
 
-    it('should only use the first session', async () => {
+    it('should only use the active network session', async () => {
       const siwx = mapToSIWX(siweConfig)
 
       const addSessionSpy = vi.spyOn(siwx, 'addSession')
@@ -215,10 +215,14 @@ describe('SIWE: mapToSIWX', () => {
         data: { ...sessionMock.data, chainId: 'eip155:2' as const }
       }
 
+      vi.spyOn(ChainController, 'getActiveCaipNetwork').mockReturnValue({
+        caipNetworkId: 'eip155:2'
+      } as any)
+
       await expect(siwx.setSessions([firstSessionMock, secondSessionMock])).resolves.not.toThrow()
 
-      expect(addSessionSpy).toBeCalledWith(firstSessionMock)
-      expect(addSessionSpy).not.toBeCalledWith(secondSessionMock)
+      expect(addSessionSpy).not.toBeCalledWith(firstSessionMock)
+      expect(addSessionSpy).toBeCalledWith(secondSessionMock)
     })
   })
 


### PR DESCRIPTION
# Description

Adds check for missing address or chainId when getting siwe session for guarantee of backwards compatibility.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
