### PR TITLE
feat: createAppkit option to override universal provider config

### DIFF
--- a/.changeset/bitter-days-talk.md
+++ b/.changeset/bitter-days-talk.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+adds support for customizing universal provider configuration via a new universalProviderConfigOverride option

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -24,7 +24,7 @@ import type { AppKitOptions } from '@reown/appkit'
 import type { AppKit } from '@reown/appkit'
 import { ConstantsUtil } from '@reown/appkit-common'
 import type { CaipNetwork, ChainNamespace } from '@reown/appkit-common'
-import { StorageUtil } from '@reown/appkit-controllers'
+import { OptionsController, StorageUtil } from '@reown/appkit-controllers'
 
 type UniversalConnector = Connector & {
   onDisplayUri(uri: string): void
@@ -110,10 +110,12 @@ export function walletConnect(
         }
         // If there isn't an active session or chains are stale, connect.
         if (!provider.session || isChainsStale) {
-          // SOMETHING LIKE THIS
-          const defaultNamespaces = WcHelpersUtil.createNamespaces(caipNetworks)
-          const optionsNamespaces = OptionsController.state.universalProviderConfigOverride?.namespaces
-          const namespaces = optionsNamespaces ? { ...defaultNamespaces, ...optionsNamespaces } : defaultNamespaces
+          const universalProviderConfigOverride =
+            OptionsController.state.universalProviderConfigOverride
+          const namespaces = WcHelpersUtil.createNamespaces(
+            caipNetworks,
+            universalProviderConfigOverride
+          )
           await provider.connect({
             optionalNamespaces: namespaces,
             ...('pairingTopic' in rest ? { pairingTopic: rest.pairingTopic } : {})

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -108,10 +108,10 @@ export function walletConnect(
         if (provider.session && isChainsStale) {
           await provider.disconnect()
         }
+        const universalProviderConfigOverride =
+          OptionsController.state.universalProviderConfigOverride
         // If there isn't an active session or chains are stale, connect.
         if (!provider.session || isChainsStale) {
-          const universalProviderConfigOverride =
-            OptionsController.state.universalProviderConfigOverride
           const namespaces = WcHelpersUtil.createNamespaces(
             caipNetworks,
             universalProviderConfigOverride
@@ -152,8 +152,8 @@ export function walletConnect(
           sessionDelete = this.onSessionDelete.bind(this)
           provider.on('session_delete', sessionDelete)
         }
-
-        provider.setDefaultChain(`eip155:${currentChainId}`)
+        const defaultChain = universalProviderConfigOverride?.defaultChain
+        provider.setDefaultChain(defaultChain ?? `eip155:${currentChainId}`)
 
         return { accounts, chainId: currentChainId }
       } catch (error) {

--- a/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/UniversalConnector.ts
@@ -110,7 +110,10 @@ export function walletConnect(
         }
         // If there isn't an active session or chains are stale, connect.
         if (!provider.session || isChainsStale) {
-          const namespaces = WcHelpersUtil.createNamespaces(caipNetworks)
+          // SOMETHING LIKE THIS
+          const defaultNamespaces = WcHelpersUtil.createNamespaces(caipNetworks)
+          const optionsNamespaces = OptionsController.state.universalProviderConfigOverride?.namespaces
+          const namespaces = optionsNamespaces ? { ...defaultNamespaces, ...optionsNamespaces } : defaultNamespaces
           await provider.connect({
             optionalNamespaces: namespaces,
             ...('pairingTopic' in rest ? { pairingTopic: rest.pairingTopic } : {})

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.0'
+export const PACKAGE_VERSION = '1.7.1'

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -213,6 +213,7 @@ export abstract class AppKitBaseClient {
     OptionsController.setFeatures(options.features)
     OptionsController.setAllowUnsupportedChain(options.allowUnsupportedChain)
     OptionsController.setDefaultAccountTypes(options.defaultAccountTypes)
+    OptionsController.setUniversalProviderConfigOverride(options.universalProviderConfigOverride)
 
     const defaultMetaData = this.getDefaultMetaData()
     if (!options.metadata && defaultMetaData) {

--- a/packages/appkit/src/connectors/WalletConnectConnector.ts
+++ b/packages/appkit/src/connectors/WalletConnectConnector.ts
@@ -2,7 +2,7 @@ import type { SessionTypes } from '@walletconnect/types'
 import UniversalProvider from '@walletconnect/universal-provider'
 
 import { type CaipNetwork, type ChainNamespace, ConstantsUtil } from '@reown/appkit-common'
-import { SIWXUtil } from '@reown/appkit-controllers'
+import { OptionsController, SIWXUtil } from '@reown/appkit-controllers'
 import { PresetsUtil } from '@reown/appkit-utils'
 
 import type { ChainAdapterConnector } from '../adapters/ChainAdapterConnector.js'
@@ -37,8 +37,14 @@ export class WalletConnectConnector<Namespace extends ChainNamespace = ChainName
     const isAuthenticated = await this.authenticate()
 
     if (!isAuthenticated) {
+      const universalProviderConfigOverride =
+        OptionsController.state.universalProviderConfigOverride
+      const namespaces = WcHelpersUtil.createNamespaces(
+        this.caipNetworks,
+        universalProviderConfigOverride
+      )
       await this.provider.connect({
-        optionalNamespaces: WcHelpersUtil.createNamespaces(this.caipNetworks)
+        optionalNamespaces: namespaces
       })
     }
 

--- a/packages/appkit/src/utils/HelpersUtil.ts
+++ b/packages/appkit/src/utils/HelpersUtil.ts
@@ -6,53 +6,55 @@ import { EnsController } from '@reown/appkit-controllers'
 
 import { solana, solanaDevnet } from '../networks/index.js'
 
+export const DEFAULT_METHODS = {
+  solana: [
+    'solana_signMessage',
+    'solana_signTransaction',
+    'solana_requestAccounts',
+    'solana_getAccounts',
+    'solana_signAllTransactions',
+    'solana_signAndSendTransaction'
+  ],
+  eip155: [
+    'eth_accounts',
+    'eth_requestAccounts',
+    'eth_sendRawTransaction',
+    'eth_sign',
+    'eth_signTransaction',
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+    'eth_sendTransaction',
+    'personal_sign',
+    'wallet_switchEthereumChain',
+    'wallet_addEthereumChain',
+    'wallet_getPermissions',
+    'wallet_requestPermissions',
+    'wallet_registerOnboarding',
+    'wallet_watchAsset',
+    'wallet_scanQRCode',
+    // EIP-5792
+    'wallet_getCallsStatus',
+    'wallet_showCallsStatus',
+    'wallet_sendCalls',
+    'wallet_getCapabilities',
+    // EIP-7715
+    'wallet_grantPermissions',
+    'wallet_revokePermissions',
+    //EIP-7811
+    'wallet_getAssets'
+  ],
+  bip122: [
+    'sendTransfer',
+    'signMessage',
+    'signPsbt',
+    'getAccountAddresses'
+  ]
+}
+
 export const WcHelpersUtil = {
   getMethodsByChainNamespace(chainNamespace: ChainNamespace): string[] {
-    switch (chainNamespace) {
-      case 'solana':
-        return [
-          'solana_signMessage',
-          'solana_signTransaction',
-          'solana_requestAccounts',
-          'solana_getAccounts',
-          'solana_signAllTransactions',
-          'solana_signAndSendTransaction'
-        ]
-      case 'eip155':
-        return [
-          'eth_accounts',
-          'eth_requestAccounts',
-          'eth_sendRawTransaction',
-          'eth_sign',
-          'eth_signTransaction',
-          'eth_signTypedData',
-          'eth_signTypedData_v3',
-          'eth_signTypedData_v4',
-          'eth_sendTransaction',
-          'personal_sign',
-          'wallet_switchEthereumChain',
-          'wallet_addEthereumChain',
-          'wallet_getPermissions',
-          'wallet_requestPermissions',
-          'wallet_registerOnboarding',
-          'wallet_watchAsset',
-          'wallet_scanQRCode',
-          // EIP-5792
-          'wallet_getCallsStatus',
-          'wallet_showCallsStatus',
-          'wallet_sendCalls',
-          'wallet_getCapabilities',
-          // EIP-7715
-          'wallet_grantPermissions',
-          'wallet_revokePermissions',
-          //EIP-7811
-          'wallet_getAssets'
-        ]
-      case 'bip122':
-        return ['sendTransfer', 'signMessage', 'signPsbt', 'getAccountAddresses']
-      default:
-        return []
-    }
+    return DEFAULT_METHODS[chainNamespace as keyof typeof DEFAULT_METHODS] || []
   },
 
   createNamespaces(caipNetworks: CaipNetwork[]): NamespaceConfig {

--- a/packages/appkit/tests/utils/HelpersUtil.test.ts
+++ b/packages/appkit/tests/utils/HelpersUtil.test.ts
@@ -290,94 +290,154 @@ describe('WcHelpersUtil', () => {
   })
 
   describe('applyNamespaceOverrides', () => {
-    const baseNamespaces = {
-      eip155: {
-        methods: ['eth_sign', 'personal_sign'],
-        events: ['accountsChanged', 'chainChanged'],
-        chains: ['eip155:1'],
-        rpcMap: { '1': 'https://ethereum.rpc.com' }
-      }
-    }
-
-    test('applies complete namespace overrides', () => {
-      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
-        namespaces: {
-          eip155: {
-            methods: ['custom_method'],
-            events: ['customEvent'],
-            chains: ['eip155:137'],
-            rpcMap: { '137': 'https://custom.rpc.com' }
-          }
-        }
-      })
-
-      expect(result).toEqual({
+    test('returns a copy of baseNamespaces when overrides is undefined', () => {
+      const baseNamespaces = {
         eip155: {
-          methods: ['custom_method'],
-          events: ['customEvent'],
-          chains: ['eip155:137'],
-          rpcMap: { '137': 'https://custom.rpc.com' }
+          methods: ['eth_sign'],
+          events: ['accountsChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
         }
-      })
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, undefined)
+
+      // Should return a copy, not the original object
+      expect(result).not.toBe(baseNamespaces)
+      expect(result).toEqual(baseNamespaces)
     })
 
-    test('applies method overrides', () => {
-      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
-        methods: {
-          eip155: ['new_method1', 'new_method2'],
-          solana: ['solana_method1', 'solana_method2']
+    test('handles empty overrides object', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign'],
+          events: ['accountsChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
         }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {})
+
+      expect(result).toEqual(baseNamespaces)
+    })
+
+    test('creates new namespace that does not exist in base when referenced in multiple override types', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign'],
+          events: ['accountsChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
+        }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
+        methods: { cosmos: ['cosmos_method'] },
+        chains: { cosmos: ['cosmos:cosmoshub-4'] },
+        events: { cosmos: ['cosmos_event'] },
+        rpcMap: { 'cosmos:cosmoshub-4': 'https://cosmos-hub.rpc.com' }
+      })
+
+      expect(result['cosmos']).toBeDefined()
+      expect(result['cosmos']?.methods).toEqual(['cosmos_method'])
+      expect(result['cosmos']?.chains).toEqual(['cosmos:cosmoshub-4'])
+      expect(result['cosmos']?.events).toEqual(['cosmos_event'])
+      expect(result['cosmos']?.rpcMap).toEqual({ 'cosmoshub-4': 'https://cosmos-hub.rpc.com' })
+
+      // Original namespace should remain unchanged
+      expect(result['eip155']).toEqual(baseNamespaces['eip155'])
+    })
+
+    test('handles missing rpcMap in base namespace when applying rpcMap overrides', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign'],
+          events: ['accountsChanged'],
+          chains: ['eip155:1']
+        }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
+        rpcMap: { 'eip155:42': 'https://kovan.rpc.com' }
+      })
+
+      expect(result['eip155']?.rpcMap).toEqual({ '42': 'https://kovan.rpc.com' })
+    })
+
+    test('applies method overrides for existing namespace', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign', 'personal_sign'],
+          events: ['accountsChanged', 'chainChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
+        }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
+        methods: { eip155: ['new_method1', 'new_method2'] }
       })
 
       expect(result['eip155']?.methods).toEqual(['new_method1', 'new_method2'])
-      expect(result['solana']?.methods).toEqual(['solana_method1', 'solana_method2'])
+      // Other properties should remain unchanged
+      expect(result['eip155']?.events).toEqual(['accountsChanged', 'chainChanged'])
       expect(result['eip155']?.chains).toEqual(['eip155:1'])
+      expect(result['eip155']?.rpcMap).toEqual({ '1': 'https://ethereum.rpc.com' })
     })
 
-    test('applies chain overrides', () => {
-      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
-        chains: {
-          eip155: ['eip155:42', 'eip155:56'],
-          bip122: ['bip122:000000000019d6689c085ae165831e93']
+    test('applies chain overrides for existing namespace', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign', 'personal_sign'],
+          events: ['accountsChanged', 'chainChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
         }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
+        chains: { eip155: ['eip155:42', 'eip155:56'] }
       })
 
       expect(result['eip155']?.chains).toEqual(['eip155:42', 'eip155:56'])
-      expect(result['bip122']?.chains).toEqual(['bip122:000000000019d6689c085ae165831e93'])
-      expect(result['bip122']?.methods).toEqual(
-        expect.arrayContaining(['sendTransfer', 'signMessage'])
-      )
+      // Other properties should remain unchanged
+      expect(result['eip155']?.methods).toEqual(['eth_sign', 'personal_sign'])
+      expect(result['eip155']?.events).toEqual(['accountsChanged', 'chainChanged'])
+      expect(result['eip155']?.rpcMap).toEqual({ '1': 'https://ethereum.rpc.com' })
     })
 
-    test('applies event overrides', () => {
-      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
-        events: {
-          eip155: ['newEvent1', 'newEvent2'],
-          solana: ['solanaEvent']
+    test('applies event overrides for existing namespace', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign', 'personal_sign'],
+          events: ['accountsChanged', 'chainChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
         }
+      }
+
+      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
+        events: { eip155: ['newEvent1', 'newEvent2'] }
       })
 
       expect(result['eip155']?.events).toEqual(['newEvent1', 'newEvent2'])
-      expect(result['solana']?.events).toEqual(['solanaEvent'])
-    })
-
-    test('applies rpcMap overrides', () => {
-      const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
-        rpcMap: {
-          'eip155:1': 'https://new-ethereum.rpc.com',
-          'solana:mainnet': 'https://solana-mainnet.rpc.com'
-        }
-      })
-
-      expect(result['eip155']?.rpcMap).toEqual({
-        '1': 'https://new-ethereum.rpc.com'
-      })
-      expect(result['solana']?.rpcMap).toEqual({
-        mainnet: 'https://solana-mainnet.rpc.com'
-      })
+      // Other properties should remain unchanged
+      expect(result['eip155']?.methods).toEqual(['eth_sign', 'personal_sign'])
+      expect(result['eip155']?.chains).toEqual(['eip155:1'])
+      expect(result['eip155']?.rpcMap).toEqual({ '1': 'https://ethereum.rpc.com' })
     })
 
     test('handles multiple types of overrides simultaneously', () => {
+      const baseNamespaces = {
+        eip155: {
+          methods: ['eth_sign', 'personal_sign'],
+          events: ['accountsChanged', 'chainChanged'],
+          chains: ['eip155:1'],
+          rpcMap: { '1': 'https://ethereum.rpc.com' }
+        }
+      }
+
       const result = WcHelpersUtil.applyNamespaceOverrides(baseNamespaces, {
         methods: { eip155: ['method1', 'method2'] },
         chains: { eip155: ['eip155:42'] },

--- a/packages/controllers/src/controllers/OptionsController.ts
+++ b/packages/controllers/src/controllers/OptionsController.ts
@@ -1,4 +1,3 @@
-import type { Namespace } from '@walletconnect/universal-provider'
 import { proxy, snapshot } from 'valtio/vanilla'
 import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 
@@ -165,7 +164,6 @@ export interface OptionsControllerStatePublic {
   manualWCControl?: boolean
   /**
    * Custom Universal Provider configuration to override the default one.
-   * If `namespaces` is provided, it will override the default namespaces.
    * If `methods` is provided, it will override the default methods.
    * If `chains` is provided, it will override the default chains.
    * If `events` is provided, it will override the default events.
@@ -174,7 +172,6 @@ export interface OptionsControllerStatePublic {
    * @default undefined
    */
   universalProviderConfigOverride?: {
-    namespaces?: Record<string, Namespace>
     methods?: Record<string, string[]>
     chains?: Record<string, string[]>
     events?: Record<string, string[]>

--- a/packages/controllers/src/controllers/OptionsController.ts
+++ b/packages/controllers/src/controllers/OptionsController.ts
@@ -18,6 +18,7 @@ import type {
   Tokens,
   WalletFeature
 } from '../utils/TypeUtil.js'
+import type { EthereumRpcMap, Namespace } from '@walletconnect/universal-provider'
 
 // -- Types --------------------------------------------- //
 export interface OptionsControllerStatePublic {
@@ -161,7 +162,25 @@ export interface OptionsControllerStatePublic {
    * @default false
    * @see https://docs.reown.com/appkit/react/core/options#manualwccontrol
    */
-  manualWCControl?: boolean
+  manualWCControl?: boolean,
+  /**
+   * Custom Universal Provider configuration to override the default one.
+   * If `namespaces` is provided, it will override the default namespaces.
+   * If `methods` is provided, it will override the default methods. 
+   * If `chains` is provided, it will override the default chains.
+   * If `events` is provided, it will override the default events.
+   * If `rpcMap` is provided, it will override the default rpcMap.
+   * If `defaultChain` is provided, it will override the default defaultChain.
+   * @default undefined
+   */
+  universalProviderConfigOverride?: {
+    namespaces?: Record<string, Namespace>,
+    methods?: Record<string, string[]>,
+    chains?: Record<string, string[]>,
+    events?: Record<string, string[]>,
+    rpcMap?: Record<string, string>,
+    defaultChain?: string
+  }
 }
 
 export interface OptionsControllerStateInternal {

--- a/packages/controllers/src/controllers/OptionsController.ts
+++ b/packages/controllers/src/controllers/OptionsController.ts
@@ -1,3 +1,4 @@
+import type { Namespace } from '@walletconnect/universal-provider'
 import { proxy, snapshot } from 'valtio/vanilla'
 import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 
@@ -18,7 +19,6 @@ import type {
   Tokens,
   WalletFeature
 } from '../utils/TypeUtil.js'
-import type { EthereumRpcMap, Namespace } from '@walletconnect/universal-provider'
 
 // -- Types --------------------------------------------- //
 export interface OptionsControllerStatePublic {
@@ -162,11 +162,11 @@ export interface OptionsControllerStatePublic {
    * @default false
    * @see https://docs.reown.com/appkit/react/core/options#manualwccontrol
    */
-  manualWCControl?: boolean,
+  manualWCControl?: boolean
   /**
    * Custom Universal Provider configuration to override the default one.
    * If `namespaces` is provided, it will override the default namespaces.
-   * If `methods` is provided, it will override the default methods. 
+   * If `methods` is provided, it will override the default methods.
    * If `chains` is provided, it will override the default chains.
    * If `events` is provided, it will override the default events.
    * If `rpcMap` is provided, it will override the default rpcMap.
@@ -174,11 +174,11 @@ export interface OptionsControllerStatePublic {
    * @default undefined
    */
   universalProviderConfigOverride?: {
-    namespaces?: Record<string, Namespace>,
-    methods?: Record<string, string[]>,
-    chains?: Record<string, string[]>,
-    events?: Record<string, string[]>,
-    rpcMap?: Record<string, string>,
+    namespaces?: Record<string, Namespace>
+    methods?: Record<string, string[]>
+    chains?: Record<string, string[]>
+    events?: Record<string, string[]>
+    rpcMap?: Record<string, string>
     defaultChain?: string
   }
 }
@@ -373,6 +373,16 @@ export const OptionsController = {
         state.defaultAccountTypes[namespace] = accountType
       }
     })
+  },
+
+  setUniversalProviderConfigOverride(
+    universalProviderConfigOverride: OptionsControllerState['universalProviderConfigOverride']
+  ) {
+    state.universalProviderConfigOverride = universalProviderConfigOverride
+  },
+
+  getUniversalProviderConfigOverride() {
+    return state.universalProviderConfigOverride
   },
 
   getSnapshot() {


### PR DESCRIPTION
# Description

Adds support for customizing Universal Provider namespace configuration via the new `universalProviderConfigOverride` option in OptionsController.
This change enables:
- Custom RPC methods for different namespaces (e.g., EVM, Solana)
- Override for namespace chains, events, and RPC endpoints

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
