### PR TITLE
fix: active chain for siwx authenticate

### DIFF
--- a/.changeset/angry-snakes-judge.md
+++ b/.changeset/angry-snakes-judge.md
@@ -1,0 +1,22 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Set active chain as first chain when calling authenticate on universal provider

--- a/packages/appkit/src/tests/siwe.test.ts
+++ b/packages/appkit/src/tests/siwe.test.ts
@@ -171,14 +171,14 @@ describe('SIWE mapped to SIWX', () => {
         }
       } as const
 
-      vi.spyOn(mockProvider, 'authenticate').mockResolvedValueOnce({
+      const authenticateSpy = vi.spyOn(mockProvider, 'authenticate').mockResolvedValueOnce({
         session: {} as any,
         auths: [cacao]
       })
 
       await SIWXUtil.universalProviderAuthenticate({
         universalProvider: mockProvider,
-        chains: ['eip155:1'],
+        chains: ['eip155:10', 'eip155:137', 'eip155:1'],
         methods: ['eth_sign']
       })
 
@@ -191,6 +191,21 @@ describe('SIWE mapped to SIWX', () => {
         }),
         message: 'Formatted auth message',
         signature: 'mock-signature'
+      })
+      expect(authenticateSpy).toHaveBeenCalledWith({
+        chainId: 'eip155:1',
+        chains: ['eip155:1', 'eip155:10', 'eip155:137'], // must be active chain first
+        domain: 'mock-domain',
+        exp: undefined,
+        iat: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/),
+        methods: ['eth_sign'],
+        nbf: undefined,
+        nonce: 'mock-nonce',
+        requestId: undefined,
+        resources: undefined,
+        statement: undefined,
+        uri: 'mock-uri',
+        version: '1'
       })
     })
 

--- a/packages/core/src/utils/SIWXUtil.ts
+++ b/packages/core/src/utils/SIWXUtil.ts
@@ -213,9 +213,9 @@ export const SIWXUtil = {
       resources: siwxMessage.resources,
       statement: siwxMessage.statement,
       chainId: siwxMessage.chainId,
-
       methods,
-      chains
+      // The first chainId is what is used for universal provider to build the message
+      chains: [siwxMessage.chainId, ...chains.filter(chain => chain !== siwxMessage.chainId)]
     })
 
     SnackController.showLoading('Authenticating...', { autoClose: false })


### PR DESCRIPTION
# Description

Set active chain as first chain when calling authenticate on universal provider

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
