### PR TITLE
refactor: disable opening modal if basic version

### DIFF
--- a/packages/core/src/controllers/ConnectionController.ts
+++ b/packages/core/src/controllers/ConnectionController.ts
@@ -77,7 +77,8 @@ type StateKey = keyof ConnectionControllerState
 const state = proxy<ConnectionControllerState>({
   wcError: false,
   buffering: false,
-  status: 'disconnected'
+  status: 'disconnected',
+  wcBasic: false
 })
 
 // eslint-disable-next-line init-declarations

--- a/packages/core/src/controllers/ModalController.ts
+++ b/packages/core/src/controllers/ModalController.ts
@@ -4,6 +4,7 @@ import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { ApiController } from './ApiController.js'
 import { ChainController } from './ChainController.js'
+import { ConnectionController } from './ConnectionController.js'
 import { ConnectorController } from './ConnectorController.js'
 import { EventsController } from './EventsController.js'
 import { OptionsController } from './OptionsController.js'
@@ -48,8 +49,12 @@ export const ModalController = {
   async open(options?: ModalControllerArguments['open']) {
     await ApiController.state.prefetchPromise
     const caipAddress = ChainController.state.activeCaipAddress
-
     const noAdapters = ChainController.state.noAdapters
+    const isAppKitBasic = ConnectionController.state.wcBasic
+
+    if (caipAddress && isAppKitBasic) {
+      return
+    }
 
     if (options?.view) {
       RouterController.reset(options.view)
@@ -64,6 +69,7 @@ export const ModalController = {
     } else {
       RouterController.reset('Connect')
     }
+    console.log('>>> caipAddress4', caipAddress, isAppKitBasic)
     state.open = true
     PublicStateController.set({ open: true })
     EventsController.sendEvent({

--- a/packages/core/tests/controllers/ConnectionController.test.ts
+++ b/packages/core/tests/controllers/ConnectionController.test.ts
@@ -99,6 +99,7 @@ describe('ConnectionController', () => {
     )
 
     expect(ConnectionController.state).toEqual({
+      wcBasic: false,
       wcError: false,
       buffering: false,
       status: 'disconnected',

--- a/packages/core/tests/controllers/ModalController.test.ts
+++ b/packages/core/tests/controllers/ModalController.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
 
-import { ModalController } from '../../exports/index.js'
+import { EventsController, ModalController, PublicStateController } from '../../exports/index.js'
+import { ConnectionController } from '../../exports/index.js'
+import { ChainController } from '../../exports/index.js'
+import { RouterController } from '../../exports/index.js'
+
+// -- Mock --------------------------------------------------------------------
 
 // -- Tests --------------------------------------------------------------------
 describe('ModalController', () => {
@@ -9,13 +15,45 @@ describe('ModalController', () => {
   })
 
   // Skipping for now, need to figure out a way to test this with new prefetch check
-  it.skip('should update state correctly on open()', () => {
-    ModalController.open()
+  it('should update state correctly on open()', async () => {
+    const eventsControllerSpy = vi.spyOn(EventsController, 'sendEvent')
+    const routerControllerSpy = vi.spyOn(RouterController, 'reset')
+    const publicStateControllerSpy = vi.spyOn(PublicStateController, 'set')
+
+    vi.spyOn(ConnectionController, 'state', 'get').mockReturnValue({
+      ...ConnectionController.state,
+      wcBasic: false
+    })
+
+    await ModalController.open()
+
     expect(ModalController.state.open).toEqual(true)
+    expect(eventsControllerSpy).toHaveBeenCalled()
+    expect(routerControllerSpy).toHaveBeenCalled()
+    expect(publicStateControllerSpy).toHaveBeenCalled()
   })
 
   it('should update state correctly on close()', () => {
     ModalController.close()
     expect(ModalController.state.open).toEqual(false)
+  })
+
+  it('should not open modal when wcBasic is true and user is connected', async () => {
+    const eventsControllerSpy = vi.spyOn(EventsController, 'sendEvent')
+    const routerControllerSpy = vi.spyOn(RouterController, 'reset')
+    const publicStateControllerSpy = vi.spyOn(PublicStateController, 'set')
+    vi.spyOn(ConnectionController.state, 'wcBasic', 'get').mockReturnValue(true)
+    vi.spyOn(ChainController.state, 'activeCaipAddress', 'get').mockReturnValue('eip155:1:0x123...')
+
+    await ModalController.open()
+
+    expect(ModalController.state.open).toBe(false)
+    expect(RouterController.state.view).not.toBe('Account')
+    expect(eventsControllerSpy).not.toHaveBeenCalled()
+    expect(routerControllerSpy).not.toHaveBeenCalled()
+    expect(publicStateControllerSpy).not.toHaveBeenCalled()
+
+    vi.spyOn(ConnectionController.state, 'wcBasic', 'get').mockReturnValue(false)
+    vi.spyOn(ChainController.state, 'activeCaipAddress', 'get').mockReturnValue(undefined)
   })
 })

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -7,6 +7,7 @@ import { type CaipNetwork } from '@reown/appkit-common'
 import {
   ApiController,
   ChainController,
+  ConnectionController,
   ModalController,
   OptionsController,
   RouterController,
@@ -126,6 +127,24 @@ describe('W3mModal', () => {
       await elementUpdated(element)
 
       expect(ModalController.state.open).toBe(false)
+    })
+
+    it('should not be visible when wcBasic is true and user is connected', async () => {
+      vi.spyOn(ConnectionController.state, 'wcBasic', 'get').mockReturnValue(true)
+      vi.spyOn(ChainController.state, 'activeCaipAddress', 'get').mockReturnValue(
+        'eip155:1:0x123...'
+      )
+
+      await ModalController.open()
+      element.requestUpdate()
+      await elementUpdated(element)
+
+      expect(HelpersUtil.getByTestId(element, 'w3m-modal-overlay')).toBeNull()
+      expect(HelpersUtil.getByTestId(element, 'w3m-modal-card')).toBeNull()
+      expect(ModalController.state.open).toBe(false)
+
+      vi.spyOn(ConnectionController.state, 'wcBasic', 'get').mockReturnValue(false)
+      vi.spyOn(ChainController.state, 'activeCaipAddress', 'get').mockReturnValue(undefined)
     })
 
     it('should add shake class when shaking', async () => {


### PR DESCRIPTION
# Description

Disables opening modal if it's AppKit Basic

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
