### PR TITLE
fix: wagmi/siwe signout

### DIFF
--- a/.changeset/violet-monkeys-dream.md
+++ b/.changeset/violet-monkeys-dream.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where wagmi adapter would emit disconnect event when user was not connected, causing SIWE to break.

--- a/.changeset/violet-monkeys-dream.md
+++ b/.changeset/violet-monkeys-dream.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where wagmi adapter would emit disconnect event when user was not connected, causing SIWE to break.
+Fixed an issue where wagmi adapter would emit disconnect event when user was not connected causing SIWE to break.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -216,7 +216,7 @@ export class WagmiAdapter extends AdapterBlueprint {
   private setupWatchers() {
     watchAccount(this.wagmiConfig, {
       onChange: (accountData, prevAccountData) => {
-        if (accountData.status === 'disconnected') {
+        if (accountData.status === 'disconnected' && prevAccountData.address) {
           this.emit('disconnect')
         }
 

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -751,10 +751,10 @@ describe('WagmiAdapter', () => {
       expect(accountChangedSpy).not.toHaveBeenCalled()
     })
 
-    it('should not emit disconnect if status is disconnected', async () => {
+    it('should emit disconnect if status is disconnected and previous data is connected', async () => {
       const currAccount = {
         status: 'disconnected',
-        address: '0x123',
+        address: undefined,
         chainId: 1
       } as unknown as wagmiCore.GetAccountReturnType
 
@@ -776,6 +776,33 @@ describe('WagmiAdapter', () => {
       adapter['setupWatchers']()
 
       expect(disconnectSpy).toHaveBeenCalled()
+    })
+
+    it('should not emit disconnect if previous account data is undefined and current account data is disconnected', async () => {
+      const currAccount = {
+        status: 'disconnected',
+        address: '0x123',
+        chainId: 1
+      } as unknown as wagmiCore.GetAccountReturnType
+
+      const prevAccount = {
+        status: 'disconnected',
+        address: undefined,
+        chainId: 1
+      } as unknown as wagmiCore.GetAccountReturnType
+
+      vi.mocked(watchAccount).mockImplementation((_, { onChange }) => {
+        onChange(currAccount, prevAccount)
+        return vi.fn()
+      })
+
+      const disconnectSpy = vi.fn()
+
+      adapter.on('disconnect', disconnectSpy)
+
+      adapter['setupWatchers']()
+
+      expect(disconnectSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
# Description

Fixed an issue where wagmi adapter would emit disconnect event when user was not connected causing SIWE to break.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2090

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
