### PR TITLE
chore: Fix regex to support version prefixes and build suffixes

### DIFF
--- a/examples/html-wagmi-cdn/inject-cdn-version.js
+++ b/examples/html-wagmi-cdn/inject-cdn-version.js
@@ -12,7 +12,7 @@ const mainJsPath = path.join(__dirname, 'src/main.js')
 let mainJsContent = fs.readFileSync(mainJsPath, 'utf8')
 
 // Regular expression to match both __VERSION__ and any semver version
-const versionRegex = /@reown\/appkit-cdn@(__VERSION__|[\d.]+)/
+const versionRegex = /@reown\/appkit-cdn@(__VERSION__|[\d]+\.[\d]+\.[\d]+(-[\w\.]+)?(\+[\w\.]+)?)/;
 
 if (versionRegex.test(mainJsContent)) {
   mainJsContent = mainJsContent.replace(versionRegex, `@reown/appkit-cdn@${appkitVersion}`)


### PR DESCRIPTION
# Description

I’ve updated the regular expression to handle version strings with optional prefixes (like `-beta`) and build suffixes (like `+build`). This fix ensures better compatibility with version formats commonly used in deployment workflows. Here’s the updated regex:

```javascript
const versionRegex = /@reown\/appkit-cdn@(__VERSION__|[\d]+\.[\d]+\.[\d]+(-[\w\.]+)?(\+[\w\.]+)?)/;
```

This now correctly matches:
- Core version (e.g., 1.2.3)
- Optional prefix labels (e.g., `-beta`)
- Optional build labels (e.g., `+build`) 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
