### PR TITLE
fix: remove redundant rpc calls in core

### DIFF
--- a/.changeset/easy-rabbits-listen.md
+++ b/.changeset/easy-rabbits-listen.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Removes balance fetch on account sync for core

--- a/.changeset/sad-carrots-act.md
+++ b/.changeset/sad-carrots-act.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Removes identity calls from core account sync

--- a/packages/appkit/src/client/appkit-basic.ts
+++ b/packages/appkit/src/client/appkit-basic.ts
@@ -68,6 +68,22 @@ export class AppKit extends AppKitCore {
     }
   }
 
+  public override async syncIdentity(
+    _request: Pick<AdapterBlueprint.ConnectResult, 'address' | 'chainId'> & {
+      chainNamespace: ChainNamespace
+    }
+  ) {
+    return Promise.resolve()
+  }
+
+  public override async syncBalance(_params: {
+    address: string
+    chainId: string | number | undefined
+    chainNamespace: ChainNamespace
+  }) {
+    return Promise.resolve()
+  }
+
   protected override async injectModalUi() {
     if (!isInitialized && CoreHelperUtil.isClient()) {
       await import('@reown/appkit-scaffold-ui/basic')

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -2,6 +2,7 @@
 import {
   type CaipAddress,
   type CaipNetwork,
+  type CaipNetworkId,
   type ChainNamespace,
   ConstantsUtil,
   getW3mThemeVariables
@@ -29,6 +30,7 @@ import { W3mFrameHelpers, W3mFrameProvider } from '@reown/appkit-wallet'
 import type { W3mFrameTypes } from '@reown/appkit-wallet'
 import { W3mFrameRpcConstants } from '@reown/appkit-wallet/utils'
 
+import type { AdapterBlueprint } from '../adapters/ChainAdapterBlueprint.js'
 import { W3mFrameProviderSingleton } from '../auth-provider/W3MFrameProviderSingleton.js'
 import { ProviderUtil } from '../store/ProviderUtil.js'
 import { AppKitCore, type AppKitOptionsWithSdk } from './core.js'
@@ -420,6 +422,57 @@ export class AppKit extends AppKitCore {
   protected override async initChainAdapter(namespace: ChainNamespace): Promise<void> {
     await super.initChainAdapter(namespace)
     this.createAuthProviderForAdapter(namespace)
+  }
+
+  public override async syncIdentity({
+    address,
+    chainId,
+    chainNamespace
+  }: Pick<AdapterBlueprint.ConnectResult, 'address' | 'chainId'> & {
+    chainNamespace: ChainNamespace
+  }) {
+    const caipNetworkId: CaipNetworkId = `${chainNamespace}:${chainId}`
+    const activeCaipNetwork = this.caipNetworks?.find(n => n.caipNetworkId === caipNetworkId)
+
+    if (chainNamespace !== ConstantsUtil.CHAIN.EVM || activeCaipNetwork?.testnet) {
+      this.setProfileName(null, chainNamespace)
+      this.setProfileImage(null, chainNamespace)
+
+      return
+    }
+
+    try {
+      const { name, avatar } = await this.fetchIdentity({
+        address,
+        caipNetworkId
+      })
+
+      this.setProfileName(name, chainNamespace)
+      this.setProfileImage(avatar, chainNamespace)
+
+      if (!name) {
+        const adapter = this.getAdapter(chainNamespace)
+        const result = await adapter?.getProfile({
+          address,
+          chainId: Number(chainId)
+        })
+
+        if (result?.profileName) {
+          this.setProfileName(result.profileName, chainNamespace)
+          if (result.profileImage) {
+            this.setProfileImage(result.profileImage, chainNamespace)
+          }
+        } else {
+          await this.syncReownName(address, chainNamespace)
+          this.setProfileImage(null, chainNamespace)
+        }
+      }
+    } catch {
+      await this.syncReownName(address, chainNamespace)
+      if (chainId !== 1) {
+        this.setProfileImage(null, chainNamespace)
+      }
+    }
   }
 
   protected override syncConnectedWalletInfo(chainNamespace: ChainNamespace): void {

--- a/packages/appkit/tests/client/debug-mode.test.ts
+++ b/packages/appkit/tests/client/debug-mode.test.ts
@@ -1,15 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SdkVersion } from '@reown/appkit-common'
+import type { ChainNamespace, SdkVersion } from '@reown/appkit-common'
 import { AlertController, OptionsController } from '@reown/appkit-controllers'
 import { ErrorUtil } from '@reown/appkit-utils'
 
+import type { AdapterBlueprint } from '../../src/adapters'
 import { AppKitCore, type AppKitOptionsWithSdk } from '../../src/client/core'
 
 // Create a mock implementation of AppKitCore
 class TestAppKitCore extends AppKitCore {
   // Implement the abstract method
   protected async injectModalUi(): Promise<void> {
+    // No-op for testing
+  }
+
+  public override async syncIdentity(
+    _request: Pick<AdapterBlueprint.ConnectResult, 'address' | 'chainId'> & {
+      chainNamespace: ChainNamespace
+    }
+  ): Promise<void> {
     // No-op for testing
   }
 }


### PR DESCRIPTION
# Description

- Removes balance and identity calls on account sync on `core` packages

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-2463

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
