### PR TITLE
fix: open `AllWallets` view on mobile when using WC wallet button

### DIFF
--- a/.changeset/fancy-falcons-knock.md
+++ b/.changeset/fancy-falcons-knock.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-wallet-button': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+---
+
+Fixed an issue where the WalletConnect wallet button wasn't opening the "All Wallets" modal view on mobile devices

--- a/packages/wallet-button/src/tests/scaffold-ui/appkit-wallet-button.test.ts
+++ b/packages/wallet-button/src/tests/scaffold-ui/appkit-wallet-button.test.ts
@@ -7,6 +7,7 @@ import { ParseUtil } from '@reown/appkit-common'
 import {
   ChainController,
   ConnectorController,
+  CoreHelperUtil,
   ModalController,
   RouterController,
   type WcWallet
@@ -41,6 +42,7 @@ describe('AppKitWalletButton', () => {
   })
 
   beforeEach(() => {
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
     ChainController.state.activeCaipAddress = undefined
   })
 
@@ -100,6 +102,12 @@ describe('AppKitWalletButton', () => {
   })
 
   test('should connect with walletConnect', async () => {
+    vi.spyOn(ParseUtil, 'parseCaipAddress').mockReturnValue({
+      chainNamespace: 'eip155',
+      chainId: 1,
+      address: '0x123'
+    })
+
     const element: AppKitWalletButton = await fixture(
       html`<appkit-wallet-button wallet="metamask"></appkit-wallet-button>`
     )
@@ -124,7 +132,7 @@ describe('AppKitWalletButton', () => {
 
     walletButton.addEventListener('click', walletButtonClick)
 
-    walletButton.click()
+    await walletButton.click()
 
     element.requestUpdate()
     await elementUpdated(element)
@@ -161,6 +169,16 @@ describe('AppKitWalletButton', () => {
 
     expect(walletButton.getAttribute('disabled')).not.toBeNull()
     expect(walletButton.getAttribute('loading')).toBeNull()
+
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+
+    element.requestUpdate()
+    await elementUpdated(element)
+
+    await walletButton.click()
+
+    expect(ModalControllerOpenSpy).toHaveBeenCalled()
+    expect(RouterControllerPushSpy).toHaveBeenCalledWith('AllWallets')
   })
 
   test('should connect with external connector', async () => {

--- a/packages/wallet-button/src/tests/scaffold-ui/appkit-wallet-button.test.ts
+++ b/packages/wallet-button/src/tests/scaffold-ui/appkit-wallet-button.test.ts
@@ -126,7 +126,7 @@ describe('AppKitWalletButton', () => {
         ModalController.state.open = true
       })
 
-    const RouterControllerPushSpy = vi.spyOn(RouterController, 'push')
+    const RouterControllerReplaceSpy = vi.spyOn(RouterController, 'replace')
 
     const walletButtonClick = vi.fn()
 
@@ -142,7 +142,7 @@ describe('AppKitWalletButton', () => {
 
     expect(walletButtonClick).toHaveBeenCalledOnce()
     expect(ModalControllerOpenSpy).toHaveBeenCalled()
-    expect(RouterControllerPushSpy).toHaveBeenCalledWith('ConnectingWalletConnect', {
+    expect(RouterControllerReplaceSpy).toHaveBeenCalledWith('ConnectingWalletConnect', {
       wallet: MetaMask
     })
 
@@ -162,23 +162,34 @@ describe('AppKitWalletButton', () => {
 
     expect(parseCaipAddressSpy).toHaveBeenCalledWith(caipAddress)
     expect(ModalControllerCloseSpy).toHaveBeenCalled()
-    expect(RouterControllerPushSpy).toHaveBeenCalledWith('Connect')
+    expect(RouterControllerReplaceSpy).toHaveBeenCalledWith('Connect')
 
     element.requestUpdate()
     await elementUpdated(element)
 
     expect(walletButton.getAttribute('disabled')).not.toBeNull()
     expect(walletButton.getAttribute('loading')).toBeNull()
+  })
 
+  test('should redirect to all wallets on mobile if walletConnect is selected', async () => {
     vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+    vi.spyOn(ModalController, 'open').mockResolvedValue()
+    const RouterControllerReplaceSpy = vi.spyOn(RouterController, 'replace')
 
-    element.requestUpdate()
-    await elementUpdated(element)
+    const element: AppKitWalletButton = await fixture(
+      html`<appkit-wallet-button wallet="walletConnect"></appkit-wallet-button>`
+    )
+
+    const walletButton = HelpersUtil.getByTestId(element, WALLET_BUTTON)
+
+    const walletButtonClick = vi.fn()
+
+    walletButton.addEventListener('click', walletButtonClick)
 
     await walletButton.click()
 
-    expect(ModalControllerOpenSpy).toHaveBeenCalled()
-    expect(RouterControllerPushSpy).toHaveBeenCalledWith('AllWallets')
+    expect(walletButtonClick).toHaveBeenCalled()
+    expect(RouterControllerReplaceSpy).toHaveBeenCalledWith('AllWallets')
   })
 
   test('should connect with external connector', async () => {

--- a/packages/wallet-button/src/utils/ConnectorUtil.ts
+++ b/packages/wallet-button/src/utils/ConnectorUtil.ts
@@ -41,9 +41,13 @@ export const ConnectorUtil = {
 
       await ModalController.open()
 
-      RouterController.push(CoreHelperUtil.isMobile() ? 'AllWallets' : 'ConnectingWalletConnect', {
-        wallet
-      })
+      if (CoreHelperUtil.isMobile()) {
+        RouterController.push('AllWallets')
+      } else {
+        RouterController.push('ConnectingWalletConnect', {
+          wallet
+        })
+      }
 
       const unsubscribeModalController = ModalController.subscribeKey('open', val => {
         if (!val) {

--- a/packages/wallet-button/src/utils/ConnectorUtil.ts
+++ b/packages/wallet-button/src/utils/ConnectorUtil.ts
@@ -41,10 +41,10 @@ export const ConnectorUtil = {
 
       await ModalController.open()
 
-      if (CoreHelperUtil.isMobile()) {
-        RouterController.push('AllWallets')
+      if (CoreHelperUtil.isMobile() && walletConnect) {
+        RouterController.replace('AllWallets')
       } else {
-        RouterController.push('ConnectingWalletConnect', {
+        RouterController.replace('ConnectingWalletConnect', {
           wallet
         })
       }
@@ -52,7 +52,7 @@ export const ConnectorUtil = {
       const unsubscribeModalController = ModalController.subscribeKey('open', val => {
         if (!val) {
           if (RouterController.state.view !== 'Connect') {
-            RouterController.push('Connect')
+            RouterController.replace('Connect')
           }
           unsubscribeModalController()
           reject(new Error('Modal closed'))

--- a/packages/wallet-button/src/utils/ConnectorUtil.ts
+++ b/packages/wallet-button/src/utils/ConnectorUtil.ts
@@ -40,7 +40,10 @@ export const ConnectorUtil = {
       }
 
       await ModalController.open()
-      RouterController.push('ConnectingWalletConnect', { wallet })
+
+      RouterController.push(CoreHelperUtil.isMobile() ? 'AllWallets' : 'ConnectingWalletConnect', {
+        wallet
+      })
 
       const unsubscribeModalController = ModalController.subscribeKey('open', val => {
         if (!val) {


### PR DESCRIPTION
# Description

Fixed an issue where the WalletConnect wallet button wasn't opening the "All Wallets" modal view on mobile devices

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2511

# Showcase (Optional)

Uploading repro.mov…

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
