### PR TITLE
fix: coinbase multichain not working

### DIFF
--- a/.changeset/twelve-months-hammer.md
+++ b/.changeset/twelve-months-hammer.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where Coinbase Wallet wasn't working with multichain

--- a/apps/laboratory/tests/shared/utils/project.ts
+++ b/apps/laboratory/tests/shared/utils/project.ts
@@ -63,6 +63,7 @@ const SINGLE_ADAPTER_EVM_TESTS = [
   'wallet-features.spec.ts',
   'wallet.spec.ts',
   'wallet-button.spec',
+  'verify.spec.ts',
   'email-after-farcaster.spec.ts'
 ]
 

--- a/apps/laboratory/tests/shared/utils/project.ts
+++ b/apps/laboratory/tests/shared/utils/project.ts
@@ -63,7 +63,6 @@ const SINGLE_ADAPTER_EVM_TESTS = [
   'wallet-features.spec.ts',
   'wallet.spec.ts',
   'wallet-button.spec',
-  'verify.spec.ts',
   'email-after-farcaster.spec.ts'
 ]
 

--- a/packages/adapters/solana/src/providers/CoinbaseWalletProvider.ts
+++ b/packages/adapters/solana/src/providers/CoinbaseWalletProvider.ts
@@ -1,6 +1,7 @@
 import type { Connection, PublicKey, SendOptions } from '@solana/web3.js'
 
 import { type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
+import { ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 import type { RequestArguments } from '@reown/appkit-controllers'
 import type { Provider as CoreProvider } from '@reown/appkit-controllers'
 import { PresetsUtil } from '@reown/appkit-utils'
@@ -57,6 +58,10 @@ export class CoinbaseWalletProvider extends ProviderEventEmitter implements Sola
 
   public get publicKey() {
     return this.coinbase.publicKey
+  }
+
+  public get imageId() {
+    return PresetsUtil.ConnectorImageIds[CommonConstantsUtil.CONNECTOR_ID.COINBASE]
   }
 
   public async connect() {

--- a/packages/adapters/solana/src/tests/providers/CoinbaseWalletProvider.test.ts
+++ b/packages/adapters/solana/src/tests/providers/CoinbaseWalletProvider.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { type CaipNetwork, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
+import { PresetsUtil } from '@reown/appkit-utils'
+import { mainnet } from '@reown/appkit/networks'
+
+import {
+  CoinbaseWalletProvider,
+  type SolanaCoinbaseWallet
+} from '../../providers/CoinbaseWalletProvider'
+
+describe('CoinbaseWalletProvider', () => {
+  it('should have correct properties', () => {
+    const mockProvider = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      on: vi.fn(),
+      removeListener: vi.fn()
+    }
+
+    const provider = new CoinbaseWalletProvider({
+      provider: mockProvider as unknown as SolanaCoinbaseWallet,
+      chains: [],
+      getActiveChain: () => mainnet as unknown as CaipNetwork
+    })
+
+    expect(provider.name).toBe('Coinbase Wallet')
+    expect(provider.type).toBe('ANNOUNCED')
+    expect(provider.chain).toBe('solana')
+    expect(provider.imageUrl).toBeDefined()
+
+    const expectedImageId = PresetsUtil.ConnectorImageIds[CommonConstantsUtil.CONNECTOR_ID.COINBASE]
+    expect(provider.imageId).toBe(expectedImageId)
+
+    const expectedId =
+      PresetsUtil.ConnectorExplorerIds[CommonConstantsUtil.CONNECTOR_ID.COINBASE_SDK]
+
+    expect(provider.id).toBe(expectedId)
+  })
+})

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -656,9 +656,12 @@ export const ChainController = {
       const disconnectResults = await Promise.allSettled(
         chainsToDisconnect.map(async ([ns, adapter]) => {
           try {
-            if (adapter.connectionControllerClient?.disconnect) {
+            const { caipAddress } = this.getAccountData(ns) || {}
+
+            if (caipAddress && adapter.connectionControllerClient?.disconnect) {
               await adapter.connectionControllerClient.disconnect(ns)
             }
+
             this.resetAccount(ns)
             this.resetNetwork(ns)
           } catch (error) {

--- a/packages/controllers/src/controllers/ConnectorController.ts
+++ b/packages/controllers/src/controllers/ConnectorController.ts
@@ -224,9 +224,12 @@ export const ConnectorController = {
   getConnectorById(id: string) {
     return state.allConnectors.find(c => c.id === id)
   },
-
   getConnector(id: string, rdns?: string | null) {
-    return state.allConnectors.find(c => c.explorerId === id || c.info?.rdns === rdns)
+    const connectorsByNamespace = state.allConnectors.filter(
+      c => c.chain === ChainController.state.activeChain
+    )
+
+    return connectorsByNamespace.find(c => c.explorerId === id || c.info?.rdns === rdns)
   },
 
   syncIfAuthConnector(connector: Connector | AuthConnector) {

--- a/packages/controllers/tests/controllers/ChainController.test.ts
+++ b/packages/controllers/tests/controllers/ChainController.test.ts
@@ -9,7 +9,11 @@ import {
 } from '@reown/appkit-common'
 import { SafeLocalStorage } from '@reown/appkit-common'
 
-import type { NetworkControllerClient } from '../../exports/index.js'
+import type {
+  ChainAdapter,
+  ChainControllerState,
+  NetworkControllerClient
+} from '../../exports/index.js'
 import { ChainController } from '../../src/controllers/ChainController.js'
 import { type ConnectionControllerClient } from '../../src/controllers/ConnectionController.js'
 import { ConnectionController } from '../../src/controllers/ConnectionController.js'
@@ -405,6 +409,18 @@ describe('ChainController', () => {
         networkControllerClient
       }
     )
+    ChainController.state.chains.set(ConstantsUtil.CHAIN.EVM, {
+      ...evmAdapterCustom,
+      accountState: {
+        caipAddress: 'eip155:1'
+      }
+    } as unknown as ChainAdapter)
+    ChainController.state.chains.set(ConstantsUtil.CHAIN.SOLANA, {
+      ...solanaAdapterCustom,
+      accountState: {
+        caipAddress: 'solana:1'
+      }
+    } as unknown as ChainAdapter)
 
     await ChainController.disconnect()
 
@@ -449,6 +465,13 @@ describe('ChainController', () => {
       connectionControllerClient: evmConnectionController,
       networkControllerClient
     })
+
+    ChainController.state.chains.set(ConstantsUtil.CHAIN.EVM, {
+      ...customEvmAdapter,
+      accountState: {
+        caipAddress: 'eip155:1'
+      }
+    } as unknown as ChainAdapter)
 
     await ChainController.disconnect()
 

--- a/packages/controllers/tests/controllers/ChainController.test.ts
+++ b/packages/controllers/tests/controllers/ChainController.test.ts
@@ -9,11 +9,7 @@ import {
 } from '@reown/appkit-common'
 import { SafeLocalStorage } from '@reown/appkit-common'
 
-import type {
-  ChainAdapter,
-  ChainControllerState,
-  NetworkControllerClient
-} from '../../exports/index.js'
+import type { ChainAdapter, NetworkControllerClient } from '../../exports/index.js'
 import { ChainController } from '../../src/controllers/ChainController.js'
 import { type ConnectionControllerClient } from '../../src/controllers/ConnectionController.js'
 import { ConnectionController } from '../../src/controllers/ConnectionController.js'

--- a/packages/controllers/tests/controllers/ConnectionController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectionController.test.ts
@@ -247,6 +247,11 @@ describe('ConnectionController', () => {
       polkadot: 'polkadot-connector',
       bip122: CommonConstantsUtil.CONNECTOR_ID.WALLET_CONNECT
     }
+    ChainController.state.chains.set('eip155', {
+      accountState: {
+        caipAddress: 'eip155:1'
+      }
+    } as unknown as ChainAdapter)
     const setLoadingSpy = vi.spyOn(ModalController, 'setLoading')
     const clearSessionsSpy = vi.spyOn(SIWXUtil, 'clearSessions')
     const disconnectSpy = vi.spyOn(ChainController, 'disconnect')
@@ -278,6 +283,17 @@ describe('ConnectionController', () => {
       polkadot: 'polkadot-connector',
       bip122: 'bip122-connector'
     }
+    ChainController.state.chains.set('eip155', {
+      accountState: {
+        caipAddress: 'eip155:1'
+      }
+    } as unknown as ChainAdapter)
+    ChainController.state.chains.set('solana', {
+      accountState: {
+        caipAddress: 'solana:1'
+      }
+    } as unknown as ChainAdapter)
+
     const setLoadingSpy = vi.spyOn(ModalController, 'setLoading')
     const clearSessionsSpy = vi.spyOn(SIWXUtil, 'clearSessions')
     const disconnectSpy = vi.spyOn(ChainController, 'disconnect')

--- a/packages/controllers/tests/controllers/ConnectorController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectorController.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConstantsUtil, getW3mThemeVariables } from '@reown/appkit-common'
 
@@ -102,9 +102,14 @@ const zerionConnector = {
 
 // -- Tests --------------------------------------------------------------------
 describe('ConnectorController', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     ChainController.state.activeChain = ConstantsUtil.CHAIN.EVM
   })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should have valid default state', () => {
     expect(ConnectorController.state.connectors).toEqual([])
   })
@@ -122,6 +127,38 @@ describe('ConnectorController', () => {
         connectors: [walletConnectConnector, walletConnectSolanaConnector]
       }
     ])
+  })
+
+  it('should find connector by active namespace only', () => {
+    const EVM_EXPLORER_ID = 'evm-explorer-id'
+    const SOLANA_EXPLORER_ID = 'solana-explorer-id'
+
+    const evmConnector = {
+      id: 'evm-connector',
+      explorerId: EVM_EXPLORER_ID,
+      type: 'INJECTED',
+      chain: ConstantsUtil.CHAIN.EVM,
+      name: 'EVM Connector'
+    } as const
+
+    const solanaConnector = {
+      id: 'solana-connector',
+      explorerId: SOLANA_EXPLORER_ID,
+      type: 'INJECTED',
+      chain: ConstantsUtil.CHAIN.SOLANA,
+      name: 'Solana Connector'
+    } as const
+
+    ConnectorController.setConnectors([evmConnector, solanaConnector])
+    ChainController.state.activeChain = ConstantsUtil.CHAIN.EVM
+
+    expect(ConnectorController.getConnector(EVM_EXPLORER_ID, '')).toEqual(evmConnector)
+    expect(ConnectorController.getConnector(SOLANA_EXPLORER_ID, '')).toBeUndefined()
+
+    ChainController.setActiveNamespace(ConstantsUtil.CHAIN.SOLANA)
+
+    expect(ConnectorController.getConnector(SOLANA_EXPLORER_ID, '')).toEqual(solanaConnector)
+    expect(ConnectorController.getConnector(EVM_EXPLORER_ID, '')).toBeUndefined()
   })
 
   it('should update state correctly on setConnectors()', () => {


### PR DESCRIPTION
# Description

When using multichain to connect to Coinbase with Ethereum, there’s a bug where the active namespace isn’t properly checked which causes it to connect to the Coinbase Solana wallet instead.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2547

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
