### PR TITLE
fix: prevent unnecessary retries for balance endpoint on unsupported networks

### DIFF
--- a/.changeset/great-feet-impress.md
+++ b/.changeset/great-feet-impress.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the balance endpoint kept retrying every 30 seconds, even after returning a 503 status code.

--- a/.changeset/great-feet-impress.md
+++ b/.changeset/great-feet-impress.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where the balance endpoint kept retrying every 30 seconds, even after returning a 503 status code.
+Fixed an issue where the balance endpoint was being called every 30 seconds for unsupported networks.

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -48,5 +48,8 @@ export const ConstantsUtil = {
     '0x55d398326f99059fF775485246999027B3197955',
     // Arbitrum
     '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'
-  ]
+  ],
+  HTTP_STATUS_CODES: {
+    SERVICE_UNAVAILABLE: 503
+  }
 } as const

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -232,12 +232,11 @@ export const AccountController = {
     ChainController.setAccountProp('farcasterUrl', farcasterUrl, chain)
   },
 
-  async fetchTokenBalance() {
+  async fetchTokenBalance(onError?: (error: unknown) => void) {
     const chainId = ChainController.state.activeCaipNetwork?.caipNetworkId
     const chain = ChainController.state.activeCaipNetwork?.chainNamespace
     const caipAddress = ChainController.state.activeCaipAddress
     const address = caipAddress ? CoreHelperUtil.getPlainAddress(caipAddress) : undefined
-
     if (
       state.lastRetry &&
       !CoreHelperUtil.isAllowedRetry(state.lastRetry, 30 * ConstantsUtil.ONE_SEC_MS)
@@ -260,6 +259,7 @@ export const AccountController = {
     } catch (error) {
       state.lastRetry = Date.now()
 
+      onError?.(error)
       SnackController.showError('Token Balance Unavailable')
     }
   },

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -222,7 +222,21 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
   }
 
   private watchSwapValues() {
-    this.watchTokenBalance = setInterval(() => AccountController.fetchTokenBalance(), 10000)
+    this.watchTokenBalance = setInterval(() => {
+      AccountController.fetchTokenBalance(error => {
+        this.onTokenBalanceError(error)
+      })
+    }, 10_000)
+  }
+
+  private onTokenBalanceError(error: unknown) {
+    if (error instanceof Error && error.cause instanceof Response) {
+      const statusCode = error.cause.status
+
+      if (statusCode === CommonConstantsUtil.HTTP_STATUS_CODES.SERVICE_UNAVAILABLE) {
+        clearInterval(this.watchTokenBalance)
+      }
+    }
   }
 
   private listContentTemplate() {

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -222,11 +222,10 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
   }
 
   private watchSwapValues() {
-    this.watchTokenBalance = setInterval(() => {
-      AccountController.fetchTokenBalance(error => {
-        this.onTokenBalanceError(error)
-      })
-    }, 10_000)
+    this.watchTokenBalance = setInterval(
+      () => AccountController.fetchTokenBalance(error => this.onTokenBalanceError(error)),
+      10_000
+    )
   }
 
   private onTokenBalanceError(error: unknown) {

--- a/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
@@ -110,7 +110,7 @@ describe('W3mAccountWalletFeaturesWidget', () => {
     expect(pushSpy).toHaveBeenCalledWith('Profile')
   })
 
-  it('should clearInterval when fetchTokenBalance fails with 503 Service Unavailable after 10 seconds', async () => {
+  it('should clearInterval when fetchTokenBalance fails after 10 seconds', async () => {
     vi.useFakeTimers()
     vi.spyOn(global, 'setInterval')
     vi.spyOn(global, 'clearInterval')

--- a/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
@@ -4,11 +4,14 @@ import { fixture, elementUpdated } from '@open-wc/testing'
 import { AccountController, CoreHelperUtil, RouterController } from '@reown/appkit-core'
 import { html } from 'lit'
 import { HelpersUtil } from '../utils/HelpersUtil'
+import { ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 
 // --- Constants ---------------------------------------------------- //
 const WALLET_FEATURE_WIDGET_TEST_ID = 'w3m-account-wallet-features-widget'
 const MOCK_ADDRESS = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
 const PROFILE_BUTTON = 'w3m-profile-button'
+
+const SERVICE_UNAVAILABLE_MESSAGE = 'Service Unavailable'
 
 const ACCOUNT = {
   namespace: 'eip155',
@@ -22,7 +25,7 @@ describe('W3mAccountWalletFeaturesWidget', () => {
   })
 
   afterEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
   })
 
   it('it should not return any components if address is not provided in AccountController', () => {
@@ -105,5 +108,37 @@ describe('W3mAccountWalletFeaturesWidget', () => {
     button.click()
 
     expect(pushSpy).toHaveBeenCalledWith('Profile')
+  })
+
+  it('should clearInterval when fetchTokenBalance fails with 503 Service Unavailable after 10 seconds', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(global, 'setInterval')
+    vi.spyOn(global, 'clearInterval')
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...AccountController.state,
+      address: ACCOUNT.address
+    })
+
+    const element: W3mAccountWalletFeaturesWidget = await fixture(
+      html`<w3m-account-wallet-features-widget></w3m-account-wallet-features-widget>`
+    )
+
+    expect(setInterval).toHaveBeenCalled()
+
+    const response = new Response(SERVICE_UNAVAILABLE_MESSAGE, {
+      status: CommonConstantsUtil.HTTP_STATUS_CODES.SERVICE_UNAVAILABLE
+    })
+
+    const error = new Error(SERVICE_UNAVAILABLE_MESSAGE, { cause: response })
+
+    vi.spyOn(AccountController, 'fetchTokenBalance').mockImplementation(async callback => {
+      callback?.(error)
+    })
+
+    vi.advanceTimersByTime(10_000)
+
+    expect(clearInterval).toHaveBeenCalledWith((element as any).watchTokenBalance)
+
+    vi.useRealTimers()
   })
 })


### PR DESCRIPTION
# Description

Fixed an issue where the balance endpoint kept retrying every 30 seconds, even after returning a 503 status code.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-987

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
