### PR TITLE
chore: update pr_checks to run e2e tests when code style and unit tests are succeeds

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   code_style:
+    id: code_style
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -59,6 +60,7 @@ jobs:
           NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
 
   test:
+    id: test
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -93,8 +95,9 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
 
   ui-test:
+    runs-on: ubuntu-latest
     needs: [code_style, test]
-    if: success() && github.event.pull_request.draft == false
+    if: ${{ always() && contains(join(needs.*.result, ','), 'success') && github.event.pull_request.draft == false }}
     uses: ./.github/workflows/ui_tests.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -60,7 +60,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -93,7 +93,8 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
 
   ui-test:
-    if: github.event.pull_request.draft == false
+    needs: [code_style, test]
+    if: success() && github.event.pull_request.draft == false
     uses: ./.github/workflows/ui_tests.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   code_style:
-    id: code_style
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -60,7 +59,6 @@ jobs:
           NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
 
   test:
-    id: test
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -93,7 +93,6 @@ jobs:
         uses: davelosert/vitest-coverage-report-action@v2
 
   ui-test:
-    runs-on: ubuntu-latest
     needs: [code_style, test]
     if: ${{ always() && contains(join(needs.*.result, ','), 'success') && github.event.pull_request.draft == false }}
     uses: ./.github/workflows/ui_tests.yml

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -94,7 +94,7 @@ jobs:
 
   ui-test:
     needs: [code_style, test]
-    if: ${{ always() && contains(join(needs.*.result, ','), 'success') && github.event.pull_request.draft == false }}
+    if: ${{ needs.code_style.result == 'success' && needs.test.result == 'success' && github.event.pull_request.draft == false }}
     uses: ./.github/workflows/ui_tests.yml
     secrets: inherit
     permissions:

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -1037,7 +1037,7 @@ describe('Base', () => {
 
       await (appKit as any).syncExistingConnection()
 
-      expect(ChainController.showUnsupportedChainUI).not.toHaveBeenCalled()
+      expect(ChainController.showUnsupportedChainUI).toHaveBeenCalled()
     })
 
     it('should subscribe to providers', () => {

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -1037,7 +1037,7 @@ describe('Base', () => {
 
       await (appKit as any).syncExistingConnection()
 
-      expect(ChainController.showUnsupportedChainUI).toHaveBeenCalled()
+      expect(ChainController.showUnsupportedChainUI).not.toHaveBeenCalled()
     })
 
     it('should subscribe to providers', () => {


### PR DESCRIPTION
# Description

Updates if condition for E2E tests workflows to work only when static tests are succeeds. This would allow us to not unnecessarily run E2E since they are expensive.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
