### PR TITLE
chore: expose a public function to get connect method order with appkit instance

### DIFF
--- a/.changeset/silver-rockets-brush.md
+++ b/.changeset/silver-rockets-brush.md
@@ -1,0 +1,22 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Expose a public function to get connect method order with AppKit instance

--- a/apps/builder/components/configuration-sections/section-connect-options.tsx
+++ b/apps/builder/components/configuration-sections/section-connect-options.tsx
@@ -27,8 +27,7 @@ const SortableConnectMethodList = dynamic(
 export function SectionConnectOptions() {
   const { config, updateFeatures, updateSocials, updateEnableWallets } = useAppKitContext()
   const collapseWallets = config.features.collapseWallets
-  const connectMethodsOrder =
-    config.features.connectMethodsOrder || ConstantsUtil.DEFAULT_FEATURES.connectMethodsOrder
+  const connectMethodsOrder = config.features.connectMethodsOrder
 
   function toggleCollapseWallets() {
     updateFeatures({ collapseWallets: !collapseWallets })

--- a/apps/builder/components/configuration-sections/section-wallet-features.tsx
+++ b/apps/builder/components/configuration-sections/section-wallet-features.tsx
@@ -9,7 +9,7 @@ const defaultWalletFeaturesOrder = ['onramp', 'swaps', 'receive', 'send']
 
 export function SectionWalletFeatures() {
   const { config, updateFeatures } = useAppKitContext()
-  const connectMethodsOrder = config.features.walletFeaturesOrder || defaultWalletFeaturesOrder
+  const walletFeaturesOrder = config.features.walletFeaturesOrder || defaultWalletFeaturesOrder
 
   function handleNewOrder(items: UniqueIdentifier[]) {
     const titleValueMap = {
@@ -33,15 +33,12 @@ export function SectionWalletFeatures() {
       case 'Swap':
         updateFeatures({ swaps: !config.features.swaps })
         return
-      case 'Receive':
-      case 'Send':
-        return
       default:
         return
     }
   }
 
-  const featureNameMap = connectMethodsOrder.map(name => {
+  const featureNameMap = walletFeaturesOrder.map(name => {
     switch (name) {
       case 'onramp':
         return 'Buy'

--- a/apps/builder/components/preview-content.tsx
+++ b/apps/builder/components/preview-content.tsx
@@ -4,9 +4,14 @@ import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { Link1Icon, ResetIcon } from '@radix-ui/react-icons'
 import { useAppKitContext } from '@/hooks/use-appkit'
+import { useAppKitState } from '@reown/appkit/react'
+import { useEffect } from 'react'
+import { useState } from 'react'
 
 export function PreviewContent() {
-  const { isInitialized, resetConfigs } = useAppKitContext()
+  const [shouldRender, setShouldRender] = useState(false)
+  const { initialized } = useAppKitState()
+  const { resetConfigs } = useAppKitContext()
 
   async function handleShare() {
     try {
@@ -17,10 +22,18 @@ export function PreviewContent() {
     }
   }
 
+  useEffect(() => {
+    setShouldRender(initialized)
+  }, [initialized])
+
+  if (!shouldRender) {
+    return null
+  }
+
   return (
     <>
-      <div className="w-full max-w-[400px] py-8 mx-auto flex-grow items-center justify-center flex-1 flex items-center justify-center">
-        {isInitialized ? (
+      <div className="w-full max-w-[400px] py-8 mx-auto flex-grow flex-1 flex items-center justify-center">
+        {shouldRender ? (
           <>
             {/* @ts-ignore */}
             <w3m-modal

--- a/apps/builder/components/sidebar-content.tsx
+++ b/apps/builder/components/sidebar-content.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react'
 import { buttonVariants } from '@/components/ui/button'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { useAppKitContext } from '@/hooks/use-appkit'
 import { cn } from '@/lib/utils'
 
 import Link from 'next/link'
@@ -14,8 +13,6 @@ import { SectionDesign } from '@/components/configuration-sections/section-desig
 import { BrandingHeader } from '@/components/branding-header'
 
 export function SidebarContent() {
-  const { config } = useAppKitContext()
-  const { isInitialized } = useAppKitContext()
   const [activeTab, setActiveTab] = React.useState('auth')
 
   return (

--- a/apps/builder/components/social-buttons.tsx
+++ b/apps/builder/components/social-buttons.tsx
@@ -1,6 +1,5 @@
 import { SortableSocialGrid } from '@/components/sortable-social-grid'
 import { useAppKitContext } from '@/hooks/use-appkit'
-import { urlStateUtils } from '@/lib/url-state'
 import { UniqueIdentifier } from '@dnd-kit/core'
 import { ConstantsUtil, SocialProvider } from '@reown/appkit-core'
 
@@ -10,9 +9,7 @@ export function SocialButtons() {
   const { updateFeatures } = useAppKitContext()
 
   function handleNewOrder(items: UniqueIdentifier[]) {
-    const currentFeatures =
-      urlStateUtils.getStateFromURL()?.features || ConstantsUtil.DEFAULT_FEATURES
-    updateFeatures({ ...currentFeatures, socials: items as SocialProvider[] })
+    updateFeatures({ socials: items as SocialProvider[] })
   }
 
   return (

--- a/apps/builder/components/sortable-list-connect-method.tsx
+++ b/apps/builder/components/sortable-list-connect-method.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import {
-  Active,
   closestCenter,
   CollisionDetection,
   DragOverlay,
@@ -43,7 +42,6 @@ import { ConnectMethodItem } from './connect-method-item'
 import { SortableConnectMethodItem } from '@/components/sortable-item-connect-method'
 import { Wrapper } from '@/components/ui/wrapper'
 import { List } from '@/components/ui/list'
-import { useAppKitContext } from '@/hooks/use-appkit'
 
 export interface Props {
   activationConstraint?: PointerActivationConstraint
@@ -55,7 +53,6 @@ export interface Props {
   dropAnimation?: DropAnimation | null
   getNewIndex?: NewIndexGetter
   handle?: boolean
-  itemCount?: number
   items?: UniqueIdentifier[]
   measuring?: MeasuringConfiguration
   modifiers?: Modifiers
@@ -98,7 +95,6 @@ export function SortableConnectMethodList({
   getItemStyles = () => ({}),
   getNewIndex,
   handle = false,
-  itemCount = 3,
   items: initialItems,
   measuring,
   modifiers,
@@ -109,9 +105,7 @@ export function SortableConnectMethodList({
   onToggleOption,
   handleNewOrder
 }: Props) {
-  const [items, setItems] = useState<UniqueIdentifier[]>(
-    () => initialItems ?? createRange<UniqueIdentifier>(itemCount, index => index)
-  )
+  const [items, setItems] = useState<UniqueIdentifier[]>(() => initialItems ?? [])
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
   const sensors = useSensors(
     useSensor(MouseSensor, {
@@ -136,12 +130,17 @@ export function SortableConnectMethodList({
   }, [activeId])
 
   const orderString = useMemo(() => items.join(','), [items])
+  const orderFromPropsString = useMemo(() => initialItems?.join(','), [initialItems])
 
   useEffect(() => {
-    if (handleNewOrder) {
+    if (handleNewOrder && orderString) {
       handleNewOrder(orderString.split(','))
     }
   }, [orderString])
+
+  useEffect(() => {
+    setItems(orderFromPropsString ? orderFromPropsString.split(',') : [])
+  }, [orderFromPropsString])
 
   return (
     <DndContext

--- a/apps/builder/components/sortable-list-wallet-features.tsx
+++ b/apps/builder/components/sortable-list-wallet-features.tsx
@@ -137,12 +137,19 @@ export function SortableWalletFeatureList({
   }, [activeId])
 
   const orderString = useMemo(() => items.join(','), [items])
+  const orderStringFromProps = useMemo(() => initialItems?.join(','), [initialItems])
 
   useEffect(() => {
     if (handleNewOrder) {
       handleNewOrder(orderString.split(','))
     }
   }, [orderString])
+
+  useEffect(() => {
+    if (orderStringFromProps) {
+      setItems(orderStringFromProps.split(','))
+    }
+  }, [orderStringFromProps])
 
   return (
     <DndContext

--- a/apps/builder/contexts/appkit-context.tsx
+++ b/apps/builder/contexts/appkit-context.tsx
@@ -10,7 +10,6 @@ interface AppKitContextType {
   enableWallets: boolean
   socialsEnabled: boolean
   isDraggingByKey: Record<string, boolean>
-  isInitialized: boolean
   updateThemeMode: (mode: ThemeMode) => void
   updateFeatures: (features: Partial<Features>) => void
   updateSocials: (enabled: boolean) => void

--- a/apps/builder/providers/appkit-context-provider.tsx
+++ b/apps/builder/providers/appkit-context-provider.tsx
@@ -54,10 +54,21 @@ export const ContextProvider: React.FC<AppKitProviderProps> = ({ children }) => 
 
   function updateFeatures(newFeatures: Partial<Features>) {
     setFeatures(prev => {
-      const newValue = { ...prev, ...newFeatures }
-      appKit?.updateFeatures(newValue)
-      urlStateUtils.updateURLWithState({ features: newValue })
-      return newValue
+      // Update the AppKit state first
+      const newAppKitValue = { ...prev, ...newFeatures }
+      appKit?.updateFeatures(newAppKitValue)
+
+      // Get the connection methods order since it's calculated based on injected connectors dynamically
+      const order =
+        newFeatures?.connectMethodsOrder === undefined
+          ? appKit?.getConnectMethodsOrder()
+          : newFeatures.connectMethodsOrder
+
+      // Define and set new internal value with the order
+      const newInternalValue = { ...newAppKitValue, connectMethodsOrder: order }
+      urlStateUtils.updateURLWithState({ features: newInternalValue })
+
+      return newInternalValue
     })
   }
 

--- a/apps/builder/providers/appkit-context-provider.tsx
+++ b/apps/builder/providers/appkit-context-provider.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode, useEffect, useState } from 'react'
-import { Features, ThemeMode, ThemeVariables, type AppKit } from '@reown/appkit/react'
+import { Features, ThemeMode, ThemeVariables, useAppKitState } from '@reown/appkit/react'
 import { ConnectMethod, ConstantsUtil } from '@reown/appkit-core'
 import { ThemeStore } from '../lib/theme-store'
 import { URLState, urlStateUtils } from '@/lib/url-state'
@@ -24,7 +24,8 @@ interface AppKitProviderProps {
 const initialConfig = urlStateUtils.getStateFromURL()
 
 export const ContextProvider: React.FC<AppKitProviderProps> = ({ children }) => {
-  const [isInitialized, setIsInitialized] = useState(false)
+  const { initialized } = useAppKitState()
+
   const [features, setFeatures] = useState<Features>(
     initialConfig?.features || ConstantsUtil.DEFAULT_FEATURES
   )
@@ -118,8 +119,15 @@ export const ContextProvider: React.FC<AppKitProviderProps> = ({ children }) => 
 
   useEffect(() => {
     setTheme(theme as ThemeMode)
-    setIsInitialized(true)
   }, [])
+
+  useEffect(() => {
+    if (initialized) {
+      const connectMethodsOrder = appKit?.getConnectMethodsOrder()
+      const order = connectMethodsOrder
+      updateFeatures({ connectMethodsOrder: order })
+    }
+  }, [initialized])
 
   const socialsEnabled = Array.isArray(features.socials)
 
@@ -143,7 +151,6 @@ export const ContextProvider: React.FC<AppKitProviderProps> = ({ children }) => 
         socialsEnabled,
         enableWallets,
         isDraggingByKey,
-        isInitialized,
         updateFeatures,
         updateThemeMode,
         updateSocials,

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -83,6 +83,7 @@ import type { SessionTypes } from '@walletconnect/types'
 import type { UniversalProviderOpts } from '@walletconnect/universal-provider'
 import { W3mFrameProviderSingleton } from './auth-provider/W3MFrameProviderSingleton.js'
 import { WcHelpersUtil } from './utils/HelpersUtil.js'
+import { WalletUtil } from '@reown/appkit-scaffold-ui/utils'
 
 declare global {
   interface Window {
@@ -234,6 +235,7 @@ export class AppKit {
         }
       }
     })
+    PublicStateController.set({ initialized: true })
   }
 
   // -- Public -------------------------------------------------------------------
@@ -640,6 +642,13 @@ export class AppKit {
 
   public async disconnect() {
     await this.connectionControllerClient?.disconnect()
+  }
+
+  public getConnectMethodsOrder() {
+    return WalletUtil.getConnectOrderMethod(
+      OptionsController.state.features,
+      ConnectorController.getConnectors()
+    )
   }
 
   // -- Private ------------------------------------------------------------------

--- a/packages/core/src/controllers/PublicStateController.ts
+++ b/packages/core/src/controllers/PublicStateController.ts
@@ -1,12 +1,33 @@
 import { proxy, subscribe as sub } from 'valtio/vanilla'
-import type { CaipNetworkId } from '@reown/appkit-common'
+import type { CaipNetworkId, ChainNamespace } from '@reown/appkit-common'
 
 // -- Types --------------------------------------------- //
 export interface PublicStateControllerState {
+  /**
+   * @description Indicates if the AppKit is loading.
+   * @type {boolean}
+   */
   loading: boolean
+  /**
+   * @description Indicates if the AppKit modal is open.
+   * @type {boolean}
+   */
   open: boolean
-  selectedNetworkId?: CaipNetworkId
-  activeChain?: string
+  /**
+   * @description Indicates the selected network id in CAIP-2 format.
+   * @type {CaipNetworkId | undefined}
+   */
+  selectedNetworkId?: CaipNetworkId | undefined
+  /**
+   * @description Indicates the active chain namespace.
+   * @type {ChainNamespace | undefined}
+   */
+  activeChain?: ChainNamespace | undefined
+  /**
+   * @description Indicates if the AppKit has been initialized. This sets to true when all controllers, adapters and internal state is ready.
+   * @type {boolean}
+   */
+  initialized: boolean
 }
 
 // -- State --------------------------------------------- //
@@ -14,7 +35,8 @@ const state = proxy<PublicStateControllerState>({
   loading: false,
   open: false,
   selectedNetworkId: undefined,
-  activeChain: undefined
+  activeChain: undefined,
+  initialized: false
 })
 
 // -- Controller ---------------------------------------- //

--- a/packages/core/tests/controllers/PublicStateController.test.ts
+++ b/packages/core/tests/controllers/PublicStateController.test.ts
@@ -7,7 +7,9 @@ describe('PublicStateController', () => {
     expect(PublicStateController.state).toEqual({
       loading: false,
       open: false,
-      selectedNetworkId: undefined
+      selectedNetworkId: undefined,
+      activeChain: undefined,
+      initialized: false
     })
   })
 
@@ -15,14 +17,18 @@ describe('PublicStateController', () => {
     PublicStateController.set({ open: true })
     expect(PublicStateController.state).toEqual({
       loading: false,
-      open: true,
-      selectedNetworkId: undefined
+      selectedNetworkId: undefined,
+      activeChain: undefined,
+      initialized: false,
+      open: true
     })
     PublicStateController.set({ selectedNetworkId: 'eip155:1' })
     expect(PublicStateController.state).toEqual({
       loading: false,
       open: true,
-      selectedNetworkId: 'eip155:1'
+      selectedNetworkId: 'eip155:1',
+      activeChain: undefined,
+      initialized: false
     })
   })
 })

--- a/packages/scaffold-ui/exports/utils.tsx
+++ b/packages/scaffold-ui/exports/utils.tsx
@@ -1,0 +1,3 @@
+export * from '../src/utils/ConnectorUtil.js'
+export * from '../src/utils/ConstantsUtil.js'
+export * from '../src/utils/WalletUtil.js'

--- a/packages/scaffold-ui/package.json
+++ b/packages/scaffold-ui/package.json
@@ -18,6 +18,11 @@
       "types": "./dist/types/exports/w3m-modal.d.ts",
       "import": "./dist/esm/exports/w3m-modal.js",
       "default": "./dist/esm/exports/w3m-modal.js"
+    },
+    "./utils": {
+      "types": "./dist/types/exports/utils.d.ts",
+      "import": "./dist/esm/exports/utils.js",
+      "default": "./dist/esm/exports/utils.js"
     }
   },
   "scripts": {

--- a/packages/scaffold-ui/src/utils/WalletUtil.ts
+++ b/packages/scaffold-ui/src/utils/WalletUtil.ts
@@ -4,7 +4,9 @@ import {
   OptionsController,
   StorageUtil
 } from '@reown/appkit-core'
-import type { WcWallet } from '@reown/appkit-core'
+import type { ConnectMethod, Connector, Features, WcWallet } from '@reown/appkit-core'
+import { ConnectorUtil } from './ConnectorUtil'
+import { ConstantsUtil } from './ConstantsUtil'
 
 interface AppKitWallet extends WcWallet {
   installed: boolean
@@ -79,5 +81,26 @@ export const WalletUtil = {
     )
 
     return sortedWallets
+  },
+
+  getConnectOrderMethod(_features: Features | undefined, _connectors: Connector[]) {
+    const connectMethodOrder =
+      _features?.connectMethodsOrder || OptionsController.state.features?.connectMethodsOrder
+    const connectors = _connectors || ConnectorController.state.connectors
+
+    if (connectMethodOrder) {
+      return connectMethodOrder
+    }
+
+    const { injected, announced } = ConnectorUtil.getConnectorsByType(connectors)
+
+    const shownInjected = injected.filter(ConnectorUtil.showConnector)
+    const shownAnnounced = announced.filter(ConnectorUtil.showConnector)
+
+    if (shownInjected.length || shownAnnounced.length) {
+      return ['wallet', 'email', 'social'] as ConnectMethod[]
+    }
+
+    return ConstantsUtil.DEFAULT_CONNECT_METHOD_ORDER
   }
 }

--- a/packages/scaffold-ui/src/utils/WalletUtil.ts
+++ b/packages/scaffold-ui/src/utils/WalletUtil.ts
@@ -5,8 +5,8 @@ import {
   StorageUtil
 } from '@reown/appkit-core'
 import type { ConnectMethod, Connector, Features, WcWallet } from '@reown/appkit-core'
-import { ConnectorUtil } from './ConnectorUtil'
-import { ConstantsUtil } from './ConstantsUtil'
+import { ConnectorUtil } from './ConnectorUtil.js'
+import { ConstantsUtil } from './ConstantsUtil.js'
 
 interface AppKitWallet extends WcWallet {
   installed: boolean

--- a/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
@@ -7,15 +7,13 @@ import {
   CoreHelperUtil,
   OptionsController,
   RouterController,
-  type ConnectMethod,
   type WalletGuideType
 } from '@reown/appkit-core'
 import { state } from 'lit/decorators/state.js'
 import { property } from 'lit/decorators.js'
 import { classMap } from 'lit/directives/class-map.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
-import { ConnectorUtil } from '../../utils/ConnectorUtil.js'
-import { ConstantsUtil } from '../../utils/ConstantsUtil.js'
+import { WalletUtil } from '../../utils/WalletUtil.js'
 
 @customElement('w3m-connect-view')
 export class W3mConnectView extends LitElement {
@@ -119,7 +117,7 @@ export class W3mConnectView extends LitElement {
 
   // -- Private ------------------------------------------- //
   private renderConnectMethod(tabIndex?: number) {
-    const connectMethodsOrder = this.getConnectOrderMethod()
+    const connectMethodsOrder = WalletUtil.getConnectOrderMethod(this.features, this.connectors)
 
     return html`${connectMethodsOrder.map((method, index) => {
       switch (method) {
@@ -151,7 +149,7 @@ export class W3mConnectView extends LitElement {
   }
 
   private checkIsThereNextMethod(currentIndex: number): string | undefined {
-    const connectMethodsOrder = this.getConnectOrderMethod()
+    const connectMethodsOrder = WalletUtil.getConnectOrderMethod(this.features, this.connectors)
 
     const nextMethod = connectMethodsOrder[currentIndex + 1] as
       | 'wallet'
@@ -343,25 +341,6 @@ export class W3mConnectView extends LitElement {
         connectEl.scrollHeight - connectEl.scrollTop - connectEl.offsetHeight
       ).toString()
     )
-  }
-
-  private getConnectOrderMethod() {
-    const connectMethodOrder = this.features?.connectMethodsOrder
-
-    if (connectMethodOrder) {
-      return connectMethodOrder
-    }
-
-    const { injected, announced } = ConnectorUtil.getConnectorsByType(this.connectors)
-
-    const shownInjected = injected.filter(ConnectorUtil.showConnector)
-    const shownAnnounced = announced.filter(ConnectorUtil.showConnector)
-
-    if (shownInjected.length || shownAnnounced.length) {
-      return ['wallet', 'email', 'social'] as ConnectMethod[]
-    }
-
-    return ConstantsUtil.DEFAULT_CONNECT_METHOD_ORDER
   }
 
   // -- Private Methods ----------------------------------- //


### PR DESCRIPTION
# Description

We recently introduced changes to our connect method orders logic. In the connect view, we are conditionally changing the default order if user has injected wallets or not. 

- If user has injected wallets, the default order goes as `wallets`, `email`, `socials`
- If not, the default order goes as  `email`, `socials`, `wallets`

This breaks the logics on the Builder/Demo since there is no static default value and it's now calculated dynamically. This causes an issue when we open the Demo, the order of the items getting changed after first render. This brings an issue that we need to create two data binding between Demo app and AppKit to control the connect methods.

## Changes

- Expose `getConnectMethodOrder` from AppKit class to call from outside
- Refactor `w3m-connect-view` to use `WalletsUtil` from `scaffold-ui`
- Refactor Demo app to respect the dynamic connect method order while initializing the state

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
