### PR TITLE
feat(web-wallet): disable button while loading

### DIFF
--- a/.changeset/every-actors-train.md
+++ b/.changeset/every-actors-train.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-scaffold-ui': patch
+---
+
+disable `open` button until connection established

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-web/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-web/index.ts
@@ -1,10 +1,14 @@
 import { ConnectionController, CoreHelperUtil, EventsController } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
+import { state } from 'lit/decorators.js'
 
 import { W3mConnectingWidget } from '../../utils/w3m-connecting-widget/index.js'
 
 @customElement('w3m-connecting-wc-web')
 export class W3mConnectingWcWeb extends W3mConnectingWidget {
+  // Add a property to control button disabled state
+  @state() protected override isLoading = true
+
   public constructor() {
     super()
     if (!this.wallet) {
@@ -14,11 +18,25 @@ export class W3mConnectingWcWeb extends W3mConnectingWidget {
     this.secondaryBtnLabel = 'Open'
     this.secondaryLabel = 'Open and continue in a new browser tab'
     this.secondaryBtnIcon = 'externalLink'
+    
+    // Update isLoading state initially and whenever URI changes
+    this.updateLoadingState()
+    this.unsubscribe.push(
+      ConnectionController.subscribeKey('wcUri', () => {
+        this.updateLoadingState()
+      })
+    )
+    
     EventsController.sendEvent({
       type: 'track',
       event: 'SELECT_WALLET',
       properties: { name: this.wallet.name, platform: 'web' }
     })
+  }
+  
+  // Update the isLoading state based on required conditions
+  private updateLoadingState() {
+    this.isLoading = !this.uri
   }
 
   // -- Private ------------------------------------------- //

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-web/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-web/index.ts
@@ -1,6 +1,7 @@
+import { state } from 'lit/decorators.js'
+
 import { ConnectionController, CoreHelperUtil, EventsController } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
-import { state } from 'lit/decorators.js'
 
 import { W3mConnectingWidget } from '../../utils/w3m-connecting-widget/index.js'
 
@@ -18,7 +19,7 @@ export class W3mConnectingWcWeb extends W3mConnectingWidget {
     this.secondaryBtnLabel = 'Open'
     this.secondaryLabel = 'Open and continue in a new browser tab'
     this.secondaryBtnIcon = 'externalLink'
-    
+
     // Update isLoading state initially and whenever URI changes
     this.updateLoadingState()
     this.unsubscribe.push(
@@ -26,14 +27,14 @@ export class W3mConnectingWcWeb extends W3mConnectingWidget {
         this.updateLoadingState()
       })
     )
-    
+
     EventsController.sendEvent({
       type: 'track',
       event: 'SELECT_WALLET',
       properties: { name: this.wallet.name, platform: 'web' }
     })
   }
-  
+
   // Update the isLoading state based on required conditions
   private updateLoadingState() {
     this.isLoading = !this.uri

--- a/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
+++ b/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
@@ -67,6 +67,8 @@ export class W3mConnectingWidget extends LitElement {
 
   @state() public buffering = false
 
+  @state() protected isLoading = false
+
   @property({ type: Boolean }) public isMobile = false
 
   @property() public onRetry?: (() => void) | (() => Promise<void>) = undefined
@@ -162,7 +164,7 @@ export class W3mConnectingWidget extends LitElement {
               <wui-button
                 variant="accent"
                 size="md"
-                ?disabled=${this.isRetrying || (!this.error && this.buffering)}
+                ?disabled=${this.isRetrying || (!this.error && this.buffering) || this.isLoading}
                 @click=${this.onTryAgain.bind(this)}
                 data-testid="w3m-connecting-widget-secondary-button"
               >

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-web.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-web.test.ts
@@ -1,0 +1,95 @@
+import { fixture } from '@open-wc/testing'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { html } from 'lit'
+
+import {
+  ConnectionController,
+  CoreHelperUtil,
+  EventsController,
+  RouterController,
+  type WcWallet
+} from '@reown/appkit-controllers'
+
+// -- Constants ------------------------------------------- //
+const WC_URI = 'xyz'
+const WALLET = {
+  name: 'React Wallet',
+  webapp_link: 'https://react-wallet.walletconnect.com/'
+} as WcWallet
+const REDIRECT_URL = `${WALLET.webapp_link}wc?uri=${encodeURIComponent(WC_URI)}`
+
+describe('W3mConnectingWcWeb', () => {
+  beforeAll(() => {
+    Element.prototype.animate = vi.fn()
+    vi.spyOn(ConnectionController, 'setWcLinking')
+    vi.spyOn(ConnectionController, 'setRecentWallet')
+    vi.spyOn(CoreHelperUtil, 'openHref')
+    vi.spyOn(EventsController, 'sendEvent')
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('it should handle redirection if the wallet webapp link exists and URI is available', async () => {
+    vi.spyOn(ConnectionController, 'state', 'get').mockReturnValue({
+      ...ConnectionController.state,
+      wcUri: WC_URI
+    })
+    vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
+      ...RouterController.state,
+      data: {
+        wallet: WALLET
+      }
+    })
+
+    const element = await fixture(html`<w3m-connecting-wc-web></w3m-connecting-wc-web>`)
+
+    expect(EventsController.sendEvent).toHaveBeenCalledWith({
+      type: 'track',
+      event: 'SELECT_WALLET',
+      properties: { name: WALLET.name, platform: 'web' }
+    })
+
+    // Test the "Open" button is not disabled
+    const button = element.shadowRoot?.querySelector('wui-button')
+    expect(button?.hasAttribute('disabled')).toBe(false)
+
+    // Simulate clicking the button
+    button?.click()
+
+    expect(ConnectionController.setWcLinking).toHaveBeenCalledWith({
+      name: WALLET.name,
+      href: WALLET.webapp_link
+    })
+    expect(ConnectionController.setRecentWallet).toHaveBeenCalledWith(WALLET)
+    expect(CoreHelperUtil.openHref).toHaveBeenCalledWith(REDIRECT_URL, '_blank')
+  })
+
+  it('it should disable the button if no URI is available', async () => {
+    vi.spyOn(ConnectionController, 'state', 'get').mockReturnValue({
+      ...ConnectionController.state,
+      wcUri: undefined
+    })
+    vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
+      ...RouterController.state,
+      data: {
+        wallet: WALLET
+      }
+    })
+
+    const element = await fixture(html`<w3m-connecting-wc-web></w3m-connecting-wc-web>`)
+
+    // Verify the button is disabled
+    const button = element.shadowRoot?.querySelector('wui-button')
+    expect(button?.hasAttribute('disabled')).toBe(true)
+
+    // Simulate clicking the button
+    button?.click()
+
+    // Verify no actions are performed
+    expect(CoreHelperUtil.openHref).not.toHaveBeenCalled()
+  })
+}) 

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-web.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-web.test.ts
@@ -92,4 +92,4 @@ describe('W3mConnectingWcWeb', () => {
     // Verify no actions are performed
     expect(CoreHelperUtil.openHref).not.toHaveBeenCalled()
   })
-}) 
+})

--- a/w3m-connecting-wc-web.ts.new
+++ b/w3m-connecting-wc-web.ts.new
@@ -1,1 +1,0 @@
-404: Not Found

--- a/w3m-connecting-wc-web.ts.new
+++ b/w3m-connecting-wc-web.ts.new
@@ -1,0 +1,1 @@
+404: Not Found


### PR DESCRIPTION
# Description

Web wallets can only be opened once a connection to WalletConnect has been established. Currently the UX is confusing as the button can be clicked whilst loading with no effect. This change disables the button until it is actually clickable.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)


https://github.com/user-attachments/assets/5eae7635-51b5-449b-a552-ea47dba9020a



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
