### PR TITLE
chore(multichain): rename Ethereum to EVM

### DIFF
--- a/.changeset/many-camels-grow.md
+++ b/.changeset/many-camels-grow.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-common': patch
+---
+
+changes the 'Ethereum' multichain label to 'EVM Networks' to avoid confusion

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -33,7 +33,7 @@ export const ConstantsUtil = {
     BITCOIN: 'bip122'
   } as const satisfies Record<string, ChainNamespace>,
   CHAIN_NAME_MAP: {
-    eip155: 'Ethereum',
+    eip155: 'EVM',
     solana: 'Solana',
     polkadot: 'Polkadot',
     bip122: 'Bitcoin'

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -33,7 +33,7 @@ export const ConstantsUtil = {
     BITCOIN: 'bip122'
   } as const satisfies Record<string, ChainNamespace>,
   CHAIN_NAME_MAP: {
-    eip155: 'EVM',
+    eip155: 'EVM Networks',
     solana: 'Solana',
     polkadot: 'Polkadot',
     bip122: 'Bitcoin'


### PR DESCRIPTION
# Description

Changes the label from `Ethereum` which confused users to `EVM Networks`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2100/change-label-ethereum-to-evm-networks-in-the-select-chain-modal

# Showcase (Optional)

<img width="417" alt="Screenshot 2025-03-06 at 5 45 15 PM" src="https://github.com/user-attachments/assets/b95c0a20-f648-44e1-affc-f6dbbc89d1dc" />

(label in the image is outdated)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
