### PR TITLE
typo fix Update CHANGELOG.md

### DIFF
--- a/packages/cdn/CHANGELOG.md
+++ b/packages/cdn/CHANGELOG.md
@@ -200,7 +200,7 @@
 
 - [#3350](https://github.com/reown-com/appkit/pull/3350) [`0c55e65`](https://github.com/reown-com/appkit/commit/0c55e6576da71a7aa5922a02ff489184bf65c026) Thanks [@zoruka](https://github.com/zoruka)! - Add SIWX BIP122Verifier
 
-- [#3419](https://github.com/reown-com/appkit/pull/3419) [`192e4e0`](https://github.com/reown-com/appkit/commit/192e4e0b256021f97742520532907c2a7a6f30a5) Thanks [@enesozturk](https://github.com/enesozturk)! - Fixes state and storage syncronization and persisting on multiple adapter instances
+- [#3419](https://github.com/reown-com/appkit/pull/3419) [`192e4e0`](https://github.com/reown-com/appkit/commit/192e4e0b256021f97742520532907c2a7a6f30a5) Thanks [@enesozturk](https://github.com/enesozturk)! - Fixes state and storage synchronization and persisting on multiple adapter instances
 
 - [#3392](https://github.com/reown-com/appkit/pull/3392) [`1021422`](https://github.com/reown-com/appkit/commit/1021422c157b3a8a4d90edcd40f435adac21d119) Thanks [@tomiir](https://github.com/tomiir)! - Only syncs identity on address updates
 


### PR DESCRIPTION
### Title:
Fix Typo in `CHANGELOG.md`

### Description:
This pull request corrects the typo in the `CHANGELOG.md` file. The word "syncronization" has been fixed to "synchronization."
