### PR TITLE
fix: socials multichain not working

### DIFF
--- a/.changeset/tasty-flies-call.md
+++ b/.changeset/tasty-flies-call.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-common': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where multichain auth connector was not working

--- a/.changeset/tasty-flies-call.md
+++ b/.changeset/tasty-flies-call.md
@@ -20,4 +20,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where multichain auth connector was not working
+Fixed an issue where multichain social/email login was not working

--- a/packages/adapters/solana/src/providers/AuthProvider.ts
+++ b/packages/adapters/solana/src/providers/AuthProvider.ts
@@ -18,7 +18,7 @@ import { ProviderEventEmitter } from './shared/ProviderEventEmitter.js'
 
 export class AuthProvider extends ProviderEventEmitter implements SolanaProvider {
   public readonly id = ConstantsUtil.CONNECTOR_ID.AUTH
-  public readonly name = ConstantsUtil.CONNECTOR_ID.AUTH
+  public readonly name = ConstantsUtil.CONNECTOR_NAMES.AUTH
   public readonly type = 'AUTH'
   public readonly chain = ConstantsUtil.CHAIN.SOLANA
   public readonly provider: W3mFrameProvider

--- a/packages/adapters/solana/src/tests/AuthProvider.test.ts
+++ b/packages/adapters/solana/src/tests/AuthProvider.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConstantsUtil } from '@reown/appkit-common'
+
 import { AuthProvider } from '../providers/AuthProvider'
 import { mockLegacyTransaction, mockVersionedTransaction } from './mocks/Transaction'
 import { mockW3mFrameProvider } from './mocks/W3mFrameProvider'
@@ -22,6 +24,18 @@ describe('AuthProvider specific tests', () => {
       getActiveChain,
       chains: TestConstants.chains
     })
+  })
+
+  it('should have correct metadata', () => {
+    expect(authProvider).toEqual(
+      expect.objectContaining({
+        id: ConstantsUtil.CONNECTOR_ID.AUTH,
+        name: ConstantsUtil.CONNECTOR_NAMES.AUTH,
+        type: 'AUTH',
+        chain: ConstantsUtil.CHAIN.SOLANA,
+        provider
+      })
+    )
   })
 
   it('should call connect', async () => {

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -34,7 +34,7 @@ export function authConnector(parameters: AuthParameters) {
 
   return createConnector<W3mFrameProvider, Properties>(config => ({
     id: CommonConstantsUtil.CONNECTOR_ID.AUTH,
-    name: 'AppKit Auth',
+    name: CommonConstantsUtil.CONNECTOR_NAMES.AUTH,
     type: 'AUTH',
     chain: CommonConstantsUtil.CHAIN.EVM,
 

--- a/packages/appkit/src/adapters/ChainAdapterBlueprint.ts
+++ b/packages/appkit/src/adapters/ChainAdapterBlueprint.ts
@@ -105,7 +105,7 @@ export abstract class AdapterBlueprint<
     this.addConnector({
       id: CommonConstantsUtil.CONNECTOR_ID.AUTH,
       type: 'AUTH',
-      name: 'Auth',
+      name: CommonConstantsUtil.CONNECTOR_NAMES.AUTH,
       provider: authProvider,
       imageId: PresetsUtil.ConnectorImageIds[CommonConstantsUtil.CONNECTOR_ID.AUTH],
       chain: this.namespace,

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -18,6 +18,9 @@ export const ConstantsUtil = {
     EIP6963: 'eip6963',
     AUTH: 'ID_AUTH'
   },
+  CONNECTOR_NAMES: {
+    AUTH: 'Auth'
+  },
   AUTH_CONNECTOR_SUPPORTED_CHAINS: ['eip155', 'solana'],
   LIMITS: {
     PENDING_TRANSACTIONS: 99


### PR DESCRIPTION
# Description

Multichain social login is currently broken when using all adapters at once, you can test it here https://appkit-lab.reown.com/library/siwx-default

For some reason if we don't use the same connector names for all of our auth providers the auth provider will not be found during the connection. This line of code is causing this issue https://github.com/reown-com/appkit/blob/main/packages/core/src/controllers/ConnectorController.ts#L76

As a fix i've made sure to use the exact same auth connector name for all of our auth connectors 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

![image](https://github.com/user-attachments/assets/18b0d01a-c984-4ce1-9295-5cb09a3a8bd4)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
