### PR TITLE
fix: modal not closing after logging in with social

### DIFF
--- a/.changeset/rich-bulldogs-rush.md
+++ b/.changeset/rich-bulldogs-rush.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the modal didn't close after completing login if users navigated between different social login options.

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -220,9 +220,11 @@ export const AccountController = {
     socialWindow: AccountControllerState['socialWindow'],
     chain: ChainNamespace | undefined
   ) {
-    if (socialWindow) {
-      ChainController.setAccountProp('socialWindow', ref(socialWindow), chain)
-    }
+    ChainController.setAccountProp(
+      'socialWindow',
+      socialWindow ? ref(socialWindow) : undefined,
+      chain
+    )
   },
 
   setFarcasterUrl(

--- a/packages/scaffold-ui/src/views/w3m-connecting-social-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-social-view/index.ts
@@ -28,8 +28,6 @@ export class W3mConnectingSocialView extends LitElement {
   // -- State & Properties -------------------------------- //
   @state() private socialProvider = AccountController.state.socialProvider
 
-  @state() private interval?: ReturnType<typeof setInterval>
-
   @state() private socialWindow = AccountController.state.socialWindow
 
   @state() protected error = false
@@ -67,7 +65,6 @@ export class W3mConnectingSocialView extends LitElement {
   public override disconnectedCallback() {
     this.unsubscribe.forEach(unsubscribe => unsubscribe())
     window.removeEventListener('message', this.handleSocialConnection, false)
-    clearInterval(this.interval)
     this.socialWindow?.close()
     AccountController.setSocialWindow(undefined, ChainController.state.activeChain)
   }
@@ -178,7 +175,7 @@ export class W3mConnectingSocialView extends LitElement {
   }
 
   private connectSocial() {
-    this.interval = setInterval(() => {
+    const interval = setInterval(() => {
       if (this.socialWindow?.closed) {
         if (!this.connecting && RouterController.state.view === 'ConnectingSocial') {
           if (this.socialProvider) {
@@ -190,7 +187,7 @@ export class W3mConnectingSocialView extends LitElement {
           }
           RouterController.goBack()
         }
-        clearInterval(this.interval)
+        clearInterval(interval)
       }
     }, 1000)
     window.addEventListener('message', this.handleSocialConnection, false)

--- a/packages/scaffold-ui/src/views/w3m-connecting-social-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-social-view/index.ts
@@ -28,6 +28,8 @@ export class W3mConnectingSocialView extends LitElement {
   // -- State & Properties -------------------------------- //
   @state() private socialProvider = AccountController.state.socialProvider
 
+  @state() private interval?: ReturnType<typeof setInterval>
+
   @state() private socialWindow = AccountController.state.socialWindow
 
   @state() protected error = false
@@ -64,8 +66,10 @@ export class W3mConnectingSocialView extends LitElement {
 
   public override disconnectedCallback() {
     this.unsubscribe.forEach(unsubscribe => unsubscribe())
-
     window.removeEventListener('message', this.handleSocialConnection, false)
+    clearInterval(this.interval)
+    this.socialWindow?.close()
+    AccountController.setSocialWindow(undefined, ChainController.state.activeChain)
   }
 
   // -- Render -------------------------------------------- //
@@ -174,7 +178,7 @@ export class W3mConnectingSocialView extends LitElement {
   }
 
   private connectSocial() {
-    const interval = setInterval(() => {
+    this.interval = setInterval(() => {
       if (this.socialWindow?.closed) {
         if (!this.connecting && RouterController.state.view === 'ConnectingSocial') {
           if (this.socialProvider) {
@@ -186,7 +190,7 @@ export class W3mConnectingSocialView extends LitElement {
           }
           RouterController.goBack()
         }
-        clearInterval(interval)
+        clearInterval(this.interval)
       }
     }, 1000)
     window.addEventListener('message', this.handleSocialConnection, false)

--- a/packages/scaffold-ui/test/views/w3m-connecting-social-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-connecting-social-view.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fixture } from '@open-wc/testing'
+import { html } from 'lit'
+import { W3mConnectingSocialView } from '../../src/views/w3m-connecting-social-view'
+import {
+  ConnectionController,
+  ConnectorController,
+  type AuthConnector,
+  RouterController,
+  AccountController,
+  ChainController
+} from '@reown/appkit-core'
+
+describe('W3mConnectingSocialView - disconnectedCallback', () => {
+  it('should call socialWindow.close when component unmounts', async () => {
+    const mockSocialWindow = {
+      close: vi.fn(),
+      closed: false
+    } as unknown as Window
+
+    const mockAuthConnector = {
+      provider: {
+        connectSocial: vi.fn()
+      }
+    } as unknown as AuthConnector
+
+    vi.spyOn(ConnectionController, 'connectExternal').mockImplementation(() => Promise.resolve())
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(mockAuthConnector)
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...AccountController.state,
+      socialWindow: mockSocialWindow
+    })
+    vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
+      ...RouterController.state,
+      view: 'ConnectingSocial'
+    })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      ...ChainController.state,
+      activeChain: 'eip155'
+    })
+
+    const setSocialWindowSpy = vi.spyOn(AccountController, 'setSocialWindow')
+
+    const element: W3mConnectingSocialView = await fixture(
+      html`<w3m-connecting-social-view></w3m-connecting-social-view>`
+    )
+
+    element.disconnectedCallback()
+
+    expect(mockSocialWindow.close).toHaveBeenCalled()
+    expect(setSocialWindowSpy).toHaveBeenCalledWith(undefined, 'eip155')
+  })
+})


### PR DESCRIPTION
# Description

Fixed an issue where the modal didn't close after completing login if users navigated between different social login options.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1277

# Showcase (Optional)

https://github.com/user-attachments/assets/f6196ca4-262c-4667-b7c7-9d21b5291b79

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
