### PR TITLE
fix: correct return of chain when connecting to bitcoin

### DIFF
--- a/.changeset/tender-moles-notice.md
+++ b/.changeset/tender-moles-notice.md
@@ -1,0 +1,22 @@
+---
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fix the chainId response when connecting to bitcoin with multichain adapters

--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -63,11 +63,17 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
     this.connector = connector
     this.bindEvents(this.connector)
 
+    const chain = connector.chains.find(c => c.id === params.chainId) || connector.chains[0]
+
+    if (!chain) {
+      throw new Error('The connector does not support any of the requested chains')
+    }
+
     return {
       id: connector.id,
       type: connector.type,
       address,
-      chainId: this.networks[0]?.id || '',
+      chainId: chain.id,
       provider: connector.provider
     }
   }

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -52,7 +52,7 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
   }
 
   public get chains() {
-    return this.requestedChains
+    return this.requestedChains.filter(chain => chain.chainNamespace === 'bip122')
   }
 
   async request<T>(args: RequestArguments) {

--- a/packages/adapters/bitcoin/src/connectors/WalletStandardConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/WalletStandardConnector.ts
@@ -6,6 +6,7 @@ import type { BitcoinFeatures } from '../utils/wallet-standard/WalletFeatures.js
 import type { Provider, RequestArguments } from '@reown/appkit-core'
 import { ProviderEventEmitter } from '../utils/ProviderEventEmitter.js'
 import { MethodNotSupportedError } from '../errors/MethodNotSupportedError.js'
+import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
 
 export class WalletStandardConnector extends ProviderEventEmitter implements BitcoinConnector {
   public readonly chain = 'bip122'
@@ -39,7 +40,18 @@ export class WalletStandardConnector extends ProviderEventEmitter implements Bit
 
   public get chains() {
     return this.wallet.chains
-      .map(chainId => this.requestedChains.find(chain => chain.caipNetworkId === chainId))
+      .map(chainId =>
+        this.requestedChains.find(chain => {
+          switch (chainId) {
+            case 'bitcoin:mainnet':
+              return chain.caipNetworkId === bitcoin.caipNetworkId
+            case 'bitcoin:testnet':
+              return chain.caipNetworkId === bitcoinTestnet.caipNetworkId
+            default:
+              return chain.caipNetworkId === chainId
+          }
+        })
+      )
       .filter(Boolean) as CaipNetwork[]
   }
 

--- a/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
@@ -3,7 +3,7 @@ import { SatsConnectConnector } from '../../src/connectors/SatsConnectConnector'
 import { mockSatsConnectProvider } from '../mocks/mockSatsConnect'
 import type { CaipNetwork } from '@reown/appkit-common'
 import { MessageSigningProtocols } from 'sats-connect'
-import { bitcoin } from '@reown/appkit/networks'
+import { bitcoin, bitcoinTestnet, mainnet } from '@reown/appkit/networks'
 
 describe('SatsConnectConnector', () => {
   let connector: SatsConnectConnector
@@ -12,7 +12,12 @@ describe('SatsConnectConnector', () => {
   let getActiveNetwork: Mock<() => CaipNetwork | undefined>
 
   beforeEach(() => {
-    requestedChains = []
+    // requested chains may contain not bip122 chains
+    requestedChains = [
+      { ...mainnet, caipNetworkId: 'eip155:1', chainNamespace: 'eip155' },
+      bitcoin,
+      bitcoinTestnet
+    ]
     mocks = mockSatsConnectProvider()
     getActiveNetwork = vi.fn(() => bitcoin)
     connector = new SatsConnectConnector({
@@ -39,7 +44,7 @@ describe('SatsConnectConnector', () => {
     expect(connector.id).toBe(mocks.provider.name)
     expect(connector.name).toBe(mocks.provider.name)
     expect(connector.imageUrl).toBe(mocks.provider.icon)
-    expect(connector.chains).toEqual(requestedChains)
+    expect(connector.chains).toEqual([bitcoin, bitcoinTestnet])
   })
 
   it('should disconnect correctly', async () => {
@@ -309,7 +314,7 @@ describe('SatsConnectConnector', () => {
 
       await callback?.({ type: 'networkChange' })
 
-      expect(emitSpy).toHaveBeenCalledWith('chainChanged', requestedChains)
+      expect(emitSpy).toHaveBeenCalledWith('chainChanged', [bitcoin, bitcoinTestnet])
     })
   })
 })

--- a/packages/adapters/bitcoin/tests/connectors/WalletStandardConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/WalletStandardConnector.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CaipNetwork } from '@reown/appkit-common'
-import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
+import { bitcoin, bitcoinTestnet, mainnet } from '@reown/appkit/networks'
 import { WalletStandardConnector } from '../../src/connectors/WalletStandardConnector'
 import { mockWalletStandardProvider } from '../mocks/mockWalletStandard'
 import { MethodNotSupportedError } from '../../src/errors/MethodNotSupportedError'
@@ -20,7 +20,12 @@ describe('WalletStandardConnector', () => {
   let requestedChains: CaipNetwork[]
 
   beforeEach(() => {
-    requestedChains = [bitcoin, bitcoinTestnet]
+    // requested chains may contain not bip122 chains
+    requestedChains = [
+      { ...mainnet, caipNetworkId: 'eip155:1', chainNamespace: 'eip155' },
+      bitcoin,
+      bitcoinTestnet
+    ]
     wallet = mockWalletStandardProvider()
     connector = new WalletStandardConnector({
       wallet,
@@ -40,10 +45,6 @@ describe('WalletStandardConnector', () => {
     expect(connector.imageUrl).toBe(wallet.icon)
   })
 
-  it('should map correctly only chains that are requested and the wallet supports', async () => {
-    expect(connector.chains).toEqual([bitcoin])
-  })
-
   it('should throw if feature is not available', async () => {
     wallet = mockWalletStandardProvider({
       features: {}
@@ -53,6 +54,18 @@ describe('WalletStandardConnector', () => {
       requestedChains
     })
     await expect(connector.connect()).rejects.toThrow(MethodNotSupportedError)
+  })
+
+  describe('chains', () => {
+    it('should map correctly only chains that are requested and the wallet supports', async () => {
+      expect(connector.chains).toEqual([bitcoin])
+    })
+
+    it('should map network id aliases', async () => {
+      vi.spyOn(wallet, 'chains', 'get').mockReturnValueOnce(['bitcoin:mainnet', 'bitcoin:testnet'])
+
+      expect(connector.chains).toEqual([bitcoin, bitcoinTestnet])
+    })
   })
 
   describe('watchWallets', () => {


### PR DESCRIPTION
# Description

Fix the chainId response when connecting to bitcoin with multichain adapters.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
