### PR TITLE
fix: `ProviderUtil.getProvider('eip155')` returns `undefined` when using wagmi adapter

### DIFF
--- a/.changeset/selfish-rivers-shout.md
+++ b/.changeset/selfish-rivers-shout.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where the `walletProvider` from the `useAppKitProvider` hook was `undefined` when the wallet was connected. This issue occurred only when using wagmi adapter.
+Fixed an issue where `walletProvider` from the `useAppKitProvider` hook was `undefined` when the wallet was connected. This issue occurred only when using wagmi adapter.

--- a/.changeset/selfish-rivers-shout.md
+++ b/.changeset/selfish-rivers-shout.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where the `walletProvider` from the `useAppKitProvider` hook was `undefined` when the wallet was connected. This issue occurred only when using the WagmiAdapter.
+Fixed an issue where the `walletProvider` from the `useAppKitProvider` hook was `undefined` when the wallet was connected. This issue occurred only when using wagmi adapter.

--- a/.changeset/selfish-rivers-shout.md
+++ b/.changeset/selfish-rivers-shout.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the `walletProvider` from the `useAppKitProvider` hook was `undefined` when the wallet was connected. This issue occurred only when using the WagmiAdapter.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -410,7 +410,7 @@ export class WagmiAdapter extends AdapterBlueprint {
     return formatUnits(params.value, params.decimals)
   }
 
-  private addWagmiConnector(connector: Connector, options: AppKitOptions) {
+  private async addWagmiConnector(connector: Connector, options: AppKitOptions) {
     /*
      * We don't need to set auth connector or walletConnect connector
      * from wagmi since we already set it in chain adapter blueprint
@@ -433,6 +433,7 @@ export class WagmiAdapter extends AdapterBlueprint {
         connector.id === CommonConstantsUtil.CONNECTOR_ID.INJECTED
           ? undefined
           : { rdns: connector.id },
+      provider: (await connector.getProvider().catch(() => undefined)) as Provider | undefined,
       chain: this.namespace as ChainNamespace,
       chains: []
     })

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -107,10 +107,10 @@ describe('WagmiAdapter', () => {
     it('should set wagmi connectors', async () => {
       vi.spyOn(wagmiCore, 'watchConnectors').mockImplementation(vi.fn())
 
-      adapter.syncConnectors({ networks: [mainnet], projectId: 'YOUR_PROJECT_ID' }, mockAppKit)
-
-      // Wait for connectors to be set
-      await new Promise(resolve => setTimeout(resolve, 200))
+      await adapter.syncConnectors(
+        { networks: [mainnet], projectId: 'YOUR_PROJECT_ID' },
+        mockAppKit
+      )
 
       expect(adapter.connectors).toStrictEqual([
         {

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -179,9 +179,23 @@ describe('WagmiAdapter', () => {
 
       await (adapter as any).addWagmiConnector(mockConnector)
 
-      const provider = adapter.connectors?.find(c => c.id === mockConnector.id)?.provider
-
-      expect(provider).toBeDefined()
+      expect(adapter.connectors).toStrictEqual([
+        {
+          chain: 'eip155',
+          chains: [],
+          explorerId: undefined,
+          id: 'injected',
+          imageId: '07ba87ed-43aa-4adf-4540-9e6a2b9cae00',
+          imageUrl: undefined,
+          info: undefined,
+          name: 'Browser Wallet',
+          provider: {
+            connect: expect.any(Function),
+            request: expect.any(Function)
+          },
+          type: 'INJECTED'
+        }
+      ])
     })
   })
 


### PR DESCRIPTION
# Description

Fixed an issue where `ProviderUtil.getProvider('eip155')` returned `undefined` for wagmi adapter when connected to a wallet.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2041

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
