### PR TITLE
fix: declare appkit packages as dependencies not dev deps

### DIFF
--- a/.changeset/poor-rules-design.md
+++ b/.changeset/poor-rules-design.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Declares appkit packages in ui dependencies

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -430,12 +430,12 @@
   },
   "dependencies": {
     "lit": "3.1.0",
-    "qrcode": "1.5.3"
+    "qrcode": "1.5.3",
+    "@reown/appkit-wallet": "workspace:*",
+    "@reown/appkit-controllers": "workspace:*",
+    "@reown/appkit-common": "workspace:*"
   },
   "devDependencies": {
-    "@reown/appkit-common": "workspace:*",
-    "@reown/appkit-controllers": "workspace:*",
-    "@reown/appkit-wallet": "workspace:*",
     "@types/qrcode": "1.5.5",
     "@vitest/coverage-v8": "2.1.9",
     "eslint-plugin-lit": "1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2641,13 +2641,6 @@ importers:
 
   packages/ui:
     dependencies:
-      lit:
-        specifier: 3.1.0
-        version: 3.1.0
-      qrcode:
-        specifier: 1.5.3
-        version: 1.5.3
-    devDependencies:
       '@reown/appkit-common':
         specifier: workspace:*
         version: link:../common
@@ -2657,6 +2650,13 @@ importers:
       '@reown/appkit-wallet':
         specifier: workspace:*
         version: link:../wallet
+      lit:
+        specifier: 3.1.0
+        version: 3.1.0
+      qrcode:
+        specifier: 1.5.3
+        version: 1.5.3
+    devDependencies:
       '@types/qrcode':
         specifier: 1.5.5
         version: 1.5.5


### PR DESCRIPTION
# Description

- declare appkit packages as dependencies not dev deps as there are imports of non-types

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
