### PR TITLE
fix: legal checkbox double confirmation

### DIFF
--- a/.changeset/tame-views-fall.md
+++ b/.changeset/tame-views-fall.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where users were required to re-check the legal checkbox after navigating away and returning to the connect view

--- a/packages/controllers/exports/index.ts
+++ b/packages/controllers/exports/index.ts
@@ -73,6 +73,9 @@ export type { EnsControllerState } from '../src/controllers/EnsController.js'
 export { AlertController } from '../src/controllers/AlertController.js'
 export type { AlertControllerState } from '../src/controllers/AlertController.js'
 
+export { OptionsStateController } from '../src/controllers/OptionsStateController.js'
+export type { OptionsStateControllerState } from '../src/controllers/OptionsStateController.js'
+
 // -- Utils -------------------------------------------------------------------
 export { AssetUtil } from '../src/utils/AssetUtil.js'
 export { ConstantsUtil } from '../src/utils/ConstantsUtil.js'

--- a/packages/controllers/src/controllers/OptionsStateController.ts
+++ b/packages/controllers/src/controllers/OptionsStateController.ts
@@ -1,0 +1,34 @@
+import { proxy, subscribe as sub } from 'valtio/vanilla'
+import { subscribeKey as subKey } from 'valtio/vanilla/utils'
+
+// -- Types --------------------------------------------- //
+export interface OptionsStateControllerState {
+  isLegalCheckboxChecked: boolean
+}
+
+type StateKey = keyof OptionsStateControllerState
+
+// -- State --------------------------------------------- //
+const state = proxy<OptionsStateControllerState>({
+  isLegalCheckboxChecked: false
+})
+
+// -- Controller ---------------------------------------- //
+export const OptionsStateController = {
+  state,
+
+  subscribe(callback: (newState: OptionsStateControllerState) => void) {
+    return sub(state, () => callback(state))
+  },
+
+  subscribeKey<K extends StateKey>(
+    key: K,
+    callback: (value: OptionsStateControllerState[K]) => void
+  ) {
+    return subKey(state, key, callback)
+  },
+
+  setIsLegalCheckboxChecked(isLegalCheckboxChecked: boolean) {
+    state.isLegalCheckboxChecked = isLegalCheckboxChecked
+  }
+}

--- a/packages/scaffold-ui/src/partials/w3m-legal-checkbox/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-legal-checkbox/index.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from 'lit'
+import { state } from 'lit/decorators.js'
 
-import { OptionsController } from '@reown/appkit-controllers'
+import { OptionsController, OptionsStateController } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-checkbox'
 import '@reown/appkit-ui/wui-text'
