### PR TITLE
fix: Fixed typo in the comment Update inject-version.js

### DIFF
--- a/scripts/inject-version.js
+++ b/scripts/inject-version.js
@@ -1,6 +1,6 @@
 /**
  * This script injects the version from the packages/appkit/package.json into the packages/appkit/exports/constants.ts file.
- * This is a alternative solution to not import the package.json file in our packages due to restriction on bundlers.
+ * This is an alternative solution to not import the package.json file in our packages due to restriction on bundlers.
  * It's run before the build process of the packages starts with `prebuild` script.
  * See https://pnpm.io/it/next/cli/run#enable-pre-post-scripts
  */


### PR DESCRIPTION
# Description

I noticed a small typo in the comment where the phrase "This is a alternative solution" was used.
The correct form should be "This is an alternative solution," as the article "an" is needed before words starting with a vowel sound.  

This change corrects the grammar in the comment to make it more accurate.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
