### PR TITLE
chore: do not wait until sample apps build to run ui_tests 

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -78,6 +78,11 @@ jobs:
       - name: install
         run: pnpm install
 
+      - name: build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
+
       - name: build sample apps
         run: pnpm build:sample-apps
         env:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -29,7 +29,6 @@ jobs:
           - lint
           - prettier
           - typecheck
-          - build:sample-apps
           - danger
     steps:
       - name: checkout
@@ -56,6 +55,32 @@ jobs:
         run: pnpm ${{ matrix.style-command }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
+
+  build_sample_apps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+
+      - name: setup-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.x
+          cache: 'pnpm'
+
+      - name: install
+        run: pnpm install
+
+      - name: build sample apps
+        run: pnpm build:sample-apps
+        env:
           NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
 
   test:


### PR DESCRIPTION

# Description
- Removes `build:sample-apps` from the `checks` job to start `ui_tests` earlier
- Adds a separate build-sample-apps job running concurrently

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
