### PR TITLE
chore: add authProvider field to useAppKitAccount and serialize correct provider in appkit.getProvider

### DIFF
--- a/.changeset/nervous-bugs-brake.md
+++ b/.changeset/nervous-bugs-brake.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where appKit.getProvider() would not return correct provider.

--- a/.changeset/unlucky-islands-juggle.md
+++ b/.changeset/unlucky-islands-juggle.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Adds authProvider to embeddedWalletInfo in useAppKitAccount

--- a/apps/laboratory/next-env.d.ts
+++ b/apps/laboratory/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -464,10 +464,6 @@ export class AppKit {
     AccountController.setCaipAddress(caipAddress, chain)
   }
 
-  public setProvider: (typeof AccountController)['setProvider'] = (provider, chain) => {
-    AccountController.setProvider(provider, chain)
-  }
-
   public setBalance: (typeof AccountController)['setBalance'] = (balance, balanceSymbol, chain) => {
     AccountController.setBalance(balance, balanceSymbol, chain)
   }

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -310,6 +310,7 @@ export class AppKit {
   }
 
   public subscribeAccount(callback: (newState: UseAppKitAccountReturn) => void) {
+    const authConnector = ConnectorController.getAuthConnector()
     function updateVal() {
       callback({
         allAccounts: AccountController.state.allAccounts,
@@ -317,11 +318,14 @@ export class AppKit {
         address: CoreHelperUtil.getPlainAddress(ChainController.state.activeCaipAddress),
         isConnected: Boolean(ChainController.state.activeCaipAddress),
         status: AccountController.state.status,
-        embeddedWalletInfo: {
-          user: AccountController.state.user,
-          accountType: AccountController.state.preferredAccountType,
-          isSmartAccountDeployed: Boolean(AccountController.state.smartAccountDeployed)
-        }
+        embeddedWalletInfo: authConnector
+          ? {
+              user: AccountController.state.user,
+              authProvider: AccountController.state.socialProvider || 'email',
+              accountType: AccountController.state.preferredAccountType,
+              isSmartAccountDeployed: Boolean(AccountController.state.smartAccountDeployed)
+            }
+          : undefined
       })
     }
 
@@ -449,7 +453,9 @@ export class AppKit {
     return ChainController.getAccountProp('address', chainNamespace)
   }
 
-  public getProvider = () => AccountController.state.provider
+  public getProvider = <T>(namespace: ChainNamespace) => ProviderUtil.getProvider<T>(namespace)
+
+  public getProviderType = (namespace: ChainNamespace) => ProviderUtil.state.providerIds[namespace]
 
   public getPreferredAccountType = () =>
     AccountController.state.preferredAccountType as W3mFrameTypes.AccountType

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -13,7 +13,6 @@ import {
   ConnectionController,
   EnsController,
   EventsController,
-  type CombinedProvider,
   AssetUtil,
   ConnectorController,
   ChainController,
@@ -321,9 +320,11 @@ describe('Base', () => {
     })
 
     it('should get provider', () => {
-      const mockProvider = { request: vi.fn() }
-      vi.mocked(AccountController).state = { provider: mockProvider } as any
-      expect(appKit.getProvider()).toBe(mockProvider)
+      const mockProvider = vi.fn()
+      vi.mocked(ProviderUtil.state).providers = { eip155: mockProvider } as any
+      vi.mocked(ProviderUtil.state).providerIds = { eip155: 'INJECTED' } as any
+
+      expect(appKit.getProvider<any>('eip155')).toBe(mockProvider)
     })
 
     it('should get preferred account type', () => {
@@ -344,14 +345,6 @@ describe('Base', () => {
       appKit.setCaipAddress('eip155:1:0x123', 'eip155')
       expect(AccountController.setCaipAddress).toHaveBeenCalledWith('eip155:1:0x123', 'eip155')
       expect(appKit.getIsConnectedState()).toBe(true)
-    })
-
-    it('should set provider', () => {
-      const mockProvider = {
-        request: vi.fn()
-      }
-      appKit.setProvider(mockProvider as unknown as CombinedProvider, 'eip155')
-      expect(AccountController.setProvider).toHaveBeenCalledWith(mockProvider, 'eip155')
     })
 
     it('should set balance', () => {

--- a/packages/core/exports/react.ts
+++ b/packages/core/exports/react.ts
@@ -25,9 +25,8 @@ export function useAppKitNetworkCore(): Pick<
 }
 
 export function useAppKitAccount(): UseAppKitAccountReturn {
-  const { status, user, preferredAccountType, smartAccountDeployed, allAccounts } = useSnapshot(
-    AccountController.state
-  )
+  const { status, user, preferredAccountType, smartAccountDeployed, allAccounts, socialProvider } =
+    useSnapshot(AccountController.state)
 
   const { activeCaipAddress } = useSnapshot(ChainController.state)
 
@@ -42,6 +41,7 @@ export function useAppKitAccount(): UseAppKitAccountReturn {
     embeddedWalletInfo: authConnector
       ? {
           user,
+          authProvider: socialProvider || 'email',
           accountType: preferredAccountType,
           isSmartAccountDeployed: Boolean(smartAccountDeployed)
         }

--- a/packages/core/exports/vue.ts
+++ b/packages/core/exports/vue.ts
@@ -1,32 +1,39 @@
-import { ref, onUnmounted } from 'vue'
+import { ref, onUnmounted, type Ref } from 'vue'
 import { AccountController } from '../src/controllers/AccountController.js'
 import { CoreHelperUtil } from '../src/utils/CoreHelperUtil.js'
 import { ChainController } from '../src/controllers/ChainController.js'
 import { ConnectionController } from '../src/controllers/ConnectionController.js'
+import { ConnectorController } from '../src/controllers/ConnectorController.js'
+import type { SocialProvider, UseAppKitAccountReturn } from '../src/utils/TypeUtil.js'
 
 // -- Hooks ------------------------------------------------------------
-export function useAppKitAccount() {
+export function useAppKitAccount(): Ref<UseAppKitAccountReturn> {
+  const authConnector = ConnectorController.getAuthConnector()
   const state = ref({
     allAccounts: AccountController.state.allAccounts,
-    address: CoreHelperUtil.getPlainAddress(ChainController.state.activeCaipAddress) ?? null,
-    caipAddress: ChainController.state.activeCaipAddress ?? null,
-    status: AccountController.state.status ?? null,
+    address: CoreHelperUtil.getPlainAddress(ChainController.state.activeCaipAddress),
+    caipAddress: ChainController.state.activeCaipAddress,
+    status: AccountController.state.status,
     isConnected: Boolean(ChainController.state.activeCaipAddress),
-    embeddedWalletInfo: {
-      user: AccountController.state.user ?? null,
-      accountType: AccountController.state.preferredAccountType ?? null,
-      isSmartAccountDeployed: Boolean(AccountController.state.smartAccountDeployed)
-    }
+    embeddedWalletInfo: authConnector
+      ? {
+          user: AccountController.state.user,
+          authProvider:
+            AccountController.state.socialProvider ?? ('email' as SocialProvider | 'email'),
+          accountType: AccountController.state.preferredAccountType,
+          isSmartAccountDeployed: Boolean(AccountController.state.smartAccountDeployed)
+        }
+      : undefined
   })
 
   const unsubscribeCaipAddress = ChainController.subscribeKey('activeCaipAddress', val => {
-    state.value.caipAddress = val ?? null
-    state.value.address = CoreHelperUtil.getPlainAddress(val) ?? null
+    state.value.caipAddress = val
+    state.value.address = CoreHelperUtil.getPlainAddress(val)
     state.value.isConnected = Boolean(val)
   })
 
   const unsubscribeStatus = AccountController.subscribeKey('status', val => {
-    state.value.status = val ?? null
+    state.value.status = val
   })
 
   const unsubscribeAllAccounts = AccountController.subscribeKey('allAccounts', val => {
@@ -34,15 +41,21 @@ export function useAppKitAccount() {
   })
 
   const unsubscribeAccountDeployed = AccountController.subscribeKey('smartAccountDeployed', val => {
-    state.value.embeddedWalletInfo.isSmartAccountDeployed = Boolean(val)
+    if (state.value.embeddedWalletInfo) {
+      state.value.embeddedWalletInfo.isSmartAccountDeployed = Boolean(val)
+    }
   })
 
   const unsubscribeAccountType = AccountController.subscribeKey('preferredAccountType', val => {
-    state.value.embeddedWalletInfo.accountType = val ?? null
+    if (state.value.embeddedWalletInfo) {
+      state.value.embeddedWalletInfo.accountType = val
+    }
   })
 
   const unsubscribeUser = AccountController.subscribeKey('user', val => {
-    state.value.embeddedWalletInfo.user = val ?? null
+    if (state.value.embeddedWalletInfo) {
+      state.value.embeddedWalletInfo.user = val
+    }
   })
 
   onUnmounted(() => {

--- a/packages/core/src/controllers/AccountController.ts
+++ b/packages/core/src/controllers/AccountController.ts
@@ -2,10 +2,8 @@ import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import type {
   AccountType,
   AccountTypeMap,
-  CombinedProvider,
   ConnectedWalletInfo,
   User,
-  Provider,
   SocialProvider
 } from '../utils/TypeUtil.js'
 import type { CaipAddress, ChainNamespace } from '@reown/appkit-common'
@@ -17,7 +15,6 @@ import { SwapApiUtil } from '../utils/SwapApiUtil.js'
 import type { W3mFrameTypes } from '@reown/appkit-wallet'
 import { ChainController } from './ChainController.js'
 import { proxy, ref } from 'valtio/vanilla'
-import type UniversalProvider from '@walletconnect/universal-provider'
 import { ConstantsUtil } from '../utils/ConstantsUtil.js'
 
 // -- Types --------------------------------------------- //
@@ -41,7 +38,6 @@ export interface AccountControllerState {
   preferredAccountType?: W3mFrameTypes.AccountType
   socialWindow?: Window
   farcasterUrl?: string
-  provider?: UniversalProvider | Provider | CombinedProvider
   status?: 'reconnecting' | 'connected' | 'disconnected' | 'connecting'
   lastRetry?: number
 }
@@ -107,12 +103,6 @@ export const AccountController = {
 
   getCaipAddress(chain: ChainNamespace | undefined) {
     return ChainController.getAccountProp('caipAddress', chain)
-  },
-
-  setProvider(provider: AccountControllerState['provider'], chain: ChainNamespace | undefined) {
-    if (provider) {
-      ChainController.setAccountProp('provider', provider, chain)
-    }
   },
 
   setCaipAddress(

--- a/packages/core/src/utils/TypeUtil.ts
+++ b/packages/core/src/utils/TypeUtil.ts
@@ -1103,6 +1103,7 @@ export type UseAppKitAccountReturn = {
   isConnected: boolean
   embeddedWalletInfo?: {
     user: AccountControllerState['user']
+    authProvider: AccountControllerState['socialProvider'] | 'email'
     accountType: W3mFrameTypes.AccountType | undefined
     isSmartAccountDeployed: boolean
   }

--- a/packages/core/tests/hooks/react.test.ts
+++ b/packages/core/tests/hooks/react.test.ts
@@ -114,6 +114,50 @@ describe('useAppKitAccount', () => {
           email: 'email@email.test',
           userName: 'test'
         },
+        authProvider: 'email',
+        isSmartAccountDeployed: false,
+        accountType: 'eoa'
+      }
+    })
+
+    expect(useSnapshot).toHaveBeenCalledWith(AccountController.state)
+    expect(useSnapshot).toHaveBeenCalledWith(ChainController.state)
+  })
+
+  it('should return appropiate auth provider when social provider is set', () => {
+    const mockCaipAddress = 'eip155:1:0x123...'
+    const mockPlainAddress = '0x123...'
+
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({} as any)
+
+    // Mock the useSnapshot hook for both calls
+    useSnapshot
+      .mockReturnValueOnce({
+        allAccounts: undefined,
+        status: 'connected',
+        socialProvider: 'google',
+        preferredAccountType: 'eoa',
+        smartAccountDeployed: false,
+        user: {
+          email: 'email@email.test',
+          userName: 'test'
+        }
+      }) // For AccountController
+      .mockReturnValueOnce({ activeCaipAddress: mockCaipAddress }) // For ChainController
+
+    const result = useAppKitAccount()
+
+    expect(result).toEqual({
+      address: mockPlainAddress,
+      caipAddress: mockCaipAddress,
+      isConnected: true,
+      status: 'connected',
+      embeddedWalletInfo: {
+        user: {
+          email: 'email@email.test',
+          userName: 'test'
+        },
+        authProvider: 'google',
         isSmartAccountDeployed: false,
         accountType: 'eoa'
       }


### PR DESCRIPTION
# Description

- Adds `authProvider` field to embeddedWalletInfo
- Serializes provider in appkit.getProvider

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
