### PR TITLE
refactor: disconnect logic and state update for multiple adapter use cases

### DIFF
--- a/.changeset/ninety-kangaroos-promise.md
+++ b/.changeset/ninety-kangaroos-promise.md
@@ -1,0 +1,22 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Refactors disconnect business logic for multiple adapter use cases

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -904,20 +904,12 @@ export class AppKit {
         const provider = ProviderUtil.getProvider<UniversalProvider | Provider | W3mFrameProvider>(
           ChainController.state.activeChain as ChainNamespace
         )
-
         const providerType =
           ProviderUtil.state.providerIds[ChainController.state.activeChain as ChainNamespace]
 
         await adapter?.disconnect({ provider, providerType })
 
         this.setStatus('disconnected', ChainController.state.activeChain as ChainNamespace)
-
-        StorageUtil.deleteConnectedConnector()
-        StorageUtil.deleteActiveCaipNetworkId()
-
-        ChainController.state.chains.forEach(chain => {
-          this.resetAccount(chain.namespace as ChainNamespace)
-        })
       },
       checkInstalled: (ids?: string[]) => {
         if (!ids) {

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -541,10 +541,7 @@ export const ChainController = {
       await Promise.allSettled(disconnectPromises)
 
       StorageUtil.deleteConnectedConnector()
-      StorageUtil.deleteWalletConnectDeepLink()
-
       ConnectionController.resetWcConnection()
-
       EventsController.sendEvent({
         type: 'track',
         event: 'DISCONNECT_SUCCESS'

--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -249,8 +249,6 @@ export const ConnectionController = {
 
   async disconnect() {
     try {
-      const connectionControllerClient = this._getClient()
-
       const siwx = OptionsController.state.siwx
       if (siwx) {
         const activeCaipNetwork = ChainController.getActiveCaipNetwork()
@@ -261,9 +259,7 @@ export const ConnectionController = {
         }
       }
 
-      await connectionControllerClient?.disconnect()
-
-      this.resetWcConnection()
+      await ChainController.disconnect()
     } catch (error) {
       throw new Error('Failed to disconnect')
     }

--- a/packages/core/src/utils/TypeUtil.ts
+++ b/packages/core/src/utils/TypeUtil.ts
@@ -460,6 +460,9 @@ export type Event =
   | {
       type: 'track'
       event: 'DISCONNECT_ERROR'
+      properties?: {
+        message: string
+      }
     }
   | {
       type: 'track'

--- a/packages/core/tests/controllers/ChainController.test.ts
+++ b/packages/core/tests/controllers/ChainController.test.ts
@@ -424,7 +424,7 @@ describe('ChainController', () => {
 
     await ChainController.disconnect()
 
-    expect(consoleSpy).toHaveBeenCalledWith('Failed to disconnect chains', expect.any(Error))
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('EVM disconnect failed'))
     expect(sendEventSpy).toHaveBeenCalledWith({
       type: 'track',
       event: 'DISCONNECT_ERROR',

--- a/packages/core/tests/controllers/ChainController.test.ts
+++ b/packages/core/tests/controllers/ChainController.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ConstantsUtil,
   SafeLocalStorageKeys,
@@ -11,6 +11,9 @@ import { type ConnectionControllerClient } from '../../src/controllers/Connectio
 import type { NetworkControllerClient } from '../../exports/index.js'
 import { RouterController } from '../../src/controllers/RouterController.js'
 import { SafeLocalStorage } from '@reown/appkit-common'
+import { StorageUtil } from '../../src/utils/StorageUtil.js'
+import { ConnectionController } from '../../src/controllers/ConnectionController.js'
+import { EventsController } from '../../src/controllers/EventsController.js'
 
 // -- Setup --------------------------------------------------------------------
 const chainNamespace = 'eip155' as ChainNamespace
@@ -127,7 +130,8 @@ const solanaAdapter = {
   caipNetworks: [solanaCaipNetwork] as unknown as CaipNetwork[]
 }
 
-beforeAll(() => {
+beforeEach(() => {
+  ChainController.state.noAdapters = false
   ChainController.initialize([evmAdapter], requestedCaipNetworks)
 })
 
@@ -154,7 +158,6 @@ describe('ChainController', () => {
   })
 
   it('should update state correctly on getApprovedCaipNetworkIds()', async () => {
-    const namespace = 'eip155'
     const networkController = { ...networkControllerClient }
     const networkControllerSpy = vi
       .spyOn(networkController, 'getApprovedCaipNetworksData')
@@ -163,7 +166,7 @@ describe('ChainController', () => {
         supportsAllNetworks: false
       })
     const evmAdapter = {
-      chainNamespace,
+      namespace: chainNamespace,
       connectionControllerClient,
       networkControllerClient: networkController,
       caipNetworks: [] as CaipNetwork[]
@@ -171,9 +174,11 @@ describe('ChainController', () => {
 
     // Need to re-initialize to set the spy properly
     ChainController.initialize([evmAdapter], requestedCaipNetworks)
-    await ChainController.setApprovedCaipNetworksData(namespace)
+    await ChainController.setApprovedCaipNetworksData(chainNamespace)
 
-    expect(ChainController.getApprovedCaipNetworkIds(namespace)).toEqual(approvedCaipNetworkIds)
+    expect(ChainController.getApprovedCaipNetworkIds(chainNamespace)).toEqual(
+      approvedCaipNetworkIds
+    )
     expect(networkControllerSpy).toHaveBeenCalled()
   })
 
@@ -345,5 +350,94 @@ describe('ChainController', () => {
   it('should set noAdapters flag when no adapter provided', () => {
     ChainController.initialize([], requestedCaipNetworks)
     expect(ChainController.state.noAdapters).toBe(true)
+  })
+
+  it('should properly handle disconnect', async () => {
+    const evmConnectionController = { ...connectionControllerClient }
+    const solanaConnectionController = { ...connectionControllerClient }
+    const disconnectSpy = vi.spyOn(evmConnectionController, 'disconnect')
+    const disconnectSpy2 = vi.spyOn(solanaConnectionController, 'disconnect')
+
+    const customEvmAdapter = {
+      ...evmAdapter,
+      connectionControllerClient: evmConnectionController
+    }
+    const customSolanaAdapter = {
+      ...solanaAdapter,
+      connectionControllerClient: solanaConnectionController
+    }
+
+    const resetAccountSpy = vi.spyOn(ChainController, 'resetAccount')
+    const resetNetworkSpy = vi.spyOn(ChainController, 'resetNetwork')
+    const deleteConnectorSpy = vi.spyOn(StorageUtil, 'deleteConnectedConnector')
+    const resetWcConnectionSpy = vi.spyOn(ConnectionController, 'resetWcConnection')
+    const sendEventSpy = vi.spyOn(EventsController, 'sendEvent')
+
+    ChainController.initialize([customEvmAdapter, customSolanaAdapter], requestedCaipNetworks)
+
+    await ChainController.disconnect()
+
+    expect(disconnectSpy).toHaveBeenCalled()
+    expect(disconnectSpy2).toHaveBeenCalled()
+
+    expect(resetAccountSpy).toHaveBeenCalledWith(ConstantsUtil.CHAIN.EVM)
+    expect(resetAccountSpy).toHaveBeenCalledWith(ConstantsUtil.CHAIN.SOLANA)
+    expect(resetNetworkSpy).toHaveBeenCalledWith(ConstantsUtil.CHAIN.EVM)
+    expect(resetNetworkSpy).toHaveBeenCalledWith(ConstantsUtil.CHAIN.SOLANA)
+
+    expect(deleteConnectorSpy).toHaveBeenCalled()
+    expect(resetWcConnectionSpy).toHaveBeenCalled()
+
+    expect(sendEventSpy).toHaveBeenCalledWith({
+      type: 'track',
+      event: 'DISCONNECT_SUCCESS'
+    })
+
+    resetAccountSpy.mockRestore()
+    resetNetworkSpy.mockRestore()
+    deleteConnectorSpy.mockRestore()
+    resetWcConnectionSpy.mockRestore()
+    sendEventSpy.mockRestore()
+  })
+
+  it('should handle disconnect errors gracefully', async () => {
+    const evmConnectionController = {
+      ...connectionControllerClient,
+      disconnect: vi.fn().mockRejectedValue(new Error('EVM disconnect failed'))
+    }
+    const solanaConnectionController = {
+      ...connectionControllerClient,
+      disconnect: vi.fn().mockRejectedValue(new Error('Solana disconnect failed'))
+    }
+    const customEvmAdapter = {
+      ...evmAdapter,
+      connectionControllerClient: evmConnectionController
+    }
+    const customSolanaAdapter = {
+      ...solanaAdapter,
+      connectionControllerClient: solanaConnectionController
+    }
+    const sendEventSpy = vi.spyOn(EventsController, 'sendEvent')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    ChainController.initialize([customEvmAdapter, customSolanaAdapter], requestedCaipNetworks)
+
+    await ChainController.disconnect()
+
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to disconnect chains', expect.any(Error))
+    expect(sendEventSpy).toHaveBeenCalledWith({
+      type: 'track',
+      event: 'DISCONNECT_ERROR',
+      properties: {
+        message: expect.stringContaining('EVM disconnect failed')
+      }
+    })
+    expect(sendEventSpy).not.toHaveBeenCalledWith({
+      type: 'track',
+      event: 'DISCONNECT_SUCCESS'
+    })
+
+    sendEventSpy.mockRestore()
+    consoleSpy.mockRestore()
   })
 })


### PR DESCRIPTION
# Description

- Refactors's disconnect functionality to make sure it's calling the connectionController's `disconnect` method
  - Moves all adapters iteration from adapter specific code (from `appkit/client` to `ChainController`)
- Makes sure it's removing account and network data for each adapter

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
