### PR TITLE
fix: wagmi connection not working on page reload

### DIFF
--- a/.changeset/twelve-spiders-warn.md
+++ b/.changeset/twelve-spiders-warn.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where wagmi did not reconnect on page reload

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -217,8 +217,12 @@ export class WagmiAdapter extends AdapterBlueprint {
         if (accountData.status === 'disconnected') {
           this.emit('disconnect')
         }
+
         if (accountData.status === 'connected') {
-          if (accountData.address !== prevAccountData?.address) {
+          if (
+            accountData.address !== prevAccountData?.address ||
+            prevAccountData.status !== 'connected'
+          ) {
             this.setupWatchPendingTransactions()
 
             this.emit('accountChanged', {


### PR DESCRIPTION
# Description

Fixed an issue where wagmi did not reconnect on page reload

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
