### PR TITLE
fix: appkit core sign client example switch network logic

### DIFF
--- a/examples/html-ak-basic-sign-client/src/main.js
+++ b/examples/html-ak-basic-sign-client/src/main.js
@@ -39,6 +39,7 @@ let account
 let network
 
 const networks = [mainnet, polygon, solana, bitcoin]
+
 async function initialize() {
   signClient = await SignClient.init({ projectId: PROJECT_ID })
   modal = createAppKit({
@@ -54,7 +55,9 @@ async function initialize() {
   })
 
   document.getElementById('switch-network-eth')?.addEventListener('click', async () => {
-    modal.switchNetwork(mainnet)
+    await modal.switchNetwork(mainnet)
+    network = `eip155:${mainnet.id}`
+
     await signClient.request({
       topic: session.topic,
       chainId: network,
@@ -67,15 +70,14 @@ async function initialize() {
         ]
       }
     })
-    network = 'eip155:1'
     account = session?.namespaces?.eip155?.accounts?.[0]?.split(':')[2]
     updateDom()
   })
 
   document.getElementById('switch-network-polygon')?.addEventListener('click', async () => {
-    console.log(signClient)
+    await modal.switchNetwork(polygon)
+    network = `eip155:${polygon.id}`
 
-    modal.switchNetwork(polygon)
     await signClient.request({
       topic: session.topic,
       chainId: network,
@@ -88,20 +90,19 @@ async function initialize() {
         ]
       }
     })
-    network = 'eip155:137'
     account = session?.namespaces?.eip155?.accounts?.[0]?.split(':')[2]
     updateDom()
   })
 
-  document.getElementById('switch-network-solana')?.addEventListener('click', () => {
-    modal.switchNetwork(solana)
+  document.getElementById('switch-network-solana')?.addEventListener('click', async () => {
+    await modal.switchNetwork(solana)
     network = solana.caipNetworkId
     account = session?.namespaces?.solana?.accounts?.[0].split(':')[2]
     updateDom()
   })
 
-  document.getElementById('switch-network-bitcoin')?.addEventListener('click', () => {
-    modal.switchNetwork(bitcoin)
+  document.getElementById('switch-network-bitcoin')?.addEventListener('click', async () => {
+    await modal.switchNetwork(bitcoin)
     network = bitcoin.caipNetworkId
     account = session?.namespaces?.bip122?.accounts?.[0].split(':')[2]
     updateDom()


### PR DESCRIPTION
# Description

In the sign client example we are assigning active network CAIP network id to `network` variable in a wrong order so the `sign client.request` is using the Solana CAIP network id while calling `wallet_switchEthereumChain` method.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
