### PR TITLE
Fix typos in documentation files

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 - [#3290](https://github.com/reown-com/appkit/pull/3290) [`ac1845e`](https://github.com/reown-com/appkit/commit/ac1845e022072e8e2d03449c28229d3576b2dd28) Thanks [@zoruka](https://github.com/zoruka)! - Fix for wrong checking on Solana devnet id
 
-- [#3285](https://github.com/reown-com/appkit/pull/3285) [`329cb92`](https://github.com/reown-com/appkit/commit/329cb92fb87866dff4cf925894ab2e3ac03e0f2c) Thanks [@maxmaxme](https://github.com/maxmaxme)! - Updates Vue type decleration module
+- [#3285](https://github.com/reown-com/appkit/pull/3285) [`329cb92`](https://github.com/reown-com/appkit/commit/329cb92fb87866dff4cf925894ab2e3ac03e0f2c) Thanks [@maxmaxme](https://github.com/maxmaxme)! - Updates Vue type declaration module
 
 - [#3289](https://github.com/reown-com/appkit/pull/3289) [`8236837`](https://github.com/reown-com/appkit/commit/82368374693d4620bf035df2d79b724441c93b0e) Thanks [@zoruka](https://github.com/zoruka)! - Fix wagmi not reconnecting with siwe on page refresh
 
@@ -73,7 +73,7 @@
 
 ### Minor Changes
 
-- [#3076](https://github.com/reown-com/appkit/pull/3076) [`1bd3dc7`](https://github.com/reown-com/appkit/commit/1bd3dc70850257dd8db523499e8a38e3a0f2ac4a) Thanks [@svenvoskamp](https://github.com/svenvoskamp)! - Implementing new architecture design for better handling and scalibity of the various adapters
+- [#3076](https://github.com/reown-com/appkit/pull/3076) [`1bd3dc7`](https://github.com/reown-com/appkit/commit/1bd3dc70850257dd8db523499e8a38e3a0f2ac4a) Thanks [@svenvoskamp](https://github.com/svenvoskamp)! - Implementing new architecture design for better handling and scalability of the various adapters
 
 ## 1.3.2
 

--- a/readme.md
+++ b/readme.md
@@ -60,4 +60,4 @@ pnpm changeset
 
 ### Running tests
 
-See <app/laboratory/tests/README.md>
+See  `app/laboratory/tests/README.md`


### PR DESCRIPTION

## Changes

### packages/ui/CHANGELOG.md

1. Fixed typo in Vue type module reference:
- Old: `decleration`
- New: `declaration`
Reason: Corrected spelling of technical term "declaration" which is the proper spelling in programming context.

2. Fixed typo in architecture description:
- Old: `scalibity` 
- New: `scalability`
Reason: Corrected spelling of technical term "scalability" which is the standard term used when discussing system architecture.

### app/laboratory/tests/README.md

3. Fixed path formatting:
- Old: `<app/laboratory/tests/README.md>`
- New: `app/laboratory/tests/README.md`
Reason: Removed unnecessary angle brackets for consistent path formatting across documentation.
