### PR TITLE
fix: add default value if namespace is not available on upa getAccounts

### DIFF
--- a/.changeset/eight-forks-smoke.md
+++ b/.changeset/eight-forks-smoke.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Add default value if namespace is not available on upa getAccounts

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -63,13 +63,13 @@ export class UniversalAdapter extends AdapterBlueprint {
     namespace: ChainNamespace
   }): Promise<AdapterBlueprint.GetAccountsResult> {
     const provider = this.provider as UniversalProvider
-    const addresses = provider?.session?.namespaces?.[namespace]?.accounts
+    const addresses = (provider?.session?.namespaces?.[namespace]?.accounts
       ?.map(account => {
         const [, , address] = account.split(':')
 
         return address
       })
-      .filter((address, index, self) => self.indexOf(address) === index) as string[]
+      .filter((address, index, self) => self.indexOf(address) === index) || []) as string[]
 
     return Promise.resolve({
       accounts: addresses.map(address =>

--- a/packages/appkit/tests/universal-adapter.test.ts
+++ b/packages/appkit/tests/universal-adapter.test.ts
@@ -143,4 +143,48 @@ describe('UniversalAdapter', () => {
       ).rejects.toThrow('UniversalAdapter:switchNetwork - provider is undefined')
     })
   })
+
+  describe('getAccounts', () => {
+    it('should return empty array if there is no accounts', async () => {
+      mockProvider.session = undefined
+      const accounts = await adapter.getAccounts({ id: '', namespace: 'eip155' })
+
+      expect(accounts).toEqual({ accounts: [] })
+    })
+
+    it('should return accounts successfully', async () => {
+      mockProvider.session = {
+        namespaces: {
+          eip155: {
+            accounts: ['eip155:mock_network:mock_address_1', 'eip155:mock_network:mock_address_2']
+          }
+        }
+      } as any
+
+      Object.assign(adapter, {
+        provider: mockProvider
+      })
+
+      const accounts = await adapter.getAccounts({ id: '', namespace: 'eip155' })
+
+      expect(accounts).toEqual({
+        accounts: [
+          {
+            address: 'mock_address_1',
+            namespace: 'eip155',
+            path: undefined,
+            publicKey: undefined,
+            type: 'eoa'
+          },
+          {
+            address: 'mock_address_2',
+            namespace: 'eip155',
+            path: undefined,
+            publicKey: undefined,
+            type: 'eoa'
+          }
+        ]
+      })
+    })
+  })
 })


### PR DESCRIPTION
# Description

Add default value if namespace is not available on upa getAccounts

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-1998
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
