### PR TITLE
fix: add safari ios to prefetch wc uri

### DIFF
--- a/apps/builder/providers/appkit-provider.tsx
+++ b/apps/builder/providers/appkit-provider.tsx
@@ -24,7 +24,7 @@ if (!projectId) {
 const metadata = {
   name: 'AppKit Builder',
   description: 'The full stack toolkit to build onchain app UX',
-  url: 'https://github.com/0xonerb/next-reown-appkit-ssr', // origin must match your domain & subdomain
+  url: window?.origin || 'https://demo.reown.com', // origin must match your domain & subdomain
   icons: ['https://avatars.githubusercontent.com/u/179229932']
 }
 

--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -106,13 +106,9 @@ export const ConnectionController = {
       StorageUtil.setConnectedConnectorId(namespace, ConstantsUtil.CONNECTOR_ID.WALLET_CONNECT)
     })
 
-    if (CoreHelperUtil.isTelegram()) {
+    if (CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos())) {
       if (wcConnectionPromise) {
-        try {
-          await wcConnectionPromise
-        } catch (error) {
-          /* Empty */
-        }
+        await wcConnectionPromise
         wcConnectionPromise = undefined
 
         return
@@ -124,15 +120,12 @@ export const ConnectionController = {
 
         return
       }
-      wcConnectionPromise = new Promise(async (resolve, reject) => {
-        await this._getClient()
-          ?.connectWalletConnect?.(uri => {
-            state.wcUri = uri
-            state.wcPairingExpiry = CoreHelperUtil.getPairingExpiry()
-          })
-          .catch(reject)
-        resolve()
-      })
+      wcConnectionPromise = this._getClient()
+        ?.connectWalletConnect?.(uri => {
+          state.wcUri = uri
+          state.wcPairingExpiry = CoreHelperUtil.getPairingExpiry()
+        })
+        .catch(() => undefined)
       this.state.status = 'connecting'
       await wcConnectionPromise
       wcConnectionPromise = undefined

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -36,6 +36,12 @@ export const CoreHelperUtil = {
     return CoreHelperUtil.isMobile() && (ua.includes('iphone') || ua.includes('ipad'))
   },
 
+  isSafari() {
+    const ua = window.navigator.userAgent.toLowerCase()
+
+    return ua.includes('safari')
+  },
+
   isClient() {
     return typeof window !== 'undefined'
   },

--- a/packages/core/src/utils/CoreHelperUtil.ts
+++ b/packages/core/src/utils/CoreHelperUtil.ts
@@ -10,7 +10,7 @@ type OpenTarget = '_blank' | '_self' | 'popupWindow' | '_top'
 
 export const CoreHelperUtil = {
   isMobile() {
-    if (typeof window !== 'undefined') {
+    if (this.isClient()) {
       return Boolean(
         window.matchMedia('(pointer:coarse)').matches ||
           /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
@@ -25,18 +25,30 @@ export const CoreHelperUtil = {
   },
 
   isAndroid() {
+    if (!this.isMobile()) {
+      return false
+    }
+
     const ua = window.navigator.userAgent.toLowerCase()
 
     return CoreHelperUtil.isMobile() && ua.includes('android')
   },
 
   isIos() {
+    if (!this.isMobile()) {
+      return false
+    }
+
     const ua = window.navigator.userAgent.toLowerCase()
 
-    return CoreHelperUtil.isMobile() && (ua.includes('iphone') || ua.includes('ipad'))
+    return ua.includes('iphone') || ua.includes('ipad')
   },
 
   isSafari() {
+    if (!this.isClient()) {
+      return false
+    }
+
     const ua = window.navigator.userAgent.toLowerCase()
 
     return ua.includes('safari')

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-mobile/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-mobile/index.ts
@@ -20,8 +20,6 @@ export class W3mConnectingWcMobile extends W3mConnectingWidget {
     }
     this.secondaryBtnLabel = undefined
     this.secondaryLabel = ConstantsUtil.CONNECT_LABELS.MOBILE
-    this.onConnect = this.onConnectProxy.bind(this)
-    this.onRender = this.onRenderProxy.bind(this)
     document.addEventListener('visibilitychange', this.onBuffering.bind(this))
     EventsController.sendEvent({
       type: 'track',
@@ -45,14 +43,14 @@ export class W3mConnectingWcMobile extends W3mConnectingWidget {
   }
 
   // -- Private ------------------------------------------- //
-  private onRenderProxy() {
+  protected override onRender = () => {
     if (!this.ready && this.uri) {
       this.ready = true
       this.onConnect?.()
     }
   }
 
-  private onConnectProxy() {
+  protected override onConnect = () => {
     if (this.wallet?.mobile_link && this.uri) {
       try {
         this.error = false
@@ -87,6 +85,13 @@ export class W3mConnectingWcMobile extends W3mConnectingWidget {
       setTimeout(() => {
         ConnectionController.setBuffering(false)
       }, 5000)
+    }
+  }
+
+  protected override onTryAgain() {
+    if (!this.buffering) {
+      ConnectionController.setWcError(false)
+      this.onConnect()
     }
   }
 }

--- a/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
+++ b/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
@@ -78,7 +78,11 @@ export class W3mConnectingWidget extends LitElement {
       ]
     )
     // The uri should be preloaded in the tg ios context so we can safely init as the subscribeKey won't trigger
-    if (CoreHelperUtil.isTelegram() && CoreHelperUtil.isIos() && ConnectionController.state.wcUri) {
+    if (
+      (CoreHelperUtil.isTelegram() || CoreHelperUtil.isSafari()) &&
+      CoreHelperUtil.isIos() &&
+      ConnectionController.state.wcUri
+    ) {
       this.onConnect?.()
     }
   }
@@ -187,7 +191,7 @@ export class W3mConnectingWidget extends LitElement {
     }
   }
 
-  private onTryAgain() {
+  protected onTryAgain() {
     if (!this.buffering) {
       ConnectionController.setWcError(false)
       if (this.onRetry) {

--- a/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
@@ -89,26 +89,26 @@ export class W3mConnectView extends LitElement {
   public override render() {
     const { termsConditionsUrl, privacyPolicyUrl } = OptionsController.state
 
-    const legalCheckbox = OptionsController.state.features?.legalCheckbox
+    const isLegalCheckbox = OptionsController.state.features?.legalCheckbox
 
     const legalUrl = termsConditionsUrl || privacyPolicyUrl
-    const showLegalCheckbox =
-      Boolean(legalUrl) && Boolean(legalCheckbox) && this.walletGuide === 'get-started'
+    const isShowLegalCheckbox =
+      Boolean(legalUrl) && Boolean(isLegalCheckbox) && this.walletGuide === 'get-started'
 
-    const disabled = showLegalCheckbox && !this.checked
+    const isDisabled = isShowLegalCheckbox && !this.checked
 
     const classes = {
       connect: true,
-      disabled
+      disabled: isDisabled
     }
 
-    const enableWalletGuide = OptionsController.state.enableWalletGuide
+    const isEnableWalletGuide = OptionsController.state.enableWalletGuide
 
-    const enableWallets = this.enableWallets
+    const isEnableWallets = this.enableWallets
 
     const socialOrEmailLoginEnabled = this.isSocialEnabled || this.authConnector
 
-    const tabIndex = disabled ? -1 : undefined
+    const tabIndex = isDisabled ? -1 : undefined
 
     return html`
       <wui-flex flexDirection="column">
@@ -123,8 +123,8 @@ export class W3mConnectView extends LitElement {
             flexDirection="column"
             gap="s"
             .padding=${socialOrEmailLoginEnabled &&
-            enableWallets &&
-            enableWalletGuide &&
+            isEnableWallets &&
+            isEnableWalletGuide &&
             this.walletGuide === 'get-started'
               ? ['3xs', 's', '0', 's']
               : ['3xs', 's', 's', 's']}
@@ -132,7 +132,7 @@ export class W3mConnectView extends LitElement {
             ${this.renderConnectMethod(tabIndex)}
           </wui-flex>
         </wui-flex>
-        ${this.guideTemplate(disabled)}
+        ${this.guideTemplate(isDisabled)}
         <w3m-legal-footer></w3m-legal-footer>
       </wui-flex>
     `
@@ -248,16 +248,16 @@ export class W3mConnectView extends LitElement {
   }
 
   private walletListTemplate(tabIndex?: number) {
-    const enableWallets = this.enableWallets
-    const collapseWalletsOldProp = this.features?.emailShowWallets === false
-    const collapseWallets = this.features?.collapseWallets
-    const shouldCollapseWallets = collapseWalletsOldProp || collapseWallets
+    const isEnableWallets = this.enableWallets
+    const isCollapseWalletsOldProp = this.features?.emailShowWallets === false
+    const isCollapseWallets = this.features?.collapseWallets
+    const shouldCollapseWallets = isCollapseWalletsOldProp || isCollapseWallets
 
-    if (!enableWallets) {
+    if (!isEnableWallets) {
       return null
     }
     // In tg ios context, we have to preload the connection uri so we can use it to deeplink on user click
-    if (CoreHelperUtil.isTelegram() && CoreHelperUtil.isIos()) {
+    if ((CoreHelperUtil.isTelegram() || CoreHelperUtil.isSafari()) && CoreHelperUtil.isIos()) {
       ConnectionController.connectWalletConnect().catch(_e => ({}))
     }
 
@@ -280,9 +280,9 @@ export class W3mConnectView extends LitElement {
   }
 
   private guideTemplate(disabled = false) {
-    const enableWalletGuide = OptionsController.state.enableWalletGuide
+    const isEnableWalletGuide = OptionsController.state.enableWalletGuide
 
-    if (!enableWalletGuide) {
+    if (!isEnableWalletGuide) {
       return null
     }
 

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-mobile.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-mobile.test.ts
@@ -31,7 +31,7 @@ describe('W3mConnectingWcMobile', () => {
     const el: W3mConnectingWcMobile = await fixture(
       html`<w3m-connecting-wc-mobile></w3m-connecting-wc-mobile>`
     )
-    el['onConnectProxy']()
+    el['onConnect']()
 
     expect(openHrefSpy).toHaveBeenCalledWith(`link://wc?uri=${WC_URI}`, '_self')
   })
@@ -46,7 +46,7 @@ describe('W3mConnectingWcMobile', () => {
       const el: W3mConnectingWcMobile = await fixture(
         html`<w3m-connecting-wc-mobile></w3m-connecting-wc-mobile>`
       )
-      el['onConnectProxy']()
+      el['onConnect']()
 
       expect(openHrefSpy).toHaveBeenCalledWith(`link://wc?uri=${WC_URI}`, '_top')
     } finally {


### PR DESCRIPTION
# Description

This PR fixes the issue of when attempting to connect with Wallet Connect on iOS Safari through an `iframe` that would not trigger `window.open` with deeplinks.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2024
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
