### PR TITLE
fix: using enable from up returns solana address

### DIFF
--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -120,7 +120,7 @@ export function walletConnect(
         }
 
         // If session exists and chains are authorized, enable provider for required chain
-        const accounts = (await provider.enable()).map(x => getAddress(x))
+        const accounts = await this.getAccounts()
         const currentChainId = await this.getChainId()
 
         if (displayUri) {

--- a/packages/adapters/wagmi/src/tests/UniversalConnector.test.ts
+++ b/packages/adapters/wagmi/src/tests/UniversalConnector.test.ts
@@ -65,8 +65,6 @@ describe('UniversalConnector', () => {
     it('should connect successfully', async () => {
       const expectedChainId = mainnet.id
 
-      mockProvider.enable.mockResolvedValue([mockAddress])
-
       const result = await connectorInstance.connect()
 
       expect(result).toEqual({
@@ -77,17 +75,10 @@ describe('UniversalConnector', () => {
       expect(mockProvider.session.namespaces.eip155.accounts).toEqual([mockCaipAddress])
       expect(mockProvider.setDefaultChain).toHaveBeenCalledWith(`eip155:${expectedChainId}`)
     })
-
-    it('should handle user rejection', async () => {
-      mockProvider.enable.mockRejectedValue(new Error('user rejected'))
-
-      await expect(connectorInstance.connect()).rejects.toThrow('User rejected the request.')
-    })
   })
 
   describe('getAccounts', () => {
     it('should return accounts from provider session', async () => {
-      mockProvider.enable.mockResolvedValue([mockAddress])
       await connectorInstance.connect()
       const accounts = await connectorInstance.getAccounts()
 

--- a/packages/adapters/wagmi/src/tests/mocks/AppKit.ts
+++ b/packages/adapters/wagmi/src/tests/mocks/AppKit.ts
@@ -21,7 +21,7 @@ export const mockSession = {
 export const mockProvider = {
   on: vi.fn(),
   removeListener: vi.fn(),
-  enable: vi.fn().mockResolvedValue([mockAddress]),
+  getAccounts: vi.fn().mockResolvedValue([mockAddress]),
   request: vi.fn(),
   disconnect: vi.fn(),
   events: {


### PR DESCRIPTION
# Description

In the Wagmi adapter's WC connector, we are calling `enable()` function of UniversalProvider, which is an old method from before EIP1193, and not compatible with multi chain functionality. Using enable() causes some issues on multiple adapters examples, where it's returning Solana address and Viem is throwing the following error in the screen shot.

<img width="461" alt="Screenshot 2025-03-14 at 15 47 16" src="https://github.com/user-attachments/assets/68c358da-723a-4301-bc86-21e1e423cfc7" />


This PR replaces that with the `getAccounts()` method which is doing the same actually. 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
