### PR TITLE
refactor: switch network if wallet active network is different

### DIFF
--- a/.changeset/rich-monkeys-smell.md
+++ b/.changeset/rich-monkeys-smell.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Refactors connectExternal to call switch network if wallet's active chain is not in requested chains list
+Refactors connectExternal to call switch network if wallet's active chain is not in requested networks list

--- a/.changeset/rich-monkeys-smell.md
+++ b/.changeset/rich-monkeys-smell.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Refactors connectExternal to call switch network if wallet's active chain is not in requested chains list

--- a/apps/browser-extension/src/core/transport.ts
+++ b/apps/browser-extension/src/core/transport.ts
@@ -1,12 +1,4 @@
-import {
-  Address,
-  createWalletClient,
-  EIP1193Parameters,
-  EIP1193Provider,
-  fromHex,
-  http,
-  toHex
-} from 'viem'
+import { createWalletClient, EIP1193Parameters, EIP1193Provider, fromHex, http, toHex } from 'viem'
 import { ChainId, wagmiConfig } from './wagmi'
 import { AccountUtil } from '../utils/AccountUtil'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -18,8 +10,6 @@ const LOCAL_STORAGE_KEYS = {
   HAS_CONNECTED: '@appkit/extension_connected',
   CHAIN_ID: '@appkit/extension_chain_id'
 }
