### PR TITLE
fix: incorrect import path for WalletConnectConnector in wagmi adapter

### DIFF
--- a/.changeset/witty-boats-nail.md
+++ b/.changeset/witty-boats-nail.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Fix import path for WalletConnectConnector in wagmi adapter

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -53,7 +53,7 @@ import {
 import { CaipNetworksUtil, PresetsUtil } from '@reown/appkit-utils'
 import type { W3mFrameProvider } from '@reown/appkit-wallet'
 import { AdapterBlueprint } from '@reown/appkit/adapters'
-import { WalletConnectConnector } from '@reown/appkit/connectors'
+import { WalletConnectConnector } from '@reown/appkit'
 
 import { authConnector } from './connectors/AuthConnector.js'
 import { walletConnect } from './connectors/UniversalConnector.js'


### PR DESCRIPTION
# Description

The appkit-adapter-wagmi package has a build issue due to an incorrect import path, where it's trying to import from @reown/appkit/connectors, which doesn't exist in the package structure. This PR fixes the problem by updating the import to use the proper package exports.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
