### PR TITLE
fix: social login popup blocked by safari

### DIFF
--- a/.changeset/early-radios-begin.md
+++ b/.changeset/early-radios-begin.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where social popup window was blocked by safari

--- a/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
@@ -254,7 +254,7 @@ export class W3mSocialLoginWidget extends LitElement {
           })
 
           if (!uri) {
-            this.popupWindow?.close()
+            this.popupWindow.close()
             throw new Error('Something went wrong')
           }
 

--- a/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
@@ -237,11 +237,13 @@ export class W3mSocialLoginWidget extends LitElement {
 
       try {
         if (authConnector && socialProvider) {
-          this.popupWindow = CoreHelperUtil.returnOpenHref(
-            '',
-            'popupWindow',
-            'width=600,height=800,scrollbars=yes'
-          )
+          if (!CoreHelperUtil.isTelegram()) {
+            this.popupWindow = CoreHelperUtil.returnOpenHref(
+              '',
+              'popupWindow',
+              'width=600,height=800,scrollbars=yes'
+            )
+          }
 
           if (this.popupWindow) {
             AccountController.setSocialWindow(this.popupWindow, ChainController.state.activeChain)

--- a/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
@@ -245,7 +245,7 @@ export class W3mSocialLoginWidget extends LitElement {
 
           if (this.popupWindow) {
             AccountController.setSocialWindow(this.popupWindow, ChainController.state.activeChain)
-          } else {
+          } else if (!CoreHelperUtil.isTelegram()) {
             throw new Error('Something went wrong')
           }
 
@@ -254,11 +254,13 @@ export class W3mSocialLoginWidget extends LitElement {
           })
 
           if (!uri) {
-            this.popupWindow.close()
+            this.popupWindow?.close()
             throw new Error('Something went wrong')
           }
 
-          this.popupWindow.location.href = uri
+          if (this.popupWindow) {
+            this.popupWindow.location.href = uri
+          }
 
           if (CoreHelperUtil.isTelegram()) {
             SafeLocalStorage.setItem(SafeLocalStorageKeys.SOCIAL_PROVIDER, socialProvider)

--- a/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-social-login-widget/index.ts
@@ -237,22 +237,6 @@ export class W3mSocialLoginWidget extends LitElement {
 
       try {
         if (authConnector && socialProvider) {
-          const { uri } = await authConnector.provider.getSocialRedirectUri({
-            provider: socialProvider
-          })
-
-          if (!uri) {
-            throw new Error('Something went wrong')
-          }
-
-          if (CoreHelperUtil.isTelegram()) {
-            SafeLocalStorage.setItem(SafeLocalStorageKeys.SOCIAL_PROVIDER, socialProvider)
-            const parsedUri = CoreHelperUtil.formatTelegramSocialLoginUrl(uri)
-
-            // eslint-disable-next-line consistent-return
-            return CoreHelperUtil.openHref(parsedUri, '_top')
-          }
-
           this.popupWindow = CoreHelperUtil.returnOpenHref(
             '',
             'popupWindow',
@@ -261,9 +245,27 @@ export class W3mSocialLoginWidget extends LitElement {
 
           if (this.popupWindow) {
             AccountController.setSocialWindow(this.popupWindow, ChainController.state.activeChain)
-            this.popupWindow.location.href = uri
           } else {
             throw new Error('Something went wrong')
+          }
+
+          const { uri } = await authConnector.provider.getSocialRedirectUri({
+            provider: socialProvider
+          })
+
+          if (!uri) {
+            this.popupWindow?.close()
+            throw new Error('Something went wrong')
+          }
+
+          this.popupWindow.location.href = uri
+
+          if (CoreHelperUtil.isTelegram()) {
+            SafeLocalStorage.setItem(SafeLocalStorageKeys.SOCIAL_PROVIDER, socialProvider)
+            const parsedUri = CoreHelperUtil.formatTelegramSocialLoginUrl(uri)
+
+            // eslint-disable-next-line consistent-return
+            return CoreHelperUtil.openHref(parsedUri, '_top')
           }
         }
       } catch (error) {

--- a/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
@@ -10,8 +10,8 @@ import {
   ConnectorController,
   CoreHelperUtil,
   EventsController,
-  OptionsController,
- } from '@reown/appkit-core'
+  OptionsController
+} from '@reown/appkit-core'
 
 import { W3mSocialLoginWidget } from '../../src/partials/w3m-social-login-widget'
 import { HelpersUtil } from '../utils/HelpersUtil'
@@ -35,7 +35,7 @@ describe('W3mSocialLoginWidget', () => {
     })
     vi.spyOn(AccountController, 'setSocialProvider')
     vi.spyOn(EventsController, 'sendEvent')
-     vi.spyOn(CoreHelperUtil, 'returnOpenHref').mockReturnValue(mockWindow as Window)
+    vi.spyOn(CoreHelperUtil, 'returnOpenHref').mockReturnValue(mockWindow as Window)
     vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('eip155')
     vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({
       provider: {

--- a/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
@@ -11,8 +11,7 @@ import {
   CoreHelperUtil,
   EventsController,
   OptionsController,
-  RouterController
-} from '@reown/appkit-core'
+ } from '@reown/appkit-core'
 
 import { W3mSocialLoginWidget } from '../../src/partials/w3m-social-login-widget'
 import { HelpersUtil } from '../utils/HelpersUtil'

--- a/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
@@ -1,0 +1,64 @@
+import { fixture } from '@open-wc/testing'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { html } from 'lit'
+
+import {
+  AccountController,
+  type AuthConnector,
+  ChainController,
+  ConnectorController,
+  CoreHelperUtil,
+  EventsController,
+  OptionsController,
+  RouterController
+} from '@reown/appkit-core'
+
+import { W3mSocialLoginWidget } from '../../src/partials/w3m-social-login-widget'
+import { HelpersUtil } from '../utils/HelpersUtil'
+
+describe('W3mSocialLoginWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should handle standard social login flow when clicking Google button', async () => {
+    const mockWindow = { location: { href: '' } }
+    const mockUri = 'https://auth.example.com/login'
+
+    vi.spyOn(OptionsController.state, 'features', 'get').mockReturnValue({
+      ...OptionsController.state.features,
+      socials: ['google']
+    })
+    vi.spyOn(AccountController, 'setSocialProvider')
+    vi.spyOn(EventsController, 'sendEvent')
+    vi.spyOn(RouterController, 'push')
+    vi.spyOn(CoreHelperUtil, 'returnOpenHref').mockReturnValue(mockWindow as Window)
+    vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('eip155')
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({
+      provider: {
+        getSocialRedirectUri: vi.fn().mockResolvedValue({ uri: mockUri })
+      }
+    } as unknown as AuthConnector)
+    vi.spyOn(AccountController, 'setSocialWindow')
+
+    const element: W3mSocialLoginWidget = await fixture(
+      html`<w3m-social-login-widget></w3m-social-login-widget>`
+    )
+
+    const googleButton = HelpersUtil.getByTestId(element, 'social-selector-google')
+    await googleButton.click()
+
+    expect(CoreHelperUtil.returnOpenHref).toHaveBeenCalledWith(
+      '',
+      'popupWindow',
+      'width=600,height=800,scrollbars=yes'
+    )
+    expect(AccountController.setSocialWindow).toHaveBeenCalledWith(mockWindow, 'eip155')
+    expect(mockWindow.location.href).toBe(mockUri)
+  })
+})

--- a/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-social-login-widget.test.ts
@@ -36,8 +36,7 @@ describe('W3mSocialLoginWidget', () => {
     })
     vi.spyOn(AccountController, 'setSocialProvider')
     vi.spyOn(EventsController, 'sendEvent')
-    vi.spyOn(RouterController, 'push')
-    vi.spyOn(CoreHelperUtil, 'returnOpenHref').mockReturnValue(mockWindow as Window)
+     vi.spyOn(CoreHelperUtil, 'returnOpenHref').mockReturnValue(mockWindow as Window)
     vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('eip155')
     vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({
       provider: {


### PR DESCRIPTION
# Description

We have an asynchronous function which takes time to load up the popup window which then causes browsers like safari to block our popup window.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2306

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