-
-const SUPPORTED_CHAIN_IDS = [1, 137, 8453]
 
 export function createReownTransport() {
   return {
@@ -100,18 +90,6 @@ export function createReownTransport() {
           const [, typedData] = params
 
           return signTypedData(JSON.parse(typedData))
-        }
-
-        case 'wallet_addEthereumChain': {
-          const isSupported = SUPPORTED_CHAIN_IDS.some(
-            id => fromHex(params[0]?.chainId as Address, 'number') === id
-          )
-
-          if (!isSupported) {
-            throw new Error('Chain ID not supported')
-          }
-
-          return null
         }
 
         default:

--- a/apps/browser-extension/src/core/transport.ts
+++ b/apps/browser-extension/src/core/transport.ts
@@ -1,4 +1,12 @@
-import { createWalletClient, EIP1193Parameters, EIP1193Provider, fromHex, http, toHex } from 'viem'
+import {
+  Address,
+  createWalletClient,
+  EIP1193Parameters,
+  EIP1193Provider,
+  fromHex,
+  http,
+  toHex
+} from 'viem'
 import { ChainId, wagmiConfig } from './wagmi'
 import { AccountUtil } from '../utils/AccountUtil'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -10,6 +18,8 @@ const LOCAL_STORAGE_KEYS = {
   HAS_CONNECTED: '@appkit/extension_connected',
   CHAIN_ID: '@appkit/extension_chain_id'
 }
+
+const SUPPORTED_CHAIN_IDS = [1, 137, 8453]
 
 export function createReownTransport() {
   return {
@@ -90,6 +100,18 @@ export function createReownTransport() {
           const [, typedData] = params
 
           return signTypedData(JSON.parse(typedData))
+        }
+
+        case 'wallet_addEthereumChain': {
+          const isSupported = SUPPORTED_CHAIN_IDS.some(
+            id => fromHex(params[0]?.chainId as Address, 'number') === id
+          )
+
+          if (!isSupported) {
+            throw new Error('Chain ID not supported')
+          }
+
+          return null
         }
 
         default:

--- a/apps/laboratory/tests/multichain-extension.spec.ts
+++ b/apps/laboratory/tests/multichain-extension.spec.ts
@@ -61,7 +61,7 @@ extensionTest('it should connect', async () => {
   await modalValidator.expectConnected()
 })
 
-extensionTest('it should switch networks and sign', async ({ library }) => {
+extensionTest('it should switch networks and sign', async () => {
   let network = 'Polygon'
 
   await modalPage.switchNetwork(network, true)

--- a/apps/laboratory/tests/multichain-extension.spec.ts
+++ b/apps/laboratory/tests/multichain-extension.spec.ts
@@ -67,18 +67,9 @@ extensionTest('it should switch networks and sign', async ({ library }) => {
   await modalPage.switchNetwork(network, true)
   await modalValidator.checkConnectionStatus('disconnected', network)
 
-  /*
-   * Wagmi is the only EVM adapter that remembers the last connected network after connection.
-   * Other adapters defaults to Ethereum as they don't sync the latest connected network.
-   */
-  if (library !== 'wagmi') {
-    network = 'Ethereum'
-  }
-
   await modalPage.connectToExtensionMultichain('eip155')
   await modalValidator.checkConnectionStatus('connected', network)
 
-  network = 'Polygon'
   await switchNetworkAndSign(network)
   await reloadAndSign(network)
 

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -369,7 +369,7 @@ export class EthersAdapter extends AdapterBlueprint {
 
         try {
           await this.switchNetwork({
-            caipNetwork: caipNetwork,
+            caipNetwork,
             provider: selectedProvider,
             providerType: type as ConnectorType
           })

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -385,7 +385,7 @@ export class EthersAdapter extends AdapterBlueprint {
 
     return {
       address: accounts[0] as `0x${string}`,
-      chainId: Number(requestChainId) || Number(chainId),
+      chainId: Number(chainId),
       provider: selectedProvider,
       type: type as ConnectorType,
       id

--- a/packages/adapters/ethers/src/tests/client.test.ts
+++ b/packages/adapters/ethers/src/tests/client.test.ts
@@ -5,7 +5,7 @@ import type { Provider } from '@reown/appkit-core'
 import type { W3mFrameProvider } from '@reown/appkit-wallet'
 import UniversalProvider from '@walletconnect/universal-provider'
 import { JsonRpcProvider, InfuraProvider } from 'ethers'
-import { mainnet } from '@reown/appkit/networks'
+import { mainnet, polygon } from '@reown/appkit/networks'
 import { EthersMethods } from '../utils/EthersMethods'
 import { ProviderUtil } from '@reown/appkit/store'
 import { WcConstantsUtil } from '@reown/appkit'
@@ -79,7 +79,7 @@ const mockAuthProvider = {
   getUser: vi.fn()
 } as unknown as W3mFrameProvider
 
-const mockNetworks = [mainnet]
+const mockNetworks = [mainnet, polygon]
 const mockCaipNetworks = CaipNetworksUtil.extendCaipNetworks(mockNetworks, {
   projectId: 'test-project-id',
   customNetworkImageUrls: {}
@@ -197,9 +197,11 @@ describe('EthersAdapter', () => {
 
   describe('EthersAdapter -connect', () => {
     it('should connect with external provider', async () => {
+      adapter.caipNetworks = mockCaipNetworks
       vi.mocked(mockProvider.request).mockImplementation(request => {
         if (request.method === 'eth_requestAccounts') return Promise.resolve(['0x123'])
         if (request.method === 'eth_chainId') return Promise.resolve('0x1')
+        if (request.method === 'wallet_switchEthereumChain') return Promise.resolve(null)
         return Promise.resolve(null)
       })
       const connectors = [
@@ -220,6 +222,46 @@ describe('EthersAdapter', () => {
         provider: mockProvider,
         type: 'EXTERNAL',
         chainId: 1
+      })
+
+      expect(result.address).toBe('0x123')
+      expect(result.chainId).toBe(1)
+    })
+
+    it('should call switch network if wallet chain id is different than requested chain id', async () => {
+      adapter.caipNetworks = mockCaipNetworks
+
+      vi.mocked(mockProvider.request).mockImplementation(request => {
+        if (request.method === 'eth_requestAccounts') return Promise.resolve(['0x123'])
+        if (request.method === 'eth_chainId') return Promise.resolve('137') // Return a different chain id
+        if (request.method === 'wallet_switchEthereumChain') return Promise.resolve(null)
+        return Promise.resolve(null)
+      })
+
+      const connectors = [
+        {
+          id: 'test',
+          provider: mockProvider,
+          chains: [1],
+          type: 'EXTERNAL',
+          chain: 1
+        }
+      ]
+
+      Object.defineProperty(adapter, 'connectors', {
+        value: connectors
+      })
+
+      const result = await adapter.connect({
+        id: 'test',
+        provider: mockProvider,
+        type: 'EXTERNAL',
+        chainId: 1
+      })
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }]
       })
 
       expect(result.address).toBe('0x123')
@@ -461,6 +503,7 @@ describe('EthersAdapter', () => {
 
   describe('EthersAdapter - provider listener', () => {
     it('should disconnect if accountsChanged event emits no accounts', async () => {
+      adapter.caipNetworks = mockCaipNetworks
       const emitter = new Emitter()
 
       const mockProvider = {

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -368,7 +368,7 @@ export class Ethers5Adapter extends AdapterBlueprint {
 
         try {
           await this.switchNetwork({
-            caipNetwork: caipNetwork,
+            caipNetwork,
             provider: selectedProvider,
             providerType: type as ConnectorType
           })

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -384,7 +384,7 @@ export class Ethers5Adapter extends AdapterBlueprint {
 
     return {
       address: accounts[0] as `0x${string}`,
-      chainId: Number(requestChainId) || Number(chainId),
+      chainId: Number(chainId),
       provider: selectedProvider,
       type: type as ConnectorType,
       id

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -359,6 +359,24 @@ export class Ethers5Adapter extends AdapterBlueprint {
         method: 'eth_chainId'
       })
 
+      if (requestChainId !== chainId) {
+        const caipNetwork = this.caipNetworks?.find(n => n.id === chainId)
+
+        if (!caipNetwork) {
+          throw new Error('Ethers5Adapter:connect - could not find the caipNetwork to switch')
+        }
+
+        try {
+          await this.switchNetwork({
+            caipNetwork: caipNetwork,
+            provider: selectedProvider,
+            providerType: type as ConnectorType
+          })
+        } catch (error) {
+          throw new Error('Ethers5Adapter:connect - Switch network failed')
+        }
+      }
+
       this.listenProviderEvents(selectedProvider)
     }
 

--- a/packages/adapters/ethers5/src/tests/client.test.ts
+++ b/packages/adapters/ethers5/src/tests/client.test.ts
@@ -5,7 +5,7 @@ import type { Provider } from '@reown/appkit-core'
 import type { W3mFrameProvider } from '@reown/appkit-wallet'
 import UniversalProvider from '@walletconnect/universal-provider'
 import { providers } from 'ethers'
-import { mainnet } from '@reown/appkit/networks'
+import { mainnet, polygon } from '@reown/appkit/networks'
 import { Ethers5Methods } from '../utils/Ethers5Methods'
 import { ProviderUtil } from '@reown/appkit/store'
 import { Emitter } from '@reown/appkit-common'
@@ -71,7 +71,7 @@ const mockAuthProvider = {
   getUser: vi.fn()
 } as unknown as W3mFrameProvider
 
-const mockNetworks = [mainnet]
+const mockNetworks = [mainnet, polygon]
 const mockCaipNetworks = CaipNetworksUtil.extendCaipNetworks(mockNetworks, {
   projectId: 'test-project-id',
   customNetworkImageUrls: {}
@@ -189,9 +189,11 @@ describe('Ethers5Adapter', () => {
 
   describe('Ethers5Adapter -connect', () => {
     it('should connect with external provider', async () => {
+      adapter.caipNetworks = mockCaipNetworks
       vi.mocked(mockProvider.request).mockImplementation(request => {
         if (request.method === 'eth_requestAccounts') return Promise.resolve(['0x123'])
         if (request.method === 'eth_chainId') return Promise.resolve('0x1')
+        if (request.method === 'wallet_switchEthereumChain') return Promise.resolve(null)
         return Promise.resolve(null)
       })
       const connectors = [
@@ -212,6 +214,46 @@ describe('Ethers5Adapter', () => {
         provider: mockProvider,
         type: 'EXTERNAL',
         chainId: 1
+      })
+
+      expect(result.address).toBe('0x123')
+      expect(result.chainId).toBe(1)
+    })
+
+    it('should call switch network if wallet chain id is different than requested chain id', async () => {
+      adapter.caipNetworks = mockCaipNetworks
+
+      vi.mocked(mockProvider.request).mockImplementation(request => {
+        if (request.method === 'eth_requestAccounts') return Promise.resolve(['0x123'])
+        if (request.method === 'eth_chainId') return Promise.resolve('137') // Return a different chain id
+        if (request.method === 'wallet_switchEthereumChain') return Promise.resolve(null)
+        return Promise.resolve(null)
+      })
+
+      const connectors = [
+        {
+          id: 'test',
+          provider: mockProvider,
+          chains: [1],
+          type: 'EXTERNAL',
+          chain: 1
+        }
+      ]
+
+      Object.defineProperty(adapter, 'connectors', {
+        value: connectors
+      })
+
+      const result = await adapter.connect({
+        id: 'test',
+        provider: mockProvider,
+        type: 'EXTERNAL',
+        chainId: 1
+      })
+
+      expect(mockProvider.request).toHaveBeenCalledWith({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }]
       })
 
       expect(result.address).toBe('0x123')
@@ -415,6 +457,7 @@ describe('Ethers5Adapter', () => {
 
   describe('EthersAdapter - provider listener', () => {
     it('should disconnect if accountsChanged event emits no accounts', async () => {
+      adapter.caipNetworks = mockCaipNetworks
       const emitter = new Emitter()
 
       const mockProvider = {

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -886,12 +886,10 @@ export class AppKit {
 
         await this.syncWalletConnectAccount()
       },
-      connectExternal: async ({ id, info, type, provider, chain }) => {
+      connectExternal: async ({ id, info, type, provider, chain, caipNetwork }) => {
         const activeChain = ChainController.state.activeChain as ChainNamespace
-        const chainToUse = chain || activeChain
-        const adapter = this.getAdapter(chainToUse)
 
-        if (chain && chain !== activeChain) {
+        if (chain && chain !== activeChain && !caipNetwork) {
           const toConnectNetwork = this.caipNetworks?.find(
             network => network.chainNamespace === chain
           )
@@ -899,6 +897,9 @@ export class AppKit {
             this.setCaipNetwork(toConnectNetwork)
           }
         }
+
+        const chainToUse = chain || activeChain
+        const adapter = this.getAdapter(chainToUse)
 
         if (!adapter) {
           throw new Error('Adapter not found')
@@ -909,8 +910,10 @@ export class AppKit {
           info,
           type,
           provider,
-          chainId: this.getCaipNetwork()?.id,
-          rpcUrl: this.getCaipNetwork()?.rpcUrls?.default?.http?.[0]
+          chainId: caipNetwork?.id || this.getCaipNetwork()?.id,
+          rpcUrl:
+            caipNetwork?.rpcUrls?.default?.http?.[0] ||
+            this.getCaipNetwork()?.rpcUrls?.default?.http?.[0]
         })
 
         if (!res) {

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -912,26 +912,15 @@ export class AppKit {
           rpcUrl: this.getCaipNetwork()?.rpcUrls?.default?.http?.[0]
         })
 
+        if (!res) {
+          return
+        }
+
         StorageUtil.addConnectedNamespace(chainToUse)
-
-        if (res) {
-          this.syncProvider({ ...res, chainNamespace: chainToUse })
-          await this.syncAccount({ ...res, chainNamespace: chainToUse })
-
-          const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
-
-          this.setAllAccounts(accounts, chainToUse)
-        }
-
-        const hasNetwork = this.caipNetworks?.some(network => network.id === res?.chainId)
-
-        if (!hasNetwork) {
-          const activeNetwork = this.getCaipNetwork() || this.caipNetworks?.[0]
-
-          if (activeNetwork) {
-            this.switchNetwork(activeNetwork)
-          }
-        }
+        this.syncProvider({ ...res, chainNamespace: chainToUse })
+        await this.syncAccount({ ...res, chainNamespace: chainToUse })
+        const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
+        this.setAllAccounts(accounts, chainToUse)
       },
       reconnectExternal: async ({ id, info, type, provider }) => {
         const namespace = ChainController.state.activeChain as ChainNamespace

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -885,9 +885,12 @@ export class AppKit {
 
         await this.syncWalletConnectAccount()
       },
-      connectExternal: async ({ id, info, type, provider, chain, caipNetwork }) => {
+      connectExternal: async ({ id, info, type, provider, chain }) => {
         const activeChain = ChainController.state.activeChain as ChainNamespace
-        if (chain && chain !== activeChain && !caipNetwork) {
+        const chainToUse = chain || activeChain
+        const adapter = this.getAdapter(chainToUse)
+
+        if (chain && chain !== activeChain) {
           const toConnectNetwork = this.caipNetworks?.find(
             network => network.chainNamespace === chain
           )
@@ -895,9 +898,6 @@ export class AppKit {
             this.setCaipNetwork(toConnectNetwork)
           }
         }
-
-        const chainToUse = chain || activeChain
-        const adapter = this.getAdapter(chainToUse)
 
         if (!adapter) {
           throw new Error('Adapter not found')
@@ -908,32 +908,28 @@ export class AppKit {
           info,
           type,
           provider,
-          chainId: caipNetwork?.id || this.getCaipNetwork()?.id,
-          rpcUrl:
-            caipNetwork?.rpcUrls?.default?.http?.[0] ||
-            this.getCaipNetwork()?.rpcUrls?.default?.http?.[0]
+          chainId: this.getCaipNetwork()?.id,
+          rpcUrl: this.getCaipNetwork()?.rpcUrls?.default?.http?.[0]
         })
 
         StorageUtil.addConnectedNamespace(chainToUse)
 
         if (res) {
-          this.syncProvider({
-            ...res,
-            chainNamespace: chainToUse
-          })
-          await this.syncAccount({
-            ...res,
-            chainNamespace: chainToUse
-          })
+          this.syncProvider({ ...res, chainNamespace: chainToUse })
+          await this.syncAccount({ ...res, chainNamespace: chainToUse })
 
           const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
 
           this.setAllAccounts(accounts, chainToUse)
         }
 
-        if (!this.caipNetworks?.some(network => network.id === res?.chainId)) {
-          if (res?.chainId) {
-            this.setUnsupportedNetwork(res.chainId)
+        const hasNetwork = this.caipNetworks?.some(network => network.id === res?.chainId)
+
+        if (!hasNetwork) {
+          const activeNetwork = this.getCaipNetwork() || this.caipNetworks?.[0]
+
+          if (activeNetwork) {
+            this.switchNetwork(activeNetwork)
           }
         }
       },

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -303,9 +303,6 @@ export const ChainController = {
 
     if (networkControllerClient) {
       await networkControllerClient.switchCaipNetwork(network)
-    }
-
-    if (network) {
       EventsController.sendEvent({
         type: 'track',
         event: 'SWITCH_NETWORK',


### PR DESCRIPTION
# Description

Refactors Ethers adapters to handle switch network if the wallet's active network is different than AppKit's active network. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
