### PR TITLE
fix: prevent unnecessary goback call

### DIFF
--- a/.changeset/modern-tools-relax.md
+++ b/.changeset/modern-tools-relax.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed connector listing when filtering by namespace

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -271,9 +271,12 @@ export class W3mModal extends LitElement {
     // If user is on the unsupported network screen, we should go back when network has been changed
     const isUnsupportedNetworkScreen = RouterController.state.view === 'UnsupportedChain'
 
+    const isModalOpen = ModalController.state.open
     const shouldGoBack =
+      isModalOpen &&
       !isConnectingExternal &&
       (isNotConnected || isUnsupportedNetworkScreen || isNetworkChangedInSameNamespace)
+
     if (shouldGoBack) {
       RouterController.goBack()
     }

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -13,7 +13,7 @@ import {
   RouterController,
   SIWXUtil
 } from '@reown/appkit-controllers'
-import type { RouterControllerState, SIWXConfig } from '@reown/appkit-controllers'
+import type { SIWXConfig } from '@reown/appkit-controllers'
 import { ErrorUtil } from '@reown/appkit-utils'
 
 import { W3mModal } from '../../src/modal/w3m-modal'
@@ -154,12 +154,9 @@ describe('W3mModal', () => {
     })
 
     it('prevents closing on unsupported chain', async () => {
-      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-        view: 'UnsupportedChain'
-      } as RouterControllerState)
       const shakeSpy = vi.spyOn(ModalController, 'shake')
+      ModalController.open({ view: 'UnsupportedChain' })
 
-      ModalController.open()
       element.requestUpdate()
       await elementUpdated(element)
 
@@ -174,8 +171,17 @@ describe('W3mModal', () => {
   describe('Network Changes', () => {
     let element: W3mModal
 
+    beforeAll(() => {
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        ...ChainController.state,
+        activeChain: 'eip155'
+      })
+    })
+
     beforeEach(async () => {
       vi.spyOn(ApiController, 'prefetch').mockImplementation(() => Promise.resolve([]))
+      vi.spyOn(ApiController, 'prefetchAnalyticsConfig').mockImplementation(() => Promise.resolve())
+      OptionsController.setEnableEmbedded(false)
       element = await fixture(html`<w3m-modal></w3m-modal>`)
     })
 
@@ -184,6 +190,7 @@ describe('W3mModal', () => {
     })
 
     it('should handle network change when not connected', async () => {
+      ModalController.close()
       const goBackSpy = vi.spyOn(RouterController, 'goBack')
       ;(element as any).caipAddress = undefined
       ;(element as any).caipNetwork = mainnet
@@ -192,18 +199,14 @@ describe('W3mModal', () => {
       element.requestUpdate()
       await elementUpdated(element)
 
-      expect(ApiController.prefetchAnalyticsConfig).toHaveBeenCalled()
-      expect(goBackSpy).toHaveBeenCalled()
+      expect(goBackSpy).not.toHaveBeenCalled()
     })
 
-    it('should call goBack when network changed and page is UnsupportedChain', async () => {
-      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-        view: 'UnsupportedChain'
-      } as RouterControllerState)
+    it('should handle network change when not connected and modal is open', async () => {
       const goBackSpy = vi.spyOn(RouterController, 'goBack')
-      ;(element as any).caipAddress = 'eip155:1:0x123'
+      ModalController.open()
+      ;(element as any).caipAddress = undefined
       ;(element as any).caipNetwork = polygon
-      element.requestUpdate()
 
       ChainController.setActiveCaipNetwork(mainnet)
       element.requestUpdate()
@@ -212,18 +215,44 @@ describe('W3mModal', () => {
       expect(goBackSpy).toHaveBeenCalled()
     })
 
-    it('should handle network change when connected', async () => {
+    it('should call goBack when network changed and page is UnsupportedChain', async () => {
+      ModalController.open({ view: 'UnsupportedChain' })
       const goBackSpy = vi.spyOn(RouterController, 'goBack')
       ;(element as any).caipAddress = 'eip155:1:0x123'
       ;(element as any).caipNetwork = mainnet
+
+      ChainController.setActiveCaipNetwork(polygon) // switch network
+
       element.requestUpdate()
+      await elementUpdated(element)
+
+      expect(goBackSpy).toHaveBeenCalled()
+    })
+
+    it('should handle network change when connected', async () => {
+      ModalController.close()
+      const goBackSpy = vi.spyOn(RouterController, 'goBack')
+      ;(element as any).caipAddress = 'eip155:137:0x123'
+      ;(element as any).caipNetwork = polygon
+
+      ChainController.setActiveCaipNetwork(mainnet)
+      element.requestUpdate()
+      await elementUpdated(element)
+
+      expect(goBackSpy).not.toHaveBeenCalled()
+    })
+
+    it('should handle network change when connected and modal is open', async () => {
+      ModalController.open()
+      const goBackSpy = vi.spyOn(RouterController, 'goBack')
+      ;(element as any).caipAddress = 'eip155:1:0x123'
+      ;(element as any).caipNetwork = mainnet
 
       ChainController.setActiveCaipNetwork(polygon)
       element.requestUpdate()
       await elementUpdated(element)
 
       expect(goBackSpy).toHaveBeenCalled()
-      expect(ApiController.prefetchAnalyticsConfig).toHaveBeenCalled()
     })
   })
 
@@ -255,15 +284,9 @@ describe('W3mModal', () => {
     })
 
     it('should prevent the user from closing the modal when required is set to true', async () => {
+      ModalController.open({ view: 'ApproveTransaction' })
       vi.useFakeTimers()
 
-      vi.spyOn(ModalController, 'state', 'get').mockReturnValue({
-        ...ModalController.state,
-        open: true
-      })
-      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-        view: 'ApproveTransaction'
-      } as unknown as RouterControllerState)
       vi.spyOn(SIWXUtil, 'getSIWX').mockReturnValue({
         getRequired: vi.fn().mockReturnValue(true),
         getSessions: vi.fn().mockResolvedValue([])
@@ -285,15 +308,9 @@ describe('W3mModal', () => {
     })
 
     it('should allow the user to close the modal when required is set to false', async () => {
+      ModalController.open({ view: 'ApproveTransaction' })
       vi.useFakeTimers()
 
-      vi.spyOn(ModalController, 'state', 'get').mockReturnValue({
-        ...ModalController.state,
-        open: true
-      })
-      vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-        view: 'ApproveTransaction'
-      } as unknown as RouterControllerState)
       vi.spyOn(SIWXUtil, 'getSIWX').mockReturnValue({
         getRequired: vi.fn().mockReturnValue(false),
         getSessions: vi.fn().mockResolvedValue([])
@@ -317,6 +334,10 @@ describe('W3mModal', () => {
 
   describe('Debug Mode', () => {
     let element: W3mModal
+
+    beforeAll(() => {
+      ModalController.open()
+    })
 
     beforeEach(async () => {
       vi.spyOn(ApiController, 'prefetch').mockImplementation(() => Promise.resolve([]))


### PR DESCRIPTION
# Description

We are calling to `RouterController.goBack` in the W3mModal's `onNewNetwork` event handler even though the modal is not open. This causes an issue where we are clearing the `ConnectorController`'s `filterByNamespace` state, thus, the connector list doesn't get the filtered connectors as expected.
 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2525
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
