### PR TITLE
fix: reset profile info if not evm or testnet

### DIFF
--- a/.changeset/curly-news-draw.md
+++ b/.changeset/curly-news-draw.md
@@ -1,0 +1,23 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes profile name syncing when switching to non EVM network or to a testnet

--- a/packages/appkit/src/client/core.ts
+++ b/packages/appkit/src/client/core.ts
@@ -1033,6 +1033,9 @@ export abstract class AppKitCore {
     const activeCaipNetwork = this.caipNetworks?.find(n => n.caipNetworkId === caipNetworkId)
 
     if (chainNamespace !== ConstantsUtil.CHAIN.EVM || activeCaipNetwork?.testnet) {
+      this.setProfileName(null, chainNamespace)
+      this.setProfileImage(null, chainNamespace)
+
       return
     }
 

--- a/packages/appkit/tests/client/listeners.test.ts
+++ b/packages/appkit/tests/client/listeners.test.ts
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { Emitter } from '@reown/appkit-common'
 import { AccountController, BlockchainApiController, ChainController } from '@reown/appkit-core'
 
 import { AppKit } from '../../src/client/appkit.js'
 import { emitter, mockEvmAdapter, solanaEmitter } from '../mocks/Adapter'
-import { mainnet, solana, unsupportedNetwork } from '../mocks/Networks'
+import { mainnet, sepolia, solana, unsupportedNetwork } from '../mocks/Networks'
 import { mockOptions } from '../mocks/Options'
 import {
   mockBlockchainApiController,

--- a/packages/appkit/tests/client/listeners.test.ts
+++ b/packages/appkit/tests/client/listeners.test.ts
@@ -4,7 +4,7 @@ import { AccountController, BlockchainApiController, ChainController } from '@re
 
 import { AppKit } from '../../src/client/appkit.js'
 import { emitter, mockEvmAdapter, solanaEmitter } from '../mocks/Adapter'
-import { mainnet, sepolia, solana, unsupportedNetwork } from '../mocks/Networks'
+import { mainnet, solana, unsupportedNetwork } from '../mocks/Networks'
 import { mockOptions } from '../mocks/Options'
 import {
   mockBlockchainApiController,

--- a/packages/appkit/tests/client/listeners.test.ts
+++ b/packages/appkit/tests/client/listeners.test.ts
@@ -4,7 +4,7 @@ import { Emitter } from '@reown/appkit-common'
 import { AccountController, BlockchainApiController, ChainController } from '@reown/appkit-core'
 
 import { AppKit } from '../../src/client/appkit.js'
-import { mockEvmAdapter } from '../mocks/Adapter'
+import { emitter, mockEvmAdapter, solanaEmitter } from '../mocks/Adapter'
 import { mainnet, solana, unsupportedNetwork } from '../mocks/Networks'
 import { mockOptions } from '../mocks/Options'
 import {
@@ -57,7 +57,6 @@ describe('Listeners', () => {
   })
 
   it('should call syncAccountInfo when namespace is different than active namespace', async () => {
-    const emitter = new Emitter()
     const appKit = new AppKit({ ...mockOptions, defaultNetwork: solana })
     const setCaipAddressSpy = vi.spyOn(appKit, 'setCaipAddress')
 
@@ -72,6 +71,22 @@ describe('Listeners', () => {
       `${mockAccount.chainNamespace}:${mockAccount.chainId}:${mockAccount.address}`,
       'eip155'
     )
+  })
+
+  it('should reset profile info if switched namespace is not EVM', async () => {
+    const appKit = new AppKit({ ...mockOptions, defaultNetwork: mainnet })
+    const setProfileNameSpy = vi.spyOn(appKit, 'setProfileName')
+    const setProfileImageSpy = vi.spyOn(appKit, 'setProfileImage')
+
+    const mockAccount = {
+      address: 'C3k5AvYqoXjsfrkXdFBkUhqHHApeC8amP7y85LkLHL5X',
+      chainId: solana.id,
+      chainNamespace: solana.chainNamespace
+    }
+    solanaEmitter.emit('accountChanged', mockAccount)
+
+    expect(setProfileNameSpy).toHaveBeenCalledWith(null, solana.chainNamespace)
+    expect(setProfileImageSpy).toHaveBeenCalledWith(null, solana.chainNamespace)
   })
 
   it('should show unsupported chain UI when network is unsupported and allowUnsupportedChain is false', async () => {

--- a/packages/appkit/tests/mocks/Adapter.ts
+++ b/packages/appkit/tests/mocks/Adapter.ts
@@ -58,6 +58,7 @@ export const mockBitcoinAdapter = {
 } as unknown as AdapterBlueprint
 
 export const emitter = new Emitter()
+export const solanaEmitter = new Emitter()
 
 export const mockEvmAdapter = {
   namespace: 'eip155',
@@ -97,8 +98,8 @@ export const mockSolanaAdapter = {
   }),
   getBalance: vi.fn().mockResolvedValue({ balance: '1.00', symbol: 'SOL' }),
   getProfile: vi.fn().mockResolvedValue({}),
-  on: vi.fn(),
-  off: vi.fn(),
-  emit: vi.fn(),
+  on: solanaEmitter.on.bind(solanaEmitter),
+  off: solanaEmitter.off.bind(solanaEmitter),
+  emit: solanaEmitter.emit.bind(solanaEmitter),
   removeAllEventListeners: vi.fn()
 } as unknown as AdapterBlueprint


### PR DESCRIPTION
# Description

Fixes an issue where user switch network but profile info not getting updated when it should:
- Switching from non EVM to non EVM network
- Switching from profile supported network to testnet

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
