### PR TITLE
chore(cloud-auth-nonce): update CloudAuthSIWx to provide the nonce header

### DIFF
--- a/.changeset/metal-coins-guess.md
+++ b/.changeset/metal-coins-guess.md
@@ -1,0 +1,22 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-core': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fix logic for authentication header on CloudAuthSIWX"

--- a/.changeset/metal-coins-guess.md
+++ b/.changeset/metal-coins-guess.md
@@ -19,4 +19,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fix logic for authentication header on CloudAuthSIWX"
+Fix logic for authentication header on CloudAuthSIWX

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -10,6 +10,8 @@ export type SafeLocalStorageItems = {
   '@appkit/recent_wallets': string
   '@appkit/active_namespace': string
   '@appkit/connection_status': string
+  '@appkit/siwx-auth-token': string
+  '@appkit/siwx-nonce-token': string
   /*
    * DO NOT CHANGE: @walletconnect/universal-provider requires us to set this specific key
    *  This value is a stringified version of { href: stiring; name: string }
@@ -29,8 +31,10 @@ export const SafeLocalStorageKeys = {
   RECENT_WALLETS: '@appkit/recent_wallets',
   DEEPLINK_CHOICE: 'WALLETCONNECT_DEEPLINK_CHOICE',
   ACTIVE_NAMESPACE: '@appkit/active_namespace',
-  CONNECTION_STATUS: '@appkit/connection_status'
-} as const
+  CONNECTION_STATUS: '@appkit/connection_status',
+  SIWX_AUTH_TOKEN: '@appkit/siwx-auth-token',
+  SIWX_NONCE_TOKEN: '@appkit/siwx-nonce-token'
+} as const satisfies Record<string, keyof SafeLocalStorageItems>
 
 export const SafeLocalStorage = {
   setItem<Key extends keyof SafeLocalStorageItems>(

--- a/packages/siwx/src/configs/CloudAuthSIWX.ts
+++ b/packages/siwx/src/configs/CloudAuthSIWX.ts
@@ -1,4 +1,10 @@
-import { ConstantsUtil, type CaipNetworkId } from '@reown/appkit-common'
+import {
+  ConstantsUtil,
+  type CaipNetworkId,
+  SafeLocalStorage,
+  SafeLocalStorageKeys,
+  type SafeLocalStorageItems
+} from '@reown/appkit-common'
 import {
   AccountController,
   ApiController,
@@ -18,13 +24,17 @@ import { InformalMessenger } from '../index.js'
  * WARNING: The Claud Auth is only available in EVM networks.
  */
 export class CloudAuthSIWX implements SIWXConfig {
-  private readonly localAuthStorageKey: string
-  private readonly localNonceStorageKey: string
+  private readonly localAuthStorageKey: keyof SafeLocalStorageItems
+  private readonly localNonceStorageKey: keyof SafeLocalStorageItems
   private readonly messenger: SIWXMessenger
 
   constructor(params: CloudAuthSIWX.ConstructorParams = {}) {
-    this.localAuthStorageKey = params.localAuthStorageKey || '@appkit/siwx-auth-token'
-    this.localNonceStorageKey = params.localNonceStorageKey || '@appkit/siwx-nonce-token'
+    this.localAuthStorageKey =
+      (params.localAuthStorageKey as keyof SafeLocalStorageItems) ||
+      SafeLocalStorageKeys.SIWX_AUTH_TOKEN
+    this.localNonceStorageKey =
+      (params.localNonceStorageKey as keyof SafeLocalStorageItems) ||
+      SafeLocalStorageKeys.SIWX_NONCE_TOKEN
 
     this.messenger = new InformalMessenger({
       domain: typeof document === 'undefined' ? 'Unknown Domain' : document.location.host,
@@ -130,17 +140,17 @@ export class CloudAuthSIWX implements SIWXConfig {
     throw new Error(await response.text())
   }
 
-  private getStorageToken(key: string): string | undefined {
-    return localStorage.getItem(key) || undefined
+  private getStorageToken(key: keyof SafeLocalStorageItems): string | undefined {
+    return SafeLocalStorage.getItem(key)
   }
 
-  private setStorageToken(token: string, key: string): void {
-    localStorage.setItem(key, token)
+  private setStorageToken(token: string, key: keyof SafeLocalStorageItems): void {
+    SafeLocalStorage.setItem(key, token)
   }
 
   private clearStorageTokens(): void {
-    localStorage.removeItem(this.localAuthStorageKey)
-    localStorage.removeItem(this.localNonceStorageKey)
+    SafeLocalStorage.removeItem(this.localAuthStorageKey)
+    SafeLocalStorage.removeItem(this.localNonceStorageKey)
   }
 
   private async getNonce(): Promise<string> {

--- a/packages/siwx/src/configs/CloudAuthSIWX.ts
+++ b/packages/siwx/src/configs/CloudAuthSIWX.ts
@@ -24,7 +24,7 @@ export class CloudAuthSIWX implements SIWXConfig {
 
   constructor(params: CloudAuthSIWX.ConstructorParams = {}) {
     this.localAuthStorageKey = params.localAuthStorageKey || '@appkit/siwx-token'
-    this.localNonceStorageKey = '@appkit/siwx-nonce-token'
+    this.localNonceStorageKey = params.localNonceStorageKey || '@appkit/siwx-nonce-token'
 
     this.messenger = new InformalMessenger({
       domain: typeof document === 'undefined' ? 'Unknown Domain' : document.location.host,
@@ -187,6 +187,11 @@ export namespace CloudAuthSIWX {
      * @default '@appkit/siwx-token'
      */
     localAuthStorageKey?: string
+    /**
+     * The key to use for storing the nonce token in local storage.
+     * @default '@appkit/siwx-nonce-token'
+     */
+    localNonceStorageKey?: string
   }
 
   export type Request<Method extends 'GET' | 'POST' | 'PATCH', Params, Response> = {

--- a/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
+++ b/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
@@ -80,7 +80,7 @@ Issued At: 2024-12-05T16:02:32.905Z`)
         }
       )
 
-      expect(setItemSpy).toHaveBeenCalledWith('@appkit/siwx-token', 'mock_token')
+      expect(setItemSpy).toHaveBeenCalledWith('@appkit/siwx-nonce-token', 'mock_token')
     })
 
     it('should throw an text error if response is not json', async () => {
@@ -137,12 +137,12 @@ Issued At: 2024-12-05T16:02:32.905Z`)
         {
           body: '{"message":"Hello AppKit!","signature":"0x3c70e0a2d87f677dc0c3faf98fdf6313e99a3d9191bb79f7ecfce0c2cf46b7b33fd4c4bb83bca82fe872e35963382027d0d18018342d7dc36a675918cb73e9061c","clientId":null}',
           headers: {
-            Authorization: 'Bearer mock_nonce_token'
+            'x-nonce-jwt': 'Bearer mock_nonce_token'
           },
           method: 'POST'
         }
       )
-      expect(setItemSpy).toHaveBeenCalledWith('@appkit/siwx-token', 'mock_authenticate_token')
+      expect(setItemSpy).toHaveBeenCalledWith('@appkit/siwx-auth-token', 'mock_authenticate_token')
     })
 
     it('should use correct client id', async () => {
@@ -162,7 +162,7 @@ Issued At: 2024-12-05T16:02:32.905Z`)
         {
           body: '{"message":"Hello AppKit!","signature":"0x3c70e0a2d87f677dc0c3faf98fdf6313e99a3d9191bb79f7ecfce0c2cf46b7b33fd4c4bb83bca82fe872e35963382027d0d18018342d7dc36a675918cb73e9061c","clientId":"mock_client_id"}',
           headers: {
-            Authorization: 'Bearer mock_nonce_token'
+            'x-nonce-jwt': 'Bearer mock_nonce_token'
           },
           method: 'POST'
         }
@@ -188,7 +188,7 @@ Issued At: 2024-12-05T16:02:32.905Z`)
         {
           body: '{"message":"Hello AppKit!","signature":"0x3c70e0a2d87f677dc0c3faf98fdf6313e99a3d9191bb79f7ecfce0c2cf46b7b33fd4c4bb83bca82fe872e35963382027d0d18018342d7dc36a675918cb73e9061c","walletInfo":{"name":"mock_wallet_name","icon":"mock_wallet_icon"}}',
           headers: {
-            Authorization: 'Bearer mock_nonce_token'
+            'x-nonce-jwt': 'Bearer mock_nonce_token'
           },
           method: 'POST'
         }
@@ -280,7 +280,7 @@ Issued At: 2024-12-05T16:02:32.905Z`)
 
       await siwx.revokeSession('eip155:1', '0x1234567890abcdef1234567890abcdef12345678')
 
-      expect(removeItemSpy).toHaveBeenCalledWith('@appkit/siwx-token')
+      expect(removeItemSpy).toHaveBeenCalledWith('@appkit/siwx-auth-token')
     })
   })
 
@@ -290,7 +290,7 @@ Issued At: 2024-12-05T16:02:32.905Z`)
 
       await siwx.setSessions([])
 
-      expect(removeItemSpy).toHaveBeenCalledWith('@appkit/siwx-token')
+      expect(removeItemSpy).toHaveBeenCalledWith('@appkit/siwx-auth-token')
     })
 
     it('adds a session with default first item', async () => {


### PR DESCRIPTION
# Description

We've updated the Cloud Auth API to send a different header when making the authenticate request.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
