### PR TITLE
refactor: handle undefined caipNetwork when calling syncBalance

### DIFF
--- a/.changeset/nine-chicken-join.md
+++ b/.changeset/nine-chicken-join.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Refactors AppKit client to handle syncBalance call for unsupported networks as expected

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -1588,25 +1588,26 @@ export class AppKit {
         )
       }
 
-      const network = (caipNetwork || fallbackCaipNetwork) as CaipNetwork
-      if (network.chainNamespace === ChainController.state.activeChain) {
+      const network = caipNetwork || fallbackCaipNetwork
+
+      if (network?.chainNamespace === ChainController.state.activeChain) {
         this.setCaipNetwork(network)
       }
       this.syncConnectedWalletInfo(chainNamespace)
 
-      await this.syncBalance({ address, chainId: network.id, chainNamespace })
+      await this.syncBalance({ address, chainId: network?.id, chainNamespace })
     }
   }
 
   private async syncBalance(params: {
     address: string
-    chainId: string | number
+    chainId: string | number | undefined
     chainNamespace: ChainNamespace
   }) {
     const caipNetwork = NetworkUtil.getNetworksByNamespace(
       this.caipNetworks,
       params.chainNamespace
-    ).find(n => n.id.toString() === params.chainId.toString())
+    ).find(n => n.id.toString() === params.chainId?.toString())
 
     if (!caipNetwork) {
       return

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -5,7 +5,6 @@ import {
   type AppKitNetwork,
   type Balance,
   type CaipNetwork,
-  type CaipNetworkId,
   type ChainNamespace,
   Emitter,
   NetworkUtil,

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -1627,9 +1627,10 @@ describe('Balance sync', () => {
     vi.resetAllMocks()
     vi.spyOn(OptionsController, 'getSnapshot').mockReturnValue({ ...OptionsController.state })
     vi.spyOn(ThemeController, 'getSnapshot').mockReturnValue({ ...ThemeController.state })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({ ...ChainController.state })
   })
 
-  it.only('should not sync balance if theres no matching caipNetwork', async () => {
+  it('should not sync balance if theres no matching caipNetwork', async () => {
     const appKit = new AppKit({
       ...mockOptions,
       networks: [mainnet]

--- a/packages/appkit/tests/mocks/Options.ts
+++ b/packages/appkit/tests/mocks/Options.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest'
 import type { ChainAdapter } from '@reown/appkit-core'
 import type { SdkVersion } from '@reown/appkit-core'
 
-import { mainnet, solana } from '../../src/networks/index.js'
+import { mainnet, sepolia, solana } from '../../src/networks/index.js'
 import type { AppKitOptions } from '../../src/utils/index.js'
 
 export const mockOptions: AppKitOptions & {
@@ -29,7 +29,7 @@ export const mockOptions: AppKitOptions & {
       emit: vi.fn()
     } as unknown as ChainAdapter
   ],
-  networks: [mainnet, solana],
+  networks: [mainnet, sepolia, solana],
   metadata: {
     name: 'Test App',
     description: 'Test App Description',

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -12,16 +12,21 @@ import type { ConnectionStatus, SocialProvider, WcWallet } from './TypeUtil.js'
 // -- Utility -----------------------------------------------------------------
 export const StorageUtil = {
   getActiveNetworkProps() {
-    const activeNamespace = StorageUtil.getActiveNamespace()
-    const activeCaipNetworkId = StorageUtil.getActiveCaipNetworkId()
-    const caipNetworkIdFromStorage = activeCaipNetworkId
-      ? activeCaipNetworkId.split(':')[1]
+    const namespace = StorageUtil.getActiveNamespace()
+    const caipNetworkId = StorageUtil.getActiveCaipNetworkId() as CaipNetworkId | undefined
+    const stringChainId = caipNetworkId ? caipNetworkId.split(':')[1] : undefined
+
+    // eslint-disable-next-line no-nested-ternary
+    const chainId = stringChainId
+      ? isNaN(Number(stringChainId))
+        ? stringChainId
+        : Number(stringChainId)
       : undefined
 
     return {
-      namespace: activeNamespace,
-      caipNetworkId: activeCaipNetworkId,
-      chainId: caipNetworkIdFromStorage
+      namespace,
+      caipNetworkId,
+      chainId
     }
   },
 


### PR DESCRIPTION
# Description

- Refactors AppKit client to handle undefined network object when calling `syncBalance`
- Refactors AppKit client tests to remove redundant mocks

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
