### PR TITLE
fix: redundant goBack call when switching to another namespace

### DIFF
--- a/.changeset/hot-dogs-rest.md
+++ b/.changeset/hot-dogs-rest.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@reown/appkit-core': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes redundant goBack call when switching to another namespace

--- a/apps/laboratory/tests/multichain-extension.spec.ts
+++ b/apps/laboratory/tests/multichain-extension.spec.ts
@@ -65,9 +65,10 @@ extensionTest('it should switch networks and sign', async () => {
   let network = 'Polygon'
 
   await modalPage.switchNetwork(network, true)
-  await modalValidator.checkConnectionStatus('disconnected', network)
+  await modalPage.switchActiveChain()
+  await modalValidator.checkConnectionStatus('loading', network)
 
-  await modalPage.connectToExtensionMultichain('eip155')
+  await modalPage.connectToExtensionMultichain('eip155', true)
   await modalValidator.checkConnectionStatus('connected', network)
 
   await switchNetworkAndSign(network)

--- a/apps/laboratory/tests/multichain-siwe-extension.spec.ts
+++ b/apps/laboratory/tests/multichain-siwe-extension.spec.ts
@@ -16,11 +16,16 @@ const PATH_FOR_LIBRARIES = {
 // -- Helpers ------------------------------------------------------------------
 async function switchNetworkAndMaybeSignSiwe(network: string, siwe = true) {
   await modalPage.switchNetwork(network)
+  if (network === 'Solana') {
+    await modalPage.switchActiveChain()
+    modalPage.closeModal()
+  }
   await modalValidator.expectOnSignOutEventCalled(true)
   if (siwe) {
     await modalPage.promptSiwe()
     await modalValidator.expectOnSignOutEventCalled(true)
   }
+
   await modalValidator.expectNetworkButton(network)
 }
 

--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -414,6 +414,11 @@ export class ModalPage {
     await this.page.waitForTimeout(300)
   }
 
+  async switchActiveChain() {
+    await this.page.getByText('Switch to', { exact: false }).waitFor()
+    await this.page.getByTestId('w3m-switch-active-chain-button').click()
+  }
+
   async clickWalletDeeplink() {
     await this.connectButton.click()
     await this.page.getByTestId('wallet-selector-react-wallet-v2').click()
@@ -684,8 +689,13 @@ export class ModalPage {
     await walletSelector.click()
   }
 
-  async connectToExtensionMultichain(chainNamespace: 'eip155' | 'solana' | 'bitcoin') {
-    await this.connectButton.click()
+  async connectToExtensionMultichain(
+    chainNamespace: 'eip155' | 'solana' | 'bitcoin',
+    modalOpen?: boolean
+  ) {
+    if (!modalOpen) {
+      await this.connectButton.click()
+    }
     const walletSelector = await this.getExtensionWallet()
     await walletSelector.click()
     const chainSelector = this.page.getByTestId(`wui-list-chain-${chainNamespace}`)

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -26,6 +26,19 @@ export class ModalValidator {
     await this.page.waitForTimeout(500)
   }
 
+  async expectLoading() {
+    const accountButton = this.page.locator('appkit-connect-button')
+    await expect(accountButton, 'Account button should be present').toBeAttached({
+      timeout: MAX_WAIT
+    })
+    await expect(
+      this.page.getByTestId('connect-button'),
+      'Connect button should show connecting state'
+    ).toHaveText('Connecting...', {
+      timeout: MAX_WAIT
+    })
+  }
+
   async expectBalanceFetched(currency: 'SOL' | 'ETH') {
     const accountButton = this.page.locator('appkit-account-button')
     await expect(accountButton, `Account button should show balance as ${currency}`).toContainText(
@@ -417,11 +430,13 @@ export class ModalValidator {
     await expect(smartAccountStatus).toBeVisible({ timeout: MAX_WAIT })
   }
 
-  async checkConnectionStatus(status: 'connected' | 'disconnected', network?: string) {
+  async checkConnectionStatus(status: 'connected' | 'disconnected' | 'loading', network?: string) {
     if (status === 'connected') {
       await this.expectConnected()
-    } else {
+    } else if (status === 'disconnected') {
       await this.expectDisconnected()
+    } else if (status === 'loading') {
+      await this.expectLoading()
     }
 
     if (network) {

--- a/packages/appkit/src/client.ts
+++ b/packages/appkit/src/client.ts
@@ -1538,7 +1538,8 @@ export class AppKit {
 
     const { chainId: activeChainId } = StorageUtil.getActiveNetworkProps()
     const chainIdToUse = chainId || activeChainId
-    const isUnsupportedNetwork = ChainController.state.activeCaipNetwork?.name === 'Unknown Network'
+    const isUnsupportedNetwork =
+      ChainController.state.activeCaipNetwork?.name === ConstantsUtil.UNSUPPORTED_NETWORK_NAME
     const shouldSupportAllNetworks = ChainController.getNetworkProp(
       'supportsAllNetworks',
       chainNamespace
@@ -2018,7 +2019,7 @@ export class AppKit {
     return {
       id: caipNetworkId.split(':')[1],
       caipNetworkId,
-      name: 'Unknown Network',
+      name: ConstantsUtil.UNSUPPORTED_NETWORK_NAME,
       chainNamespace: caipNetworkId.split(':')[0],
       nativeCurrency: {
         name: '',

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -1034,7 +1034,7 @@ describe('Base', () => {
     })
   })
   describe('syncExistingConnection', () => {
-    it('should set status to "connecting" and sync the connection when a connector and namespace are present', async () => {
+    it.only('should set status to "connecting" and sync the connection when a connector and namespace are present', async () => {
       vi.spyOn(AccountController, 'state', 'get').mockReturnValueOnce({
         currentTab: 0,
         addressLabels: new Map(),
@@ -1043,7 +1043,7 @@ describe('Base', () => {
       vi.mocked(CoreHelperUtil.isClient).mockReturnValueOnce(true)
       vi.spyOn(StorageUtil, 'getActiveNamespace').mockReturnValue('eip155')
       vi.spyOn(StorageUtil, 'getConnectedConnectorId').mockReturnValue('test-connector')
-      vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
         activeCaipNetwork: { id: 'eip155:1', chainNamespace: 'eip155' } as CaipNetwork
       } as ChainControllerState)
       vi.mocked(StorageUtil.getActiveNetworkProps).mockReturnValue({
@@ -1069,8 +1069,8 @@ describe('Base', () => {
       await appKit['syncExistingConnection']()
 
       expect(mockAdapter.syncConnection).toHaveBeenCalled()
-      expect(AccountController.setStatus).toHaveBeenCalledWith('connected', 'eip155')
       expect(AccountController.setStatus).toHaveBeenCalledWith('connecting', 'eip155')
+      expect(AccountController.setStatus).toHaveBeenCalledWith('connected', 'eip155')
     })
 
     it('should set status to "disconnected" when no connector is present', async () => {

--- a/packages/appkit/tests/appkit.test.ts
+++ b/packages/appkit/tests/appkit.test.ts
@@ -1034,7 +1034,7 @@ describe('Base', () => {
     })
   })
   describe('syncExistingConnection', () => {
-    it.only('should set status to "connecting" and sync the connection when a connector and namespace are present', async () => {
+    it('should set status to "connecting" and sync the connection when a connector and namespace are present', async () => {
       vi.spyOn(AccountController, 'state', 'get').mockReturnValueOnce({
         currentTab: 0,
         addressLabels: new Map(),

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -51,5 +51,6 @@ export const ConstantsUtil = {
   ],
   HTTP_STATUS_CODES: {
     SERVICE_UNAVAILABLE: 503
-  }
+  },
+  UNSUPPORTED_NETWORK_NAME: 'Unknown Network'
 } as const

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -18,6 +18,7 @@ export const ConstantsUtil = {
     EIP6963: 'eip6963',
     AUTH: 'ID_AUTH'
   },
+  AUTH_CONNECTOR_SUPPORTED_CHAINS: ['eip155', 'solana'],
   LIMITS: {
     PENDING_TRANSACTIONS: 99
   },

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -251,6 +251,10 @@ export const ChainController = {
       return
     }
 
+    if (state.activeChain !== caipNetwork.chainNamespace) {
+      this.setIsSwitchingNamespace(true)
+    }
+
     const newAdapter = state.chains.get(caipNetwork.chainNamespace)
     state.activeChain = caipNetwork.chainNamespace
     state.activeCaipNetwork = caipNetwork

--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -52,6 +52,7 @@ export interface ChainControllerState {
   chains: Map<ChainNamespace, ChainAdapter>
   universalAdapter: Pick<ChainAdapter, 'networkControllerClient' | 'connectionControllerClient'>
   noAdapters: boolean
+  isSwitchingNamespace: boolean
 }
 
 type ChainControllerStateKey = keyof ChainControllerState
@@ -66,7 +67,8 @@ const state = proxy<ChainControllerState>({
   universalAdapter: {
     networkControllerClient: undefined,
     connectionControllerClient: undefined
-  }
+  },
+  isSwitchingNamespace: false
 })
 
 // -- Controller ---------------------------------------- //
@@ -493,9 +495,7 @@ export const ChainController = {
   },
 
   showUnsupportedChainUI() {
-    setTimeout(() => {
-      ModalController.open({ view: 'UnsupportedChain' })
-    }, 300)
+    ModalController.open({ view: 'UnsupportedChain' })
   },
 
   checkIfNamesSupported(): boolean {
@@ -591,5 +591,9 @@ export const ChainController = {
         }
       })
     }
+  },
+
+  setIsSwitchingNamespace(isSwitchingNamespace: boolean) {
+    state.isSwitchingNamespace = isSwitchingNamespace
   }
 }

--- a/packages/core/src/controllers/RouterController.ts
+++ b/packages/core/src/controllers/RouterController.ts
@@ -174,9 +174,10 @@ export const RouterController = {
     }
   },
 
-  reset(view: RouterControllerState['view']) {
+  reset(view: RouterControllerState['view'], data?: RouterControllerState['data']) {
     state.view = view
     state.history = [view]
+    state.data = data
   },
 
   replace(view: RouterControllerState['view'], data?: RouterControllerState['data']) {

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -78,7 +78,9 @@ export const StorageUtil = {
 
   getActiveCaipNetworkId() {
     try {
-      return SafeLocalStorage.getItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK_ID)
+      return SafeLocalStorage.getItem(SafeLocalStorageKeys.ACTIVE_CAIP_NETWORK_ID) as
+        | CaipNetworkId
+        | undefined
     } catch {
       console.info('Unable to get active caip network id')
 

--- a/packages/core/src/utils/StorageUtil.ts
+++ b/packages/core/src/utils/StorageUtil.ts
@@ -154,7 +154,11 @@ export const StorageUtil = {
     return undefined
   },
 
-  getConnectedConnectorId(namespace: ChainNamespace) {
+  getConnectedConnectorId(namespace: ChainNamespace | undefined) {
+    if (!namespace) {
+      return undefined
+    }
+
     try {
       const key = getSafeConnectorIdKey(namespace)
 

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { property, state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 
-import { type CaipAddress, type CaipNetwork } from '@reown/appkit-common'
+import { type CaipAddress, type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
 import {
   ApiController,
   ChainController,
@@ -207,43 +207,40 @@ export class W3mModal extends LitElement {
     const isSwitchingNamespace = ChainController.state.isSwitchingNamespace
     const nextConnected = CoreHelperUtil.getPlainAddress(caipAddress)
 
-    this.caipAddress = caipAddress
+    // If user is switching to another namespace and connected in that namespace, we should go back
+    const isSwitchingNamespaceAndConnected = isSwitchingNamespace && nextConnected
+
+    if (isSwitchingNamespaceAndConnected) {
+      RouterController.goBack()
+    }
 
     await SIWXUtil.initializeIfEnabled()
 
-    const shouldClose = (!nextConnected && !isSwitchingNamespace) || this.enableEmbedded
-
-    if (shouldClose) {
-      ModalController.close()
-    }
-
+    this.caipAddress = caipAddress
     ChainController.setIsSwitchingNamespace(false)
   }
 
   private onNewNetwork(nextCaipNetwork: CaipNetwork | undefined) {
     ApiController.prefetch()
 
-    if (!this.caipAddress) {
-      this.caipNetwork = nextCaipNetwork
-
-      return
-    }
-
     const prevCaipNetworkId = this.caipNetwork?.caipNetworkId?.toString()
     const nextNetworkId = nextCaipNetwork?.caipNetworkId?.toString()
+    const networkChanged = prevCaipNetworkId && nextNetworkId && prevCaipNetworkId !== nextNetworkId
     const isSwitchingNamespace = ChainController.state.isSwitchingNamespace
+    const isUnsupportedNetwork = this.caipNetwork?.name === ConstantsUtil.UNSUPPORTED_NETWORK_NAME
+
+    // If user is not connected, we should go back
+    const isNotConnected = !this.caipAddress
+    // If network has been changed in the same namespace and it's not an unsupported network, we should go back
+    const isNetworkChangedInSameNamespace =
+      networkChanged && !isUnsupportedNetwork && !isSwitchingNamespace
+    // If user is on the unsupported network screen, we should go back when network has been changed
     const isUnsupportedNetworkScreen = RouterController.state.view === 'UnsupportedChain'
 
-    if (
-      isUnsupportedNetworkScreen ||
-      (prevCaipNetworkId &&
-        nextNetworkId &&
-        prevCaipNetworkId !== nextNetworkId &&
-        this.caipNetwork?.name !== 'Unknown Network' &&
-        !isSwitchingNamespace)
-    ) {
+    if (isNotConnected || isUnsupportedNetworkScreen || isNetworkChangedInSameNamespace) {
       RouterController.goBack()
     }
+
     this.caipNetwork = nextCaipNetwork
   }
 }

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -207,10 +207,15 @@ export class W3mModal extends LitElement {
     const isSwitchingNamespace = ChainController.state.isSwitchingNamespace
     const nextConnected = CoreHelperUtil.getPlainAddress(caipAddress)
 
+    // When users decline SIWE signature, we should close the modal
+    const isDisconnectedInSameNamespace = !nextConnected && !isSwitchingNamespace
+
     // If user is switching to another namespace and connected in that namespace, we should go back
     const isSwitchingNamespaceAndConnected = isSwitchingNamespace && nextConnected
 
-    if (isSwitchingNamespaceAndConnected) {
+    if (isDisconnectedInSameNamespace) {
+      ModalController.close()
+    } else if (isSwitchingNamespaceAndConnected) {
       RouterController.goBack()
     }
 

--- a/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
@@ -174,9 +174,7 @@ export class W3mNetworksView extends LitElement {
       c => c === network.chainNamespace
     )
 
-    if (!isCurrentNamespaceConnected) {
-      RouterController.push('SwitchNetwork', { ...routerData, network })
-    } else {
+    if (isCurrentNamespaceConnected) {
       if (isConnectedWithAuth && isSupportedForAuthConnector) {
         // If user connected with auth connector and the next network is supported by the auth connector, we don't need to show switch active chain view.
         RouterController.push('SwitchNetwork', { ...routerData, network })
@@ -196,6 +194,8 @@ export class W3mNetworksView extends LitElement {
         // For any other case, we redirect to switch network page
         RouterController.push('SwitchNetwork', { ...routerData, network })
       }
+    } else {
+      RouterController.push('SwitchNetwork', { ...routerData, network })
     }
   }
 }

--- a/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
@@ -161,19 +161,10 @@ export class W3mNetworksView extends LitElement {
     }
 
     const isDifferentNamespace = network.chainNamespace !== ChainController.state.activeChain
-    const isNewNetworkConnected = ChainController.getAccountProp(
-      'caipAddress',
-      network.chainNamespace
-    )
     const isCurrentNetworkConnected = AccountController.state.caipAddress
-    const isAuthConnected = Boolean(ConnectorController.getAuthConnector())
+    const isNamespaceConnected = AccountController.getCaipAddress(network.chainNamespace)
 
-    if (
-      isDifferentNamespace &&
-      isCurrentNetworkConnected &&
-      !isNewNetworkConnected &&
-      !isAuthConnected
-    ) {
+    if (isDifferentNamespace && isCurrentNetworkConnected && !isNamespaceConnected) {
       RouterController.push('SwitchActiveChain', {
         switchToChain: network.chainNamespace,
         navigateTo: 'Connect',

--- a/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-networks-view/index.ts
@@ -163,12 +163,12 @@ export class W3mNetworksView extends LitElement {
     const isDifferentNamespace = network.chainNamespace !== ChainController.state.activeChain
     const isCurrentNamespaceConnected = AccountController.state.caipAddress
     const isNextNamespaceConnected = AccountController.getCaipAddress(network.chainNamespace)
+    const connectorId = StorageUtil.getConnectedConnectorId(ChainController.state.activeChain)
 
     /**
      * If the network is supported by the auth connector, we don't need to show switch active chain view.
-     * There are some cases like switching from Ethereum to Bitcoin where Bitcoin is not supported by the auth connector and users should connect with another connector.
+     * But there are some cases like switching from Ethereum to Bitcoin where Bitcoin is not supported by the auth connector and users should connect with another connector.
      */
-    const connectorId = StorageUtil.getConnectedConnectorId(ChainController.state.activeChain)
     const isConnectedWithAuth = connectorId === ConstantsUtil.CONNECTOR_ID.AUTH
     const isSupportedForAuthConnector = ConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.find(
       c => c === network.chainNamespace
@@ -176,39 +176,26 @@ export class W3mNetworksView extends LitElement {
 
     if (!isCurrentNamespaceConnected) {
       RouterController.push('SwitchNetwork', { ...routerData, network })
-
-      return
-    }
-
-    // If user connected with auth connector and the next network is supported by the auth connector, we don't need to show switch active chain view.
-    if (isConnectedWithAuth && isSupportedForAuthConnector) {
-      RouterController.push('SwitchNetwork', { ...routerData, network })
-
-      return
-    }
-
-    // If user connected with auth connector and the next network is not supported by the auth connector, we need to show switch active chain view.
-    if (isConnectedWithAuth && !isSupportedForAuthConnector) {
-      RouterController.push('SwitchActiveChain', {
-        switchToChain: network.chainNamespace,
-        navigateTo: 'Connect',
-        navigateWithReplace: true,
-        network
-      })
-
-      return
-    }
-
-    // If user connected with non-auth connector, we should check if user switching to a different namespace.
-    if (isDifferentNamespace && !isNextNamespaceConnected) {
-      RouterController.push('SwitchActiveChain', {
-        switchToChain: network.chainNamespace,
-        navigateTo: 'Connect',
-        navigateWithReplace: true,
-        network
-      })
     } else {
-      RouterController.push('SwitchNetwork', { ...routerData, network })
+      if (isConnectedWithAuth && isSupportedForAuthConnector) {
+        // If user connected with auth connector and the next network is supported by the auth connector, we don't need to show switch active chain view.
+        RouterController.push('SwitchNetwork', { ...routerData, network })
+      } else if (
+        // 1. If user connected with auth connector and the next network is not supported by the auth connector, we need to show switch active chain view.
+        (isConnectedWithAuth && !isSupportedForAuthConnector) ||
+        // 2. If user connected with non-auth connector, we should check if user switching to a different namespace and next namespace is not connected.
+        (isDifferentNamespace && !isNextNamespaceConnected)
+      ) {
+        RouterController.push('SwitchActiveChain', {
+          switchToChain: network.chainNamespace,
+          navigateTo: 'Connect',
+          navigateWithReplace: true,
+          network
+        })
+      } else {
+        // For any other case, we redirect to switch network page
+        RouterController.push('SwitchNetwork', { ...routerData, network })
+      }
     }
   }
 }

--- a/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
@@ -87,8 +87,6 @@ export class W3mSwitchActiveChainView extends LitElement {
       return
     }
 
-    ChainController.setIsSwitchingNamespace(true)
-
     if (this.caipNetwork) {
       ChainController.setActiveCaipNetwork(this.caipNetwork)
     } else {

--- a/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { property } from 'lit/decorators.js'
 
 import { ConstantsUtil } from '@reown/appkit-common'
-import { ChainController, ModalController, RouterController } from '@reown/appkit-core'
+import { ChainController, RouterController } from '@reown/appkit-core'
 import { customElement } from '@reown/appkit-ui'
 
 import styles from './styles.js'
@@ -82,16 +82,15 @@ export class W3mSwitchActiveChainView extends LitElement {
       return
     }
 
+    ChainController.setIsSwitchingNamespace(true)
+
     if (this.caipNetwork) {
       await ChainController.switchActiveNetwork(this.caipNetwork)
     } else {
       ChainController.setActiveNamespace(this.switchToChain)
     }
 
-    ModalController.close()
-    ModalController.open({
-      view: 'Connect'
-    })
+    RouterController.reset('Connect')
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-switch-active-chain-view/index.ts
@@ -70,14 +70,19 @@ export class W3mSwitchActiveChainView extends LitElement {
             Connected wallet doesn't support connecting to ${switchedChainNameString} chain. You
             need to connect with a different wallet.
           </wui-text>
-          <wui-button size="md" @click=${this.switchActiveChain.bind(this)}>Switch</wui-button>
+          <wui-button
+            data-testid="w3m-switch-active-chain-button"
+            size="md"
+            @click=${this.switchActiveChain.bind(this)}
+            >Switch</wui-button
+          >
         </wui-flex>
       </wui-flex>
     `
   }
 
   // -- Private Methods ------------------------------------ //
-  private async switchActiveChain() {
+  private switchActiveChain() {
     if (!this.switchToChain) {
       return
     }
@@ -85,7 +90,7 @@ export class W3mSwitchActiveChainView extends LitElement {
     ChainController.setIsSwitchingNamespace(true)
 
     if (this.caipNetwork) {
-      await ChainController.switchActiveNetwork(this.caipNetwork)
+      ChainController.setActiveCaipNetwork(this.caipNetwork)
     } else {
       ChainController.setActiveNamespace(this.switchToChain)
     }

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -163,32 +163,6 @@ describe('W3mModal', () => {
       expect(goBackSpy).toHaveBeenCalled()
     })
 
-    it.skip('should handle network change when connected but not connected in the other namespace', async () => {
-      const goBackSpy = vi.spyOn(RouterController, 'goBack')
-      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-        view: 'Connect'
-      } as RouterControllerState)
-      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
-        ...ChainController.state,
-        isSwitchingNamespace: true
-      } as unknown as typeof ChainController.state)
-      ;(element as any).caipAddress = 'eip155:1:0x123'
-      ;(element as any).caipNetwork = { id: '1', name: 'Network 1', caipNetworkId: 'eip155:1' }
-
-      const nextNetwork = {
-        id: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        name: 'Solana',
-        chainNamespace: 'solana',
-        caipNetworkId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
-      } as unknown as CaipNetwork
-
-      ChainController.setActiveCaipNetwork(nextNetwork)
-      element.requestUpdate()
-      await elementUpdated(element)
-
-      expect(goBackSpy).not.toHaveBeenCalled()
-    })
-
     it('should call goBack when network changed and page is UnsupportedChain', async () => {
       vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
         view: 'UnsupportedChain'

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -163,7 +163,7 @@ describe('W3mModal', () => {
       expect(goBackSpy).toHaveBeenCalled()
     })
 
-    it('should handle network change when connected but not connected in the other namespace', async () => {
+    it.skip('should handle network change when connected but not connected in the other namespace', async () => {
       const goBackSpy = vi.spyOn(RouterController, 'goBack')
       vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
         view: 'Connect'

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -147,6 +147,56 @@ describe('W3mModal', () => {
 
     it('should handle network change when not connected', async () => {
       const goBackSpy = vi.spyOn(RouterController, 'goBack')
+      ;(element as any).caipAddress = undefined
+      ;(element as any).caipNetwork = { id: '1', name: 'Network 1', caipNetworkId: 'eip155:1' }
+      const nextNetwork = {
+        id: '2',
+        name: 'Network 2',
+        caipNetworkId: 'eip155:2'
+      } as unknown as CaipNetwork
+
+      ChainController.setActiveCaipNetwork(nextNetwork)
+      element.requestUpdate()
+      await elementUpdated(element)
+
+      expect(ApiController.prefetch).toHaveBeenCalled()
+      expect(goBackSpy).toHaveBeenCalled()
+    })
+
+    it('should handle network change when connected but not connected in the other namespace', async () => {
+      const goBackSpy = vi.spyOn(RouterController, 'goBack')
+      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
+        view: 'Connect'
+      } as RouterControllerState)
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        ...ChainController.state,
+        isSwitchingNamespace: true
+      } as unknown as typeof ChainController.state)
+      ;(element as any).caipAddress = 'eip155:1:0x123'
+      ;(element as any).caipNetwork = { id: '1', name: 'Network 1', caipNetworkId: 'eip155:1' }
+
+      const nextNetwork = {
+        id: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        name: 'Solana',
+        chainNamespace: 'solana',
+        caipNetworkId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
+      } as unknown as CaipNetwork
+
+      ChainController.setActiveCaipNetwork(nextNetwork)
+      element.requestUpdate()
+      await elementUpdated(element)
+
+      expect(goBackSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call goBack when network changed and page is UnsupportedChain', async () => {
+      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
+        view: 'UnsupportedChain'
+      } as RouterControllerState)
+      const goBackSpy = vi.spyOn(RouterController, 'goBack')
+      ;(element as any).caipAddress = 'eip155:1:0x123'
+      ;(element as any).caipNetwork = { id: '1', name: 'Network 1', caipNetworkId: 'eip155:1' }
+
       const nextNetwork = {
         id: '2',
         name: 'Network 2',
@@ -158,7 +208,6 @@ describe('W3mModal', () => {
       await elementUpdated(element)
 
       expect(goBackSpy).toHaveBeenCalled()
-      expect(ApiController.prefetch).toHaveBeenCalled()
     })
 
     it('should handle network change when connected', async () => {

--- a/packages/scaffold-ui/test/views/w3m-swap-preview-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-swap-preview-view.test.ts
@@ -46,6 +46,7 @@ const mockChainState: ChainControllerState = {
       }
     }
   },
+
   activeCaipAddress: 'eip155:1:0x123456789abcdef123456789abcdef123456789a',
   chains: new Map(),
   universalAdapter: {
@@ -72,7 +73,8 @@ const mockChainState: ChainControllerState = {
       getCapabilities: vi.fn()
     }
   },
-  noAdapters: false
+  noAdapters: false,
+  isSwitchingNamespace: false
 }
 
 const mockSwapState: SwapControllerState = {

--- a/packages/scaffold-ui/test/views/w3m-swap-preview-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-swap-preview-view.test.ts
@@ -46,7 +46,6 @@ const mockChainState: ChainControllerState = {
       }
     }
   },
-
   activeCaipAddress: 'eip155:1:0x123456789abcdef123456789abcdef123456789a',
   chains: new Map(),
   universalAdapter: {

--- a/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
@@ -69,7 +69,8 @@ const mockChainState: ChainControllerState = {
       getCapabilities: vi.fn()
     }
   },
-  noAdapters: false
+  noAdapters: false,
+  isSwitchingNamespace: false
 }
 
 describe('W3mSwapView', () => {

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
@@ -94,7 +94,8 @@ const mockChainControllerState = {
     networkControllerClient: mockNetworkControllerClient,
     connectionControllerClient: mockConnectionControllerClient
   },
-  noAdapters: false
+  noAdapters: false,
+  isSwitchingNamespace: false
 }
 
 describe('W3mWalletSendPreviewView', () => {


### PR DESCRIPTION
# Description

- Refactors `onNewNetwork` and `onNewAddress` methods to handle unnecessary `RouterController.goBack()` calls
- Refactors `onSwitchNetwork` method and few other parts to show `SwitchActiveChain` page when users trying to switch to a network from different namespace, and filter connectors with that namespace

### Steps to repro

- Go to multichain example
- Connect to a namespace
- Switch network
- Connect to another namespace

or

- Go to multichain example
- Connect to a namespace
- Switch network but don't connect, close modal
- Switch to network that previously connected

Try several flows like this

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2040
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
