### PR TITLE
chore: Mapping chain logos for missing chain logos on AppKit Lab

### DIFF
--- a/packages/appkit-utils/src/PresetsUtil.ts
+++ b/packages/appkit-utils/src/PresetsUtil.ts
@@ -61,6 +61,8 @@ export const PresetsUtil = {
     1301: '4eeea7ef-0014-4649-5d1d-07271a80f600',
     // Unichain Mainnet
     130: '2257980a-3463-48c6-cbac-a42d2a956e00',
+    // Monad Testnet
+    10_143: '0a728e83-bacb-46db-7844-948f05434900',
     // Gnosis
     100: '02b53f6a-e3d4-479e-1cb4-21178987d100',
     // EVMos

--- a/packages/appkit-utils/src/PresetsUtil.ts
+++ b/packages/appkit-utils/src/PresetsUtil.ts
@@ -49,6 +49,18 @@ export const PresetsUtil = {
     10: 'ab9c186a-c52f-464b-2906-ca59d760a400',
     // Polygon
     137: '41d04d42-da3b-4453-8506-668cc0727900',
+    // Mantle
+    5000: 'e86fae9b-b770-4eea-e520-150e12c81100',
+    // Hedera Mainnet
+    295: '6a97d510-cac8-4e58-c7ce-e8681b044c00',
+    // Sepolia
+    11_155_111: 'e909ea0a-f92a-4512-c8fc-748044ea6800',
+    // Base Sepolia
+    84532: 'a18a7ecd-e307-4360-4746-283182228e00',
+    // Unichain Sepolia
+    1301: '4eeea7ef-0014-4649-5d1d-07271a80f600',
+    // Unichain Mainnet
+    130: '2257980a-3463-48c6-cbac-a42d2a956e00',
     // Gnosis
     100: '02b53f6a-e3d4-479e-1cb4-21178987d100',
     // EVMos


### PR DESCRIPTION
# Description

This PR maps the chain logos added to the WalletConnect mono repo to AppKit. This is to ensure that the chains configured on AppKit Lab have properly configured chain logos. The PR made to WalletConnect mono repo can be found [here](https://github.com/reown-com/web-monorepo/pull/1727)

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

NA

# Showcase (Optional)

NA

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