@@ -10,6 +11,26 @@ import styles from './styles.js'
 @customElement('w3m-legal-checkbox')
 export class W3mLegalCheckbox extends LitElement {
   public static override styles = [styles]
+
+  // -- Members ------------------------------------------- //
+  private unsubscribe: (() => void)[] = []
+
+  // -- State & Properties -------------------------------- //
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
+
+  // -- Lifecycle ----------------------------------------- //
+  public constructor() {
+    super()
+    this.unsubscribe.push(
+      OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => {
+        this.checked = val
+      })
+    )
+  }
+
+  public override disconnectedCallback() {
+    this.unsubscribe.forEach(unsubscribe => unsubscribe())
+  }
 
   // -- Render -------------------------------------------- //
   public override render() {
@@ -26,7 +47,11 @@ export class W3mLegalCheckbox extends LitElement {
     }
 
     return html`
-      <wui-checkbox data-testid="wui-checkbox">
+      <wui-checkbox
+        ?checked=${this.checked}
+        @checkboxChange=${this.onCheckboxChange.bind(this)}
+        data-testid="wui-checkbox"
+      >
         <wui-text color="fg-250" variant="small-400" align="left">
           I agree to our ${this.termsTemplate()} ${this.andTemplate()} ${this.privacyTemplate()}
         </wui-text>
@@ -59,6 +84,10 @@ export class W3mLegalCheckbox extends LitElement {
     }
 
     return html`<a rel="noreferrer" target="_blank" href=${privacyPolicyUrl}>privacy policy</a>`
+  }
+
+  private onCheckboxChange() {
+    OptionsStateController.setIsLegalCheckboxChecked(!this.checked)
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-connect-socials-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connect-socials-view/index.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 
-import { OptionsController } from '@reown/appkit-controllers'
+import { OptionsController, OptionsStateController } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 
@@ -15,7 +15,24 @@ import styles from './styles.js'
 export class W3mConnectSocialsView extends LitElement {
   public static override styles = styles
 
-  @state() private checked = false
+  // -- Members ------------------------------------------- //
+  private unsubscribe: (() => void)[] = []
+
+  // -- State & Properties -------------------------------- //
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
+
+  public constructor() {
+    super()
+    this.unsubscribe.push(
+      OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => {
+        this.checked = val
+      })
+    )
+  }
+
+  public override disconnectedCallback() {
+    this.unsubscribe.forEach(unsubscribe => unsubscribe())
+  }
 
   // -- Render -------------------------------------------- //
   public override render() {
@@ -31,7 +48,7 @@ export class W3mConnectSocialsView extends LitElement {
     const tabIndex = disabled ? -1 : undefined
 
     return html`
-      <w3m-legal-checkbox @checkboxChange=${this.onCheckboxChange.bind(this)}></w3m-legal-checkbox>
+      <w3m-legal-checkbox></w3m-legal-checkbox>
       <wui-flex
         flexDirection="column"
         .padding=${showLegalCheckbox ? ['0', 's', 's', 's'] : 's'}
@@ -42,11 +59,6 @@ export class W3mConnectSocialsView extends LitElement {
       </wui-flex>
       <w3m-legal-footer></w3m-legal-footer>
     `
-  }
-
-  // -- Private Methods ----------------------------------- //
-  private onCheckboxChange(event: CustomEvent<string>) {
-    this.checked = Boolean(event.detail)
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connect-view/index.ts
@@ -13,6 +13,7 @@ import {
   CoreHelperUtil,
   type Features,
   OptionsController,
+  OptionsStateController,
   RouterController,
   type WalletGuideType
 } from '@reown/appkit-controllers'
@@ -54,7 +55,7 @@ export class W3mConnectView extends LitElement {
 
   @property() private walletGuide: WalletGuideType = 'get-started'
 
-  @state() private checked = false
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
 
   @state() private isEmailEnabled = this.features?.email && !ChainController.state.noAdapters
 
@@ -79,7 +80,8 @@ export class W3mConnectView extends LitElement {
       OptionsController.subscribeKey('enableWallets', val => (this.enableWallets = val)),
       ChainController.subscribeKey('noAdapters', val =>
         this.setEmailAndSocialEnableCheck(this.features, val)
-      )
+      ),
+      OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => (this.checked = val))
     )
   }
 
@@ -350,10 +352,7 @@ export class W3mConnectView extends LitElement {
       return null
     }
 
-    return html`<w3m-legal-checkbox
-      @checkboxChange=${this.onCheckboxChange.bind(this)}
-      data-testid="w3m-legal-checkbox"
-    ></w3m-legal-checkbox>`
+    return html`<w3m-legal-checkbox data-testid="w3m-legal-checkbox"></w3m-legal-checkbox>`
   }
 
   private handleConnectListScroll() {
@@ -401,10 +400,6 @@ export class W3mConnectView extends LitElement {
   // -- Private Methods ----------------------------------- //
   private onContinueWalletClick() {
     RouterController.push('ConnectWallets')
-  }
-
-  private onCheckboxChange(event: CustomEvent<string>) {
-    this.checked = Boolean(event.detail)
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-connect-wallets-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connect-wallets-view/index.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 import { ifDefined } from 'lit/directives/if-defined.js'
 
-import { OptionsController } from '@reown/appkit-controllers'
+import { OptionsController, OptionsStateController } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 
@@ -15,7 +15,24 @@ import styles from './styles.js'
 export class W3mConnectWalletsView extends LitElement {
   public static override styles = styles
 
-  @state() private checked = false
+  // -- Members ------------------------------------------- //
+  private unsubscribe: (() => void)[] = []
+
+  // -- State & Properties -------------------------------- //
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
+
+  public constructor() {
+    super()
+    this.unsubscribe.push(
+      OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => {
+        this.checked = val
+      })
+    )
+  }
+
+  public override disconnectedCallback() {
+    this.unsubscribe.forEach(unsubscribe => unsubscribe())
+  }
 
   // -- Render -------------------------------------------- //
   public override render() {
@@ -31,7 +48,7 @@ export class W3mConnectWalletsView extends LitElement {
     const tabIndex = disabled ? -1 : undefined
 
     return html`
-      <w3m-legal-checkbox @checkboxChange=${this.onCheckboxChange.bind(this)}></w3m-legal-checkbox>
+      <w3m-legal-checkbox></w3m-legal-checkbox>
       <wui-flex
         flexDirection="column"
         .padding=${showLegalCheckbox ? ['0', 's', 's', 's'] : 's'}
@@ -42,11 +59,6 @@ export class W3mConnectWalletsView extends LitElement {
       </wui-flex>
       <w3m-legal-footer></w3m-legal-footer>
     `
-  }
-
-  // -- Private Methods ----------------------------------- //
-  private onCheckboxChange(event: CustomEvent<string>) {
-    this.checked = Boolean(event.detail)
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-onramp-fiat-select-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-onramp-fiat-select-view/index.ts
@@ -6,7 +6,8 @@ import {
   AssetController,
   ModalController,
   OnRampController,
-  OptionsController
+  OptionsController,
+  OptionsStateController
 } from '@reown/appkit-controllers'
 import type { PaymentCurrency } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
@@ -29,7 +30,7 @@ export class W3mOnrampFiatSelectView extends LitElement {
   @state() public selectedCurrency = OnRampController.state.paymentCurrency
   @state() public currencies = OnRampController.state.paymentCurrencies
   @state() private currencyImages = AssetController.state.currencyImages
-  @state() private checked = false
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
 
   public constructor() {
     super()
@@ -39,7 +40,10 @@ export class W3mOnrampFiatSelectView extends LitElement {
           this.selectedCurrency = val.paymentCurrency
           this.currencies = val.paymentCurrencies
         }),
-        AssetController.subscribeKey('currencyImages', val => (this.currencyImages = val))
+        AssetController.subscribeKey('currencyImages', val => (this.currencyImages = val)),
+        OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => {
+          this.checked = val
+        })
       ]
     )
   }
@@ -60,7 +64,7 @@ export class W3mOnrampFiatSelectView extends LitElement {
     const disabled = showLegalCheckbox && !this.checked
 
     return html`
-      <w3m-legal-checkbox @checkboxChange=${this.onCheckboxChange.bind(this)}></w3m-legal-checkbox>
+      <w3m-legal-checkbox></w3m-legal-checkbox>
       <wui-flex
         flexDirection="column"
         .padding=${['0', 's', 's', 's']}
@@ -96,11 +100,6 @@ export class W3mOnrampFiatSelectView extends LitElement {
 
     OnRampController.setPaymentCurrency(currency)
     ModalController.close()
-  }
-
-  // -- Private Methods ----------------------------------- //
-  private onCheckboxChange(event: CustomEvent<string>) {
-    this.checked = Boolean(event.detail)
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-onramp-tokens-select-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-onramp-tokens-select-view/index.ts
@@ -6,7 +6,8 @@ import {
   AssetController,
   ModalController,
   OnRampController,
-  OptionsController
+  OptionsController,
+  OptionsStateController
 } from '@reown/appkit-controllers'
 import type { PurchaseCurrency } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
@@ -29,7 +30,7 @@ export class W3mOnrampTokensView extends LitElement {
   @state() public selectedCurrency = OnRampController.state.purchaseCurrencies
   @state() public tokens = OnRampController.state.purchaseCurrencies
   @state() private tokenImages = AssetController.state.tokenImages
-  @state() private checked = false
+  @state() private checked = OptionsStateController.state.isLegalCheckboxChecked
 
   public constructor() {
     super()
@@ -39,7 +40,10 @@ export class W3mOnrampTokensView extends LitElement {
           this.selectedCurrency = val.purchaseCurrencies
           this.tokens = val.purchaseCurrencies
         }),
-        AssetController.subscribeKey('tokenImages', val => (this.tokenImages = val))
+        AssetController.subscribeKey('tokenImages', val => (this.tokenImages = val)),
+        OptionsStateController.subscribeKey('isLegalCheckboxChecked', val => {
+          this.checked = val
+        })
       ]
     )
   }
@@ -60,7 +64,7 @@ export class W3mOnrampTokensView extends LitElement {
     const disabled = showLegalCheckbox && !this.checked
 
     return html`
-      <w3m-legal-checkbox @checkboxChange=${this.onCheckboxChange.bind(this)}></w3m-legal-checkbox>
+      <w3m-legal-checkbox></w3m-legal-checkbox>
       <wui-flex
         flexDirection="column"
         .padding=${['0', 's', 's', 's']}
@@ -99,11 +103,6 @@ export class W3mOnrampTokensView extends LitElement {
 
     OnRampController.setPurchaseCurrency(currency)
     ModalController.close()
-  }
-
-  // -- Private Methods ----------------------------------- //
-  private onCheckboxChange(event: CustomEvent<string>) {
-    this.checked = Boolean(event.detail)
   }
 }
 

--- a/packages/scaffold-ui/test/partials/w3m-legal-checkbox.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-legal-checkbox.test.ts
@@ -3,7 +3,7 @@ import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { html } from 'lit'
 
-import { OptionsController } from '@reown/appkit-controllers'
+import { OptionsController, OptionsStateController } from '@reown/appkit-controllers'
 
 import { W3mLegalCheckbox } from '../../src/partials/w3m-legal-checkbox/index'
 import { HelpersUtil } from '../utils/HelpersUtil'
@@ -84,5 +84,26 @@ describe('W3mLegalCheckbox', () => {
     await elementUpdated(element)
 
     expect(HelpersUtil.querySelect(element, CHECKBOX_TEST_ID)).toBeNull()
+  })
+
+  it('should render checked checkbox when isLegalCheckboxChecked is true', async () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      termsConditionsUrl: TERMS_CONDITIONS_URL,
+      privacyPolicyUrl: PRIVACY_POLICY_URL,
+      features: {
+        legalCheckbox: true
+      }
+    })
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: true
+    })
+
+    const element: W3mLegalCheckbox = await fixture(html`<w3m-legal-checkbox></w3m-legal-checkbox>`)
+
+    const checkbox = HelpersUtil.getByTestId(element, CHECKBOX_TEST_ID)
+    expect(checkbox).not.toBeNull()
+    expect(checkbox?.getAttribute('checked')).not.toBeNull()
   })
 })

--- a/packages/scaffold-ui/test/views/w3m-onramp-fiat-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-fiat-select-view.test.ts
@@ -8,6 +8,7 @@ import {
   ModalController,
   OnRampController,
   OptionsController,
+  OptionsStateController,
   type PaymentCurrency
 } from '@reown/appkit-controllers'
 
@@ -21,6 +22,8 @@ const mockCurrencies: PaymentCurrency[] = [
 
 describe('W3mOnrampFiatSelectView', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+
     vi.spyOn(OnRampController, 'state', 'get').mockReturnValue({
       ...OnRampController.state,
       paymentCurrency: mockCurrencies[0] as PaymentCurrency,
@@ -102,6 +105,18 @@ describe('W3mOnrampFiatSelectView', () => {
   })
 
   it('should enable currency selection when legal checkbox is checked', async () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      termsConditionsUrl: '...',
+      privacyPolicyUrl: '...',
+      features: {
+        legalCheckbox: true
+      }
+    })
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: true
+    })
     const element: W3mOnrampFiatSelectView = await fixture(
       html`<w3m-onramp-fiat-select-view></w3m-onramp-fiat-select-view>`
     )
@@ -125,6 +140,10 @@ describe('W3mOnrampFiatSelectView', () => {
   })
 
   it('should handle subscription updates', async () => {
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: false
+    })
     const element: W3mOnrampFiatSelectView = await fixture(
       html`<w3m-onramp-fiat-select-view></w3m-onramp-fiat-select-view>`
     )
@@ -150,6 +169,10 @@ describe('W3mOnrampFiatSelectView', () => {
   })
 
   it('should cleanup subscriptions on disconnect', async () => {
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: false
+    })
     const unsubscribeSpy = vi.fn()
     const subscribeSpy = vi.spyOn(OnRampController, 'subscribe').mockReturnValue(unsubscribeSpy)
     const subscribeKeySpy = vi

--- a/packages/scaffold-ui/test/views/w3m-onramp-fiat-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-fiat-select-view.test.ts
@@ -115,7 +115,7 @@ describe('W3mOnrampFiatSelectView', () => {
     })
     vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
       ...OptionsStateController.state,
-      isLegalCheckboxChecked: true
+      isLegalCheckboxChecked: false
     })
     const element: W3mOnrampFiatSelectView = await fixture(
       html`<w3m-onramp-fiat-select-view></w3m-onramp-fiat-select-view>`
@@ -124,10 +124,14 @@ describe('W3mOnrampFiatSelectView', () => {
     await elementUpdated(element)
 
     const checkbox = element.shadowRoot?.querySelector('w3m-legal-checkbox')
-    if (checkbox) {
-      checkbox.dispatchEvent(new CustomEvent('checkboxChange', { detail: true }))
-    }
+    const wuiCheckbox = checkbox?.shadowRoot?.querySelector('wui-checkbox')
+    const input = wuiCheckbox?.shadowRoot?.querySelector('input')
 
+    expect(input).not.toBeNull()
+
+    input?.click()
+
+    element.requestUpdate()
     await elementUpdated(element)
 
     const container = element.shadowRoot?.querySelector('wui-flex')

--- a/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
@@ -149,6 +149,16 @@ describe('W3mOnrampTokensView', () => {
   })
 
   it('should handle token image updates', async () => {
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: false
+    })
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      features: {
+        legalCheckbox: false
+      }
+    })
     const element: W3mOnrampTokensView = await fixture(
       html`<w3m-onramp-token-select-view></w3m-onramp-token-select-view>`
     )
@@ -171,6 +181,16 @@ describe('W3mOnrampTokensView', () => {
   })
 
   it('should cleanup subscriptions on disconnect', async () => {
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: false
+    })
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      features: {
+        legalCheckbox: false
+      }
+    })
     const element: W3mOnrampTokensView = await fixture(
       html`<w3m-onramp-token-select-view></w3m-onramp-token-select-view>`
     )

--- a/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
@@ -118,8 +118,8 @@ describe('W3mOnrampTokensView', () => {
     })
     vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
       ...OptionsController.state,
-      termsConditionsUrl: 'https://terms.com',
-      privacyPolicyUrl: 'https://privacy.com',
+      termsConditionsUrl: '...',
+      privacyPolicyUrl: '...',
       features: {
         legalCheckbox: true
       }

--- a/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
@@ -111,7 +111,7 @@ describe('W3mOnrampTokensView', () => {
     expect(listItems?.length).toBe(1)
   })
 
-  it.only('should handle legal checkbox interaction', async () => {
+  it('should handle legal checkbox interaction', async () => {
     vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
       ...OptionsStateController.state,
       isLegalCheckboxChecked: false

--- a/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-onramp-tokens-select-view.test.ts
@@ -8,6 +8,7 @@ import {
   ModalController,
   OnRampController,
   OptionsController,
+  OptionsStateController,
   type PurchaseCurrency
 } from '@reown/appkit-controllers'
 
@@ -26,6 +27,8 @@ const mockTokenImages = {
 
 describe('W3mOnrampTokensView', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+
     vi.spyOn(OnRampController, 'state', 'get').mockReturnValue({
       ...OnRampController.state,
       purchaseCurrencies: mockTokens
@@ -108,7 +111,20 @@ describe('W3mOnrampTokensView', () => {
     expect(listItems?.length).toBe(1)
   })
 
-  it('should handle legal checkbox interaction', async () => {
+  it.only('should handle legal checkbox interaction', async () => {
+    vi.spyOn(OptionsStateController, 'state', 'get').mockReturnValue({
+      ...OptionsStateController.state,
+      isLegalCheckboxChecked: false
+    })
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      termsConditionsUrl: 'https://terms.com',
+      privacyPolicyUrl: 'https://privacy.com',
+      features: {
+        legalCheckbox: true
+      }
+    })
+
     const element: W3mOnrampTokensView = await fixture(
       html`<w3m-onramp-token-select-view></w3m-onramp-token-select-view>`
     )
@@ -119,8 +135,15 @@ describe('W3mOnrampTokensView', () => {
     expect(listContainer?.classList.contains('disabled')).toBe(true)
 
     const checkbox = element.shadowRoot?.querySelector('w3m-legal-checkbox')
-    checkbox?.dispatchEvent(new CustomEvent('checkboxChange', { detail: true }))
-    await element.updateComplete
+    const wuiCheckbox = checkbox?.shadowRoot?.querySelector('wui-checkbox')
+    const input = wuiCheckbox?.shadowRoot?.querySelector('input')
+
+    expect(input).not.toBeNull()
+
+    input?.click()
+
+    element.requestUpdate()
+    await elementUpdated(element)
 
     expect(listContainer?.classList.contains('disabled')).toBe(false)
   })


### PR DESCRIPTION
# Description

If a user enables the legal checkbox feature, they are forced to click it again after navigating away and returning to the connect view.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2527

# Showcase (Optional)

https://github.com/user-attachments/assets/c8536c97-bca1-4c96-a96f-77837735488a

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
