### PR TITLE
chore: downgrade canary docker to node 20 to match workflow

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM node:23-bullseye
+FROM node:20-bullseye
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.6.9'
+export const PACKAGE_VERSION = '1.7.0'


### PR DESCRIPTION
# Description

- Downgrades canary's dockerfile node version to node20, in order to match the `ui_test.yml` workflow node version

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-2473


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
