### PR TITLE
refactor: render only unique wallets on the wallets list

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
@@ -3,7 +3,12 @@ import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 
 import type { WcWallet } from '@reown/appkit-core'
-import { ApiController, ConnectorController, RouterController } from '@reown/appkit-core'
+import {
+  ApiController,
+  ConnectorController,
+  CoreHelperUtil,
+  RouterController
+} from '@reown/appkit-core'
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-card-select-loader'
 import '@reown/appkit-ui/wui-grid'
@@ -99,7 +104,10 @@ export class W3mAllWalletsList extends LitElement {
   }
 
   private walletsTemplate() {
-    const wallets = [...this.featured, ...this.recommended, ...this.wallets]
+    const wallets = CoreHelperUtil.uniqueBy(
+      [...this.featured, ...this.recommended, ...this.wallets],
+      'id'
+    )
     const walletsWithInstalled = WalletUtil.markWalletsAsInstalled(wallets)
 
     return walletsWithInstalled.map(

--- a/packages/scaffold-ui/test/partials/w3m-all-wallets-list.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-all-wallets-list.test.ts
@@ -88,6 +88,34 @@ describe('W3mAllWalletsList', () => {
     vi.useRealTimers()
   })
 
+  it('does not render duplicate wallets when present in multiple arrays', async () => {
+    const duplicateWallet = { id: '1', name: 'Duplicate Wallet', rdns: 'rdns1' }
+    const uniqueWallet = { id: '2', name: 'Unique Wallet', rdns: 'rdns2' }
+
+    vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
+      wallets: [duplicateWallet],
+      recommended: [duplicateWallet],
+      featured: [duplicateWallet, uniqueWallet],
+      count: 2,
+      page: 1
+    } as unknown as ApiControllerState)
+
+    const element: W3mAllWalletsList = await fixture(
+      html`<w3m-all-wallets-list></w3m-all-wallets-list>`
+    )
+
+    // Simulate loading complete
+    element.requestUpdate()
+    await elementUpdated(element)
+
+    const walletItems = element.shadowRoot?.querySelectorAll('w3m-all-wallets-list-item')
+    expect(walletItems?.length).toBe(2) // Should only show 2 wallets, not 4
+
+    // Verify the wallet items have unique IDs
+    const walletIds = new Set(Array.from(walletItems || []).map(item => (item as any).wallet?.id))
+    expect(walletIds.size).toBe(2)
+  })
+
   it('renders wallet list after loading', async () => {
     const element: W3mAllWalletsList = await fixture(
       html`<w3m-all-wallets-list></w3m-all-wallets-list>`


### PR DESCRIPTION
# Description

We have several calls for fetching wallets:
- 1) When opening the modal, we are fetching 4 recommended wallets (MM one of them)
- 2) When opening the all wallets page, we are fetching 40 top wallets (MM one of them) 

In 2), we are excluding recommended wallets in the query params, but the problem is when we open directly All Wallets view, both requests going concurently and 2) doesn't know about the recommended wallets on the state. Thus, the MM and three other wallets getting duplicated

This PR fixes by getting unique wallets on all wallets list

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
