### PR TITLE
fix: debug mode not working with universal provider

### DIFF
--- a/.changeset/bright-ads-relate.md
+++ b/.changeset/bright-ads-relate.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@apps/builder': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Debug mode is now set to true by default. Additionally fixed an issue where alerts and console errors were not working in debug mode.

--- a/packages/adapters/solana/src/client.ts
+++ b/packages/adapters/solana/src/client.ts
@@ -85,7 +85,7 @@ export class SolanaAdapter extends AdapterBlueprint {
         projectId: options.projectId,
         chainId: withSolanaNamespace(appKit?.getCaipNetwork(this.namespace)?.id),
         onTimeout: () => {
-          AlertController.open(ErrorUtil.ALERT_ERRORS.INVALID_APP_CONFIGURATION, 'error')
+          AlertController.open(ErrorUtil.ALERT_ERRORS.SOCIALS_TIMEOUT, 'error')
         }
       })
 

--- a/packages/adapters/wagmi/src/connectors/AuthConnectorExport.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnectorExport.ts
@@ -19,7 +19,7 @@ export function authConnector(parameters: AuthParameters) {
     provider: W3mFrameProviderSingleton.getInstance({
       projectId: parameters.options.projectId,
       onTimeout: () => {
-        AlertController.open(ErrorUtil.ALERT_ERRORS.INVALID_APP_CONFIGURATION, 'error')
+        AlertController.open(ErrorUtil.ALERT_ERRORS.SOCIALS_TIMEOUT, 'error')
       }
     })
   })

--- a/packages/appkit/src/tests/appkit.test.ts
+++ b/packages/appkit/src/tests/appkit.test.ts
@@ -19,7 +19,8 @@ import {
   ChainController,
   type Connector,
   StorageUtil,
-  CoreHelperUtil
+  CoreHelperUtil,
+  AlertController
 } from '@reown/appkit-core'
 import {
   SafeLocalStorage,
@@ -31,6 +32,7 @@ import { mockOptions } from './mocks/Options'
 import { UniversalAdapter } from '../universal-adapter/client'
 import type { AdapterBlueprint } from '../adapters/ChainAdapterBlueprint'
 import { ProviderUtil } from '../store'
+import { ErrorUtil } from '@reown/appkit-utils'
 
 // Mock all controllers and UniversalAdapterClient
 vi.mock('@reown/appkit-core')
@@ -862,6 +864,29 @@ describe('Base', () => {
           caipNetworks: expect.any(Array)
         })
       )
+    })
+  })
+
+  describe('Alert Errors', () => {
+    it('should handle alert errors based on error messages', () => {
+      const errors = [
+        {
+          alert: ErrorUtil.ALERT_ERRORS.INVALID_APP_CONFIGURATION,
+          message:
+            'Error: WebSocket connection closed abnormally with code: 3000 (Unauthorized: origin not allowed)'
+        },
+        {
+          alert: ErrorUtil.ALERT_ERRORS.JWT_TOKEN_NOT_VALID,
+          message:
+            'WebSocket connection closed abnormally with code: 3000 (JWT validation error: JWT Token is not yet valid:)'
+        }
+      ]
+
+      for (const { alert, message } of errors) {
+        // @ts-expect-error
+        appKit.handleAlertError(new Error(message))
+        expect(AlertController.open).toHaveBeenCalledWith(alert, 'error')
+      }
     })
   })
 })

--- a/packages/core/src/controllers/OptionsController.ts
+++ b/packages/core/src/controllers/OptionsController.ts
@@ -110,7 +110,7 @@ export interface OptionsControllerStatePublic {
   enableWalletGuide?: boolean
   /**
    * Enable or disable debug mode in your AppKit. This is useful if you want to see UI alerts when debugging.
-   * @default false
+   * @default true
    */
   debug?: boolean
   /**


### PR DESCRIPTION
# Description

Fixed a regression where debug mode wasn't working properly when universal provider was throwing an error. I also set debug mode to true by default.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1694

# Showcase (Optional)

![Screenshot 2024-12-11 at 09 32 37](https://github.com/user-attachments/assets/0680fa5a-b8e8-4237-b961-71a037eb8444)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
