### PR TITLE
fix: wrong status shown when using `useAppKitAccount` hook

### DIFF
--- a/packages/core/src/controllers/ChainController.ts
+++ b/packages/core/src/controllers/ChainController.ts
@@ -601,7 +601,8 @@ export const ChainController = {
         socialWindow: undefined,
         farcasterUrl: undefined,
         provider: undefined,
-        allAccounts: []
+        allAccounts: [],
+        status: 'disconnected'
       })
     )
   },

--- a/packages/core/tests/controllers/ChainController.test.ts
+++ b/packages/core/tests/controllers/ChainController.test.ts
@@ -287,6 +287,7 @@ describe('ChainController', () => {
     expect(ChainController.getAccountProp('preferredAccountType', chainNamespace)).toEqual(
       undefined
     )
+    expect(ChainController.getAccountProp('status', chainNamespace)).toEqual('disconnected')
     expect(ChainController.getAccountProp('socialProvider', chainNamespace)).toEqual(undefined)
     expect(ChainController.getAccountProp('socialWindow', chainNamespace)).toEqual(undefined)
   })


### PR DESCRIPTION
# Description

We didn’t set status to `disconnected` for all namespaces, instead we only set it for the current namespace. This caused a bug where switching between namespaces showed `connected` status even though we were actually disconnected.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2207
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
