### PR TITLE
fix: bitcoin connectors server side issues

### DIFF
--- a/.changeset/nice-planets-hang.md
+++ b/.changeset/nice-planets-hang.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Adds client check for the methods in bitcoin connectors for ssr issues

--- a/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
@@ -128,6 +128,10 @@ export class OKXConnector extends ProviderEventEmitter implements BitcoinConnect
   }
 
   public static getWallet(params: OKXConnector.GetWalletParams): OKXConnector | undefined {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const okxwallet = (window as any)?.okxwallet
     const wallet = okxwallet?.bitcoin

--- a/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
@@ -1,7 +1,7 @@
 import type { CaipNetwork } from '@reown/appkit-common'
 import type { BitcoinConnector } from '../utils/BitcoinConnector.js'
 import { ProviderEventEmitter } from '../utils/ProviderEventEmitter.js'
-import type { RequestArguments } from '@reown/appkit-core'
+import { CoreHelperUtil, type RequestArguments } from '@reown/appkit-core'
 import { MethodNotSupportedError } from '../errors/MethodNotSupportedError.js'
 import { bitcoin } from '@reown/appkit/networks'
 import { UnitsUtil } from '../utils/UnitsUtil.js'
@@ -128,7 +128,7 @@ export class OKXConnector extends ProviderEventEmitter implements BitcoinConnect
   }
 
   public static getWallet(params: OKXConnector.GetWalletParams): OKXConnector | undefined {
-    if (typeof window === 'undefined') {
+    if (!CoreHelperUtil.isClient()) {
       return undefined
     }
 

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -1,5 +1,6 @@
 import type { BitcoinConnector } from '../utils/BitcoinConnector.js'
 import type { CaipNetwork } from '@reown/appkit-common'
+import { CoreHelperUtil } from '@reown/appkit-core'
 import {
   AddressPurpose,
   getProviders,
@@ -102,7 +103,7 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
     requestedChains,
     getActiveNetwork
   }: SatsConnectConnector.GetWalletsParams) {
-    if (typeof window === 'undefined') {
+    if (!CoreHelperUtil.isClient()) {
       return []
     }
 

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -102,6 +102,10 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
     requestedChains,
     getActiveNetwork
   }: SatsConnectConnector.GetWalletsParams) {
+    if (typeof window === 'undefined') {
+      return []
+    }
+
     const providers = getProviders()
 
     return providers.map(

--- a/packages/adapters/bitcoin/tests/connectors/OKXConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/OKXConnector.test.ts
@@ -3,6 +3,7 @@ import { OKXConnector } from '../../src/connectors/OKXConnector'
 import type { CaipNetwork } from '@reown/appkit-common'
 import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
 import { MethodNotSupportedError } from '../../src/errors/MethodNotSupportedError'
+import { CoreHelperUtil } from '@reown/appkit-core'
 
 function mockOKXWallet(): { [K in keyof OKXConnector.Wallet]: Mock<OKXConnector.Wallet[K]> } {
   return {
@@ -195,6 +196,12 @@ describe('OKXConnector', () => {
       ;(window as any).okxwallet = { bitcoin: wallet, cardano: { icon: 'mock_image' } }
       const connector = OKXConnector.getWallet({ getActiveNetwork, requestedChains })
       expect(connector?.imageUrl).toBe('mock_image')
+    })
+
+    it('should return undefined if window is undefined (server-side)', () => {
+      vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValue(false)
+
+      expect(OKXConnector.getWallet({ getActiveNetwork, requestedChains })).toBeUndefined()
     })
   })
 

--- a/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
@@ -4,6 +4,7 @@ import { mockSatsConnectProvider } from '../mocks/mockSatsConnect'
 import type { CaipNetwork } from '@reown/appkit-common'
 import { MessageSigningProtocols } from 'sats-connect'
 import { bitcoin, bitcoinTestnet, mainnet } from '@reown/appkit/networks'
+import { CoreHelperUtil } from '@reown/appkit-core'
 
 describe('SatsConnectConnector', () => {
   let connector: SatsConnectConnector
@@ -38,6 +39,17 @@ describe('SatsConnectConnector', () => {
 
     expect(wallets instanceof Array).toBeTruthy()
     wallets.forEach(wallet => expect(wallet instanceof SatsConnectConnector).toBeTruthy())
+  })
+
+  it('should return an empty array when window is undefined (server-side)', () => {
+    vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValue(false)
+
+    const wallets = SatsConnectConnector.getWallets({
+      requestedChains: [],
+      getActiveNetwork: () => undefined
+    })
+
+    expect(wallets).toEqual([])
   })
 
   it('should get metadata correctly', async () => {


### PR DESCRIPTION
# Description

When using the Bitcoin adapter on server side framework, `getWallets` and `getProvider` methods throwing `window is not found` error on server side. `sats-connector` package prob doing some window call on background while it's not available on server

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
