### PR TITLE
chore: prevent appkit.open from opening modal in basic

### DIFF
--- a/packages/appkit/src/client/appkit-basic.ts
+++ b/packages/appkit/src/client/appkit-basic.ts
@@ -45,6 +45,10 @@ export class AppKit extends AppKitCore {
   public adapter?: ChainAdapter
 
   // -- Overrides --------------------------------------------------------------
+  public override async open(_options: OpenOptions) {
+    // Do nothing
+  }
+
   protected override async injectModalUi() {
     if (!isInitialized && CoreHelperUtil.isClient()) {
       await import('@reown/appkit-scaffold-ui/basic')

--- a/packages/appkit/src/client/appkit-basic.ts
+++ b/packages/appkit/src/client/appkit-basic.ts
@@ -45,8 +45,11 @@ export class AppKit extends AppKitCore {
   public adapter?: ChainAdapter
 
   // -- Overrides --------------------------------------------------------------
-  public override async open(_options: OpenOptions) {
-    // Do nothing
+  public override async open(options: OpenOptions) {
+    // Only open modal when not connected
+    if (!AccountController.state.caipAddress) {
+      await super.open(options)
+    }
   }
 
   protected override async injectModalUi() {

--- a/packages/appkit/tests/client/appkit-basic.test.ts
+++ b/packages/appkit/tests/client/appkit-basic.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AccountController, type AccountControllerState, ModalController } from '@reown/appkit-core'
+
+import { AppKit } from '../../src/client/appkit-basic'
+import { mockOptions } from '../mocks/Options'
+import { mockBlockchainApiController, mockStorageUtil, mockWindowAndDocument } from '../test-utils'
+
+mockWindowAndDocument()
+mockStorageUtil()
+mockBlockchainApiController()
+
+describe('AppKitBasic', () => {
+  let appKit: AppKit
+
+  beforeEach(() => {
+    appKit = new AppKit(mockOptions)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should have valid default state', () => {
+    expect(appKit.activeAdapter).toBeUndefined()
+    expect(appKit.adapters).toBeUndefined()
+    expect(appKit.activeChainNamespace).toBeUndefined()
+    expect(appKit.adapter).toBeUndefined()
+  })
+
+  describe('open', () => {
+    beforeEach(() => {
+      vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+        caipAddress: undefined
+      } as unknown as AccountControllerState)
+    })
+
+    it('should open modal when not connected', async () => {
+      const modalSpy = vi.spyOn(ModalController, 'open')
+      await appKit.open({ view: 'Connect' })
+      expect(modalSpy).toHaveBeenCalledWith({ view: 'Connect' })
+    })
+
+    it('should not open modal when connected', async () => {
+      vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+        caipAddress: 'eip155:1:0x123'
+      } as unknown as AccountControllerState)
+      const modalSpy = vi.spyOn(ModalController, 'open')
+
+      await appKit.open({ view: 'Connect' })
+
+      expect(modalSpy).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
# Description

Do not open modal on `appkit.open()` in basic case

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2200


# Checklist

- [] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
