### PR TITLE
fix: incorrect EOA label/icon shown on reconnect with email/social login

### DIFF
--- a/.changeset/seven-shirts-act.md
+++ b/.changeset/seven-shirts-act.md
@@ -21,4 +21,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where an incorrect EOA account was displayed in the profile view after reconnecting via social or email login.
+Fixed an issue where an incorrect EOA label and icon were displayed in the profile view after reconnecting through social/email login

--- a/.changeset/seven-shirts-act.md
+++ b/.changeset/seven-shirts-act.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-core': patch
+'sveltekit-ethers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where an incorrect EOA account was displayed in the profile view after reconnecting via social or email login.

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -546,6 +546,7 @@ export const ChainController = {
         throw new Error(failures.map(f => f.reason.message).join(', '))
       }
 
+      StorageUtil.deleteConnectedSocialProvider()
       StorageUtil.deleteConnectedConnectorId()
       ConnectionController.resetWcConnection()
       EventsController.sendEvent({

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -171,6 +171,14 @@ export const StorageUtil = {
     return undefined
   },
 
+  deleteConnectedSocialProvider() {
+    try {
+      SafeLocalStorage.removeItem(SafeLocalStorageKeys.CONNECTED_SOCIAL)
+    } catch {
+      console.info('Unable to delete connected social provider')
+    }
+  },
+
   getConnectedSocialUsername() {
     try {
       return SafeLocalStorage.getItem(SafeLocalStorageKeys.CONNECTED_SOCIAL_USERNAME)

--- a/packages/core/tests/controllers/ChainController.test.ts
+++ b/packages/core/tests/controllers/ChainController.test.ts
@@ -370,6 +370,7 @@ describe('ChainController', () => {
     const resetAccountSpy = vi.spyOn(ChainController, 'resetAccount')
     const resetNetworkSpy = vi.spyOn(ChainController, 'resetNetwork')
     const deleteConnectorSpy = vi.spyOn(StorageUtil, 'deleteConnectedConnectorId')
+    const deleteConnectedSocialProviderSpy = vi.spyOn(StorageUtil, 'deleteConnectedSocialProvider')
     const resetWcConnectionSpy = vi.spyOn(ConnectionController, 'resetWcConnection')
     const sendEventSpy = vi.spyOn(EventsController, 'sendEvent')
 
@@ -386,6 +387,7 @@ describe('ChainController', () => {
     expect(resetNetworkSpy).toHaveBeenCalledWith(ConstantsUtil.CHAIN.SOLANA)
 
     expect(deleteConnectorSpy).toHaveBeenCalled()
+    expect(deleteConnectedSocialProviderSpy).toHaveBeenCalled()
     expect(resetWcConnectionSpy).toHaveBeenCalled()
 
     expect(sendEventSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
# Description

Fixed an issue where an incorrect EOA label and icon were displayed in the profile view after reconnecting through social/email login.

**Reproduction Steps:**
- Connect with github
- Disconnect
- Connect with same email associated with the GH account (email login)
- Go to settings

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1398

# Showcase (Optional)

![Screenshot 2024-12-24 at 15 23 04](https://github.com/user-attachments/assets/6c3be032-36fb-4a04-8241-cfeab4fbb430)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
