### PR TITLE
 chore: add CONNECT case for when magic is already connected

### DIFF
--- a/.changeset/five-clouds-drop.md
+++ b/.changeset/five-clouds-drop.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Sets secure site version to 3.
+Handles case where Magic SDK connection fizzled, causing magic to connected while AppKit believed it was not connected

--- a/packages/scaffold-ui/src/partials/w3m-email-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-email-login-widget/index.ts
@@ -1,4 +1,9 @@
-import { ChainController, ConnectorController, CoreHelperUtil } from '@reown/appkit-core'
+import {
+  ChainController,
+  ConnectionController,
+  ConnectorController,
+  CoreHelperUtil
+} from '@reown/appkit-core'
 import { customElement } from '@reown/appkit-ui'
 import { LitElement, html } from 'lit'
 import { property, state } from 'lit/decorators.js'
@@ -6,7 +11,7 @@ import { ref, createRef } from 'lit/directives/ref.js'
 import type { Ref } from 'lit/directives/ref.js'
 import styles from './styles.js'
 import { SnackController, RouterController, EventsController } from '@reown/appkit-core'
-import { ConstantsUtil } from '@reown/appkit-common'
+import { ConstantsUtil, type ChainNamespace } from '@reown/appkit-common'
 import { ifDefined } from 'lit/directives/if-defined.js'
 
 @customElement('w3m-email-login-widget')
@@ -126,7 +131,14 @@ export class W3mEmailLoginWidget extends LitElement {
         RouterController.push('EmailVerifyOtp', { email: this.email })
       } else if (action === 'VERIFY_DEVICE') {
         RouterController.push('EmailVerifyDevice', { email: this.email })
+      } else if (action === 'CONNECT') {
+        await ConnectionController.connectExternal(
+          authConnector,
+          ChainController.state.activeChain as ChainNamespace
+        )
+        RouterController.replace('Account')
       }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       const parsedError = CoreHelperUtil.parseError(error)

--- a/packages/wallet/src/W3mFrameConstants.ts
+++ b/packages/wallet/src/W3mFrameConstants.ts
@@ -3,7 +3,7 @@ export const SECURE_SITE_SDK =
 
 export const DEFAULT_LOG_LEVEL = process.env['NEXT_PUBLIC_DEFAULT_LOG_LEVEL'] || 'error'
 
-export const SECURE_SITE_SDK_VERSION = process.env['NEXT_PUBLIC_SECURE_SITE_SDK_VERSION'] || 2
+export const SECURE_SITE_SDK_VERSION = process.env['NEXT_PUBLIC_SECURE_SITE_SDK_VERSION'] || 3
 
 export const W3mFrameConstants = {
   APP_EVENT_KEY: '@w3m-app/',

--- a/packages/wallet/src/W3mFrameSchema.ts
+++ b/packages/wallet/src/W3mFrameSchema.ts
@@ -69,7 +69,7 @@ export const AppSyncDappDataRequest = z.object({
 export const AppSetPreferredAccountRequest = z.object({ type: z.string() })
 
 export const FrameConnectEmailResponse = z.object({
-  action: z.enum(['VERIFY_DEVICE', 'VERIFY_OTP'])
+  action: z.enum(['VERIFY_DEVICE', 'VERIFY_OTP', 'CONNECT'])
 })
 
 export const FrameGetFarcasterUriResponse = z.object({


### PR DESCRIPTION
# Description

- Adds `CONNECT` type as a response from connect email for when magic instance is already connected.
- Handles cases and connects  directly.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
