### PR TITLE
refactor: switch to CAIP network id for `customRpcUrls` prop

### DIFF
--- a/.changeset/lemon-forks-appear.md
+++ b/.changeset/lemon-forks-appear.md
@@ -29,8 +29,8 @@ Define your map of chain ID / URL objects:
 
 ```jsx
 const customRpcUrls = {
-  1: [{ url: 'https://your-custom-mainnet-url.com' }],
-  137: [{ url: 'https://your-custom-polygon-url.com' }]
+  "eip155:1": [{ url: 'https://your-custom-mainnet-url.com' }],
+  "eip155:137": [{ url: 'https://your-custom-polygon-url.com' }]
 }
 ```
 
@@ -59,7 +59,7 @@ If you need to pass fetch configs for your transport, you can use `config` prope
 
 ```jsx
 const customRpcUrls = {
-  1: [
+  "eip155:1": [
     {
       url: "https://your-custom-mainnet-url.com",
       config: {

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -36,7 +36,7 @@ import type {
   BaseNetwork,
   CaipNetwork,
   ChainNamespace,
-  CustomRpcUrl
+  CustomRpcUrlMap
 } from '@reown/appkit-common'
 import {
   ConstantsUtil as CommonConstantsUtil,
@@ -84,7 +84,7 @@ export class WagmiAdapter extends AdapterBlueprint {
       networks: AppKitNetwork[]
       pendingTransactionsFilter?: PendingTransactionsFilter
       projectId: string
-      customRpcUrls?: Record<string | number, CustomRpcUrl[]>
+      customRpcUrls?: CustomRpcUrlMap
     }
   ) {
     const networks = CaipNetworksUtil.extendCaipNetworks(configParams.networks, {
@@ -145,7 +145,7 @@ export class WagmiAdapter extends AdapterBlueprint {
     configParams: Partial<CreateConfigParameters> & {
       networks: CaipNetwork[]
       projectId: string
-      customRpcUrls?: Record<string | number, CustomRpcUrl[]>
+      customRpcUrls?: CustomRpcUrlMap
     }
   ) {
     this.caipNetworks = configParams.networks
@@ -158,6 +158,7 @@ export class WagmiAdapter extends AdapterBlueprint {
 
     this.wagmiChains.forEach(element => {
       const fromTransportProp = configParams.transports?.[element.id]
+      const caipNetworkId = CaipNetworksUtil.getCaipNetworkId(element)
 
       if (fromTransportProp) {
         transports[element.id] = CaipNetworksUtil.extendWagmiTransports(
@@ -169,7 +170,7 @@ export class WagmiAdapter extends AdapterBlueprint {
         transports[element.id] = CaipNetworksUtil.getViemTransport(
           element as CaipNetwork,
           configParams.projectId,
-          configParams.customRpcUrls?.[element.id]
+          configParams.customRpcUrls?.[caipNetworkId]
         )
       }
     })

--- a/packages/appkit-utils/src/CaipNetworkUtil.ts
+++ b/packages/appkit-utils/src/CaipNetworkUtil.ts
@@ -5,7 +5,8 @@ import {
   type CaipNetwork,
   type CaipNetworkId,
   ConstantsUtil,
-  type CustomRpcUrl
+  type CustomRpcUrl,
+  type CustomRpcUrlMap
 } from '@reown/appkit-common'
 
 import { PresetsUtil } from './PresetsUtil.js'
@@ -65,7 +66,7 @@ type ExtendCaipNetworkParams = {
   customNetworkImageUrls: Record<number | string, string> | undefined
   projectId: string
   customRpc?: boolean
-  customRpcUrls?: Record<string | number, CustomRpcUrl[]>
+  customRpcUrls?: CustomRpcUrlMap
 }
 
 export const CaipNetworksUtil = {
@@ -150,7 +151,7 @@ export const CaipNetworksUtil = {
 
     const chainDefaultRpcUrl =
       caipNetwork?.rpcUrls?.['chainDefault']?.http?.[0] || networkDefaultRpcUrl
-    const customRpcUrlsOfNetwork = customRpcUrls?.[caipNetwork.id]?.map(i => i.url) || []
+    const customRpcUrlsOfNetwork = customRpcUrls?.[caipNetworkId]?.map(i => i.url) || []
 
     const rpcUrls = [...customRpcUrlsOfNetwork, reownRpcUrl]
     const rpcUrlsWithoutReown = [...customRpcUrlsOfNetwork]

--- a/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
+++ b/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
@@ -1,7 +1,7 @@
 import { http } from 'viem'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { type AppKitNetwork } from '@reown/appkit-common'
+import { type AppKitNetwork, type CustomRpcUrlMap } from '@reown/appkit-common'
 
 import { CaipNetworksUtil } from '../src/CaipNetworkUtil'
 
@@ -171,8 +171,8 @@ describe('CaipNetworksUtil', () => {
     const customNetworkImageUrls = {
       1: 'https://example.com/eth.png'
     }
-    const customRpcUrls = {
-      1: [{ url: 'https://custom.eth.example.com' }]
+    const customRpcUrls: CustomRpcUrlMap = {
+      'eip155:1': [{ url: 'https://custom.eth.example.com' }]
     }
 
     it('should extend network with all required properties', () => {

--- a/packages/common/src/utils/TypeUtil.ts
+++ b/packages/common/src/utils/TypeUtil.ts
@@ -21,7 +21,7 @@ export type CaipNetwork<
   }
 }
 
-export type CustomRpcUrlMap = Record<string | number, CustomRpcUrl[]>
+export type CustomRpcUrlMap = Record<CaipNetworkId, CustomRpcUrl[]>
 
 export type CustomRpcUrl = {
   url: string


### PR DESCRIPTION
# Description

Switches to CAIP network id for `customRpcUrls` property.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
