### PR TITLE
Fix/cloudauth siwx address match

### DIFF
--- a/.changeset/serious-ravens-appear.md
+++ b/.changeset/serious-ravens-appear.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-siwx': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where 1CA session would not be found because of non-cased addresses mismatching.'

--- a/packages/siwx/src/configs/CloudAuthSIWX.ts
+++ b/packages/siwx/src/configs/CloudAuthSIWX.ts
@@ -72,7 +72,10 @@ export class CloudAuthSIWX implements SIWXConfig {
 
       const siweCaipNetworkId = `eip155:${siweSession?.chainId}`
 
-      if (!siweSession || siweCaipNetworkId !== chainId || siweSession.address !== address) {
+      const isSameAddress = siweSession?.address.toLowerCase() === address.toLowerCase()
+      const isSameNetwork = siweCaipNetworkId === chainId
+
+      if (!isSameAddress || !isSameNetwork) {
         return []
       }
 

--- a/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
+++ b/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
@@ -241,6 +241,33 @@ Issued At: 2024-12-05T16:02:32.905Z`)
       )
     })
 
+    it('gets sessions when address is not lowercased', async () => {
+      const fetchSpy = vi.spyOn(global, 'fetch')
+
+      fetchSpy.mockResolvedValueOnce(
+        mocks.mockFetchResponse({
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          chainId: 1
+        })
+      )
+
+      const sessions = await siwx.getSessions(
+        'eip155:1',
+        '0x1234567890ABCDEF1234567890abcdef12345678'
+      )
+
+      expect(sessions).toEqual([
+        {
+          data: {
+            accountAddress: '0x1234567890abcdef1234567890abcdef12345678',
+            chainId: 'eip155:1'
+          },
+          message: '',
+          signature: ''
+        }
+      ])
+    })
+
     it('returns empty array if session is not found', async () => {
       const fetchSpy = vi.spyOn(global, 'fetch')
 


### PR DESCRIPTION
# Description
Fixes issue where a non-cased address response from a wallet would cause 1CA to fail on CloudAuthSIWX

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [X] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
