### PR TITLE
fix: account not syncing on some namespaces when using multichain

### DIFF
--- a/.changeset/twelve-cougars-try.md
+++ b/.changeset/twelve-cougars-try.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the CAIP address was not set for the namespace when using multichain

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -226,7 +226,8 @@ export class WagmiAdapter extends AdapterBlueprint {
           ) {
             this.setupWatchPendingTransactions()
             this.emit('accountChanged', {
-              address: accountData.address
+              address: accountData.address,
+              chainId: accountData.chainId
             })
           }
 

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -760,7 +760,8 @@ describe('WagmiAdapter', () => {
       adapter['setupWatchers']()
 
       expect(accountChangedSpy).toHaveBeenCalledWith({
-        address: currAccount.address
+        address: currAccount.address,
+        chainId: currAccount.chainId
       })
     })
 
@@ -798,7 +799,8 @@ describe('WagmiAdapter', () => {
       adapter['setupWatchers']()
 
       expect(accountChangedSpy).toHaveBeenCalledWith({
-        address: currAccount.address
+        address: currAccount.address,
+        chainId: currAccount.chainId
       })
     })
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -803,7 +803,7 @@ export abstract class AppKitBaseClient {
   protected async syncAdapterConnection(namespace: ChainNamespace) {
     const adapter = this.getAdapter(namespace)
     const connectorId = ConnectorController.getConnectorId(namespace)
-    const caipNetwork = this.getCaipNetwork()
+    const caipNetwork = this.getCaipNetwork(namespace)
     const connector = ConnectorController.getConnectors(namespace).find(c => c.id === connectorId)
 
     try {


### PR DESCRIPTION
# Description

When using multichain if we don’t emit `chainId` the CAIP address will not be set for the namespace.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2519

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
