### PR TITLE
code-Update Dockerfile.canary

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -3,7 +3,8 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
-RUN apt update && apt install -y awscli
+RUN apt update && apt install -y awscli && rm -rf /var/lib/apt/lists/*
+
 
 WORKDIR /src
 


### PR DESCRIPTION
# Fix: Removed cache after installing packages in Dockerfile

## Changes
- Updated the `RUN apt install` command to remove cached files after package installation.

  - **Before**:
    ```dockerfile
    RUN apt update && apt install -y awscli
    ```

  - **After**:
    ```dockerfile
    RUN apt update && apt install -y awscli && rm -rf /var/lib/apt/lists/*
    ```

## Purpose
- Reduced Docker image size by removing cached files after package installation.
- Followed Docker best practices for maintaining a clean and optimized image.


