### PR TITLE
fix/remove filter namesspace when switching active namespace

### DIFF
--- a/.changeset/nice-cloths-battle.md
+++ b/.changeset/nice-cloths-battle.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes redundant namespace filter while switching between networks

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -322,7 +322,6 @@ export const ChainController = {
 
     if (state.activeChain !== caipNetwork.chainNamespace) {
       this.setIsSwitchingNamespace(true)
-      ConnectorController.setFilterByNamespace(caipNetwork.chainNamespace)
     }
 
     const newAdapter = state.chains.get(caipNetwork.chainNamespace)

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -287,6 +287,7 @@ export const ConnectionController = {
       await SIWXUtil.clearSessions()
       await ChainController.disconnect(namespace)
       ModalController.setLoading(false, namespace)
+      ConnectorController.setFilterByNamespace(undefined)
     } catch (error) {
       throw new Error('Failed to disconnect')
     }

--- a/packages/controllers/tests/controllers/ConnectionController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectionController.test.ts
@@ -191,6 +191,7 @@ describe('ConnectionController', () => {
     const setLoadingSpy = vi.spyOn(ModalController, 'setLoading')
     const clearSessionsSpy = vi.spyOn(SIWXUtil, 'clearSessions')
     const disconnectSpy = vi.spyOn(ChainController, 'disconnect')
+    const setFilterByNamespaceSpy = vi.spyOn(ConnectorController, 'setFilterByNamespace')
 
     await ConnectionController.disconnect()
 
@@ -200,6 +201,7 @@ describe('ConnectionController', () => {
     expect(setLoadingSpy).toHaveBeenCalledWith(false, undefined)
     expect(ConnectionController.state.wcUri).toEqual(undefined)
     expect(ConnectionController.state.wcPairingExpiry).toEqual(undefined)
+    expect(setFilterByNamespaceSpy).toHaveBeenCalledWith(undefined)
   })
 
   it('should disconnect only for specific namespace', async () => {


### PR DESCRIPTION
# Description

We have `setFilterNamespace` call in the `ChainController.setCaipNetwork`, where this causes unnecessary namespace filter when we switch between networks. This is resulting AppKit embed version (demo.reown.com) to have an issue when you connect and disconnect, you only see the connectors of the last connected namespace. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
