### PR TITLE
chore(demo): adjust sentry sample rates, ignore noisy non-actionable errors

### DIFF
--- a/apps/builder/sentry.client.config.ts
+++ b/apps/builder/sentry.client.config.ts
@@ -12,7 +12,7 @@ Sentry.init({
 
   ignoreErrors: [
     "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
-    "Proposal expired"
+    'Proposal expired'
   ],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.

--- a/apps/builder/sentry.client.config.ts
+++ b/apps/builder/sentry.client.config.ts
@@ -6,8 +6,14 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: 'https://af19ab89d57fbd2f614ac4db8aee248d@o1095249.ingest.us.sentry.io/4508478682365952',
 
+  sampleRate: 0.5,
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.2,
+
+  ignoreErrors: [
+    "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
+    "Proposal expired"
+  ],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
# Description

- These two errors (one is from `core`, one is IndexedDB) are consuming a big chunk of our overall sentry error quota
- Ignore them from client side ingestion, as they are both non-actionable.
- Also: adjust error sampling to 50%, traces to 20%. This is in line with what we do on Cloud app.

<img width="732" alt="Screenshot 2025-02-14 at 15 04 49" src="https://github.com/user-attachments/assets/3d24fcec-c514-44f3-bb08-52acdf6238d3" />
<img width="1250" alt="Screenshot 2025-02-14 at 14 52 11" src="https://github.com/user-attachments/assets/a408d30d-df2d-47e7-815e-49193ab83028" />


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
