### PR TITLE
feat: add optional new tab behavior for legal links

### DIFF
--- a/packages/core/src/controllers/OptionsController.ts
+++ b/packages/core/src/controllers/OptionsController.ts
@@ -140,6 +140,11 @@ export interface OptionsControllerStatePublic {
    * @default false
    */
   allowUnsupportedChain?: boolean
+  /**
+   * Open legal links (Terms and Privacy) in new tab
+   * @default false
+   */
+  legalLinksNewTab?: boolean
 }
 
 export interface OptionsControllerStateInternal {
@@ -317,6 +322,10 @@ export const OptionsController = {
     useInjectedUniversalProvider: OptionsControllerState['useInjectedUniversalProvider']
   ) {
     state.useInjectedUniversalProvider = useInjectedUniversalProvider
+  },
+
+  setLegalLinksNewTab(legalLinksNewTab: OptionsControllerState['legalLinksNewTab']) {
+    state.legalLinksNewTab = legalLinksNewTab
   },
 
   getSnapshot() {

--- a/packages/scaffold-ui/src/partials/w3m-legal-footer/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-legal-footer/index.ts
@@ -44,7 +44,12 @@ export class W3mLegalFooter extends LitElement {
       return null
     }
 
-    return html`<a href=${termsConditionsUrl}>Terms of Service</a>`
+    const { target, rel } = this.getLinkAttributes()
+    return html`<a 
+      href=${termsConditionsUrl}
+      ?target=${target} 
+      ?rel=${rel}
+    >Terms of Service</a>`
   }
 
   private privacyTemplate() {
@@ -53,7 +58,12 @@ export class W3mLegalFooter extends LitElement {
       return null
     }
 
-    return html`<a href=${privacyPolicyUrl}>Privacy Policy</a>`
+    const { target, rel } = this.getLinkAttributes()
+    return html`<a 
+      href=${privacyPolicyUrl}
+      ?target=${target}
+      ?rel=${rel}
+    >Privacy Policy</a>`
   }
 }
 


### PR DESCRIPTION
# Description

Added legalLinksNewTab option to allow legal links (Terms and Privacy) to optionally open in new tabs. This improves UX by keeping the wallet connect modal open while viewing legal documents.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
