### PR TITLE
chore: set the unused packages to private to prevent changeset to try publishing

### DIFF
--- a/packages/adapters/bitcoin/package.json
+++ b/packages/adapters/bitcoin/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@reown/appkit-adapter-bitcoin",
+  "private": true,
   "version": "1.5.1",
   "type": "module",
   "main": "./dist/esm/exports/index.js",

--- a/packages/adapters/polkadot/package.json
+++ b/packages/adapters/polkadot/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@reown/appkit-adapter-polkadot",
+  "private": true,
   "version": "1.5.2",
   "scripts": {
     "build:clean": "rm -rf dist",
@@ -17,6 +18,5 @@
   "devDependencies": {
     "vitest": "2.1.3",
     "@vitest/coverage-v8": "2.1.3"
-  },
-  "private": "true"
+  }
 }

--- a/packages/appkit-new/package.json
+++ b/packages/appkit-new/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@reown/appkit-new",
+  "private": true,
   "version": "1.5.1",
   "type": "module",
   "main": "./dist/esm/exports/index.js",

--- a/packages/scaffold-ui-new/package.json
+++ b/packages/scaffold-ui-new/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@reown/appkit-scaffold-ui-new",
+  "private": true,
   "version": "1.5.1",
   "type": "module",
   "main": "./dist/esm/exports/index.js",

--- a/packages/ui-new/package.json
+++ b/packages/ui-new/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@reown/appkit-ui-new",
+  "private": true,
   "version": "1.4.1",
   "type": "module",
   "main": "./dist/esm/index.js",


### PR DESCRIPTION
# Description

For the packages we don't want to publish to npm yet, we need to set the `private` value to `true`. We are having some NPM issues on the CI that's why the Changeset is failing for the packages it cannot publish, then it's not proceed to creating GitHub Releases. Example: https://github.com/reown-com/appkit/actions/runs/11954262429/job/33323967180

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
