### PR TITLE
fix: `ApiController.prefetch` not working after connection

### DIFF
--- a/.changeset/beige-aliens-see.md
+++ b/.changeset/beige-aliens-see.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where network and wallet images weren't prefetched after connection

--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -11,7 +11,6 @@ import type {
   ApiGetWalletsResponse,
   WcWallet
 } from '../utils/TypeUtil.js'
-import { AccountController } from './AccountController.js'
 import { AssetController } from './AssetController.js'
 import { ChainController } from './ChainController.js'
 import { ConnectorController } from './ConnectorController.js'
@@ -296,11 +295,6 @@ export const ApiController = {
     fetchRecommendedWallets = true,
     fetchNetworkImages = true
   }: PrefetchParameters = {}) {
-    // Avoid pre-fetch if user is already connected as there is no need to fetch wallets in that case
-    if (AccountController.state.status === 'connected') {
-      return Promise.resolve()
-    }
-
     if (state.prefetchPromise) {
       return state.prefetchPromise
     }

--- a/packages/controllers/tests/controllers/ApiController.test.ts
+++ b/packages/controllers/tests/controllers/ApiController.test.ts
@@ -706,4 +706,25 @@ describe('ApiController', () => {
 
     expect(ApiController.state.isAnalyticsEnabled).toBe(true)
   })
+
+  it('should not include empty promises in prefetch by default', async () => {
+    const promiseAllSettledSpy = vi.spyOn(Promise, 'allSettled')
+
+    vi.spyOn(ApiController, 'fetchConnectorImages').mockResolvedValue()
+    vi.spyOn(ApiController, 'fetchFeaturedWallets').mockResolvedValue()
+    vi.spyOn(ApiController, 'fetchRecommendedWallets').mockResolvedValue()
+    vi.spyOn(ApiController, 'fetchNetworkImages').mockResolvedValue()
+
+    await ApiController.prefetch()
+
+    expect(promiseAllSettledSpy).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.any(Promise),
+        expect.any(Promise),
+        expect.any(Promise),
+        expect.any(Promise)
+      ])
+    )
+    expect(promiseAllSettledSpy.mock.calls[0]?.[0]).toHaveLength(4)
+  })
 })


### PR DESCRIPTION
# Description

There is an issue where if you connect your wallet then refresh the page the network and wallet images aren't getting prefetch. This is because we ignored prefetch if a user was connected.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2310

# Showcase (Optional)

![Screenshot 2025-03-14 at 12 05 32](https://github.com/user-attachments/assets/561cb21b-8b91-4c57-958f-a16a264c0be4)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
