### PR TITLE
feat(paymaster): add sample ABI

### DIFF
--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -291,7 +291,9 @@ function AvailableTestContent() {
             await switchChain({ chainId: 8453 }) // Base chainId
           }
           setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
-          setContractAbi('[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]')
+          setContractAbi(
+            '[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
+          )
           setMethod('transfer')
           setMethodArgs(`["${address}", 10000]`)
         }}

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -286,14 +286,13 @@ function AvailableTestContent() {
 
       <Button
         width={'fit-content'}
-        onClick={async () => {
+        onClick={() => {
           if (switchChain) {
-            await switchChain({ chainId: 8453 }) // Base chainId
+            // Switch to Base network
+            switchChain({ chainId: 8453 })
           }
           setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
-          setContractAbi(
-            '[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
-          )
+          setContractAbi('[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]')
           setMethod('transfer')
           setMethodArgs(`["${address}", 10000]`)
         }}

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -292,7 +292,9 @@ function AvailableTestContent() {
             switchChain({ chainId: 8453 })
           }
           setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
-          setContractAbi('[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]')
+          setContractAbi(
+            '[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
+          )
           setMethod('transfer')
           setMethodArgs(`["${address}", 10000]`)
         }}

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -291,12 +291,12 @@ function AvailableTestContent() {
             // Switch to Base network
             switchChain({ chainId: 8453 })
           }
-          setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
+          setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913') // USDC on Base https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#writeProxyContract
           setContractAbi(
             '[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
           )
           setMethod('transfer')
-          setMethodArgs(`["${address}", 10000]`)
+          setMethodArgs(`["${address}", ${0.1 * Math.pow(10, 6)}]`)
         }}
         isDisabled={isLoading}
       >

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -291,12 +291,13 @@ function AvailableTestContent() {
             // Switch to Base network
             switchChain({ chainId: 8453 })
           }
-          setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913') // USDC on Base https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#writeProxyContract
+          // USDC on Base https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#writeProxyContract
+          setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
           setContractAbi(
             '[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]'
           )
           setMethod('transfer')
-          setMethodArgs(`["${address}", ${0.1 * Math.pow(10, 6)}]`)
+          setMethodArgs(`["${address}", ${0.1 * 10 ** 6}]`)
         }}
         isDisabled={isLoading}
       >

--- a/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSendCallsCustomAbiWithPaymasterServiceTest.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { Button, Input, Select, Stack, Text, Tooltip } from '@chakra-ui/react'
 import { type Abi, encodeFunctionData, parseEther } from 'viem'
-import { useAccount } from 'wagmi'
+import { useAccount, useSwitchChain } from 'wagmi'
 import { useSendCalls } from 'wagmi/experimental'
 
 import { useAppKitAccount } from '@reown/appkit/react'
@@ -78,6 +78,8 @@ export function WagmiSendCallsCustomAbiWithPaymasterServiceTest() {
 }
 
 function AvailableTestContent() {
+  const { switchChain } = useSwitchChain()
+  const { address } = useAppKitAccount({ namespace: 'eip155' })
   const [paymasterProvider, setPaymasterProvider] = useState<string>()
   const [reownPolicyId, setReownPolicyId] = useState<string>('')
   const [contractAbi, setContractAbi] = useState<string>('')
@@ -281,6 +283,22 @@ function AvailableTestContent() {
         whiteSpace="nowrap"
         textOverflow="ellipsis"
       />
+
+      <Button
+        width={'fit-content'}
+        onClick={async () => {
+          if (switchChain) {
+            await switchChain({ chainId: 8453 }) // Base chainId
+          }
+          setContractAddress('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913')
+          setContractAbi('[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]')
+          setMethod('transfer')
+          setMethodArgs(`["${address}", 10000]`)
+        }}
+        isDisabled={isLoading}
+      >
+        Try with USDC on Base
+      </Button>
 
       <Button
         width={'fit-content'}


### PR DESCRIPTION
# Description

We currently don't have a good way of testing the Paymaster. The only example we have, the "Donut contract", is not documented and requires the user to have native gas token which entirely defeats the purpose of the paymaster.

As an improvement to this we're introducing a simple button to sponsor 0.10USDC.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

<img width="735" alt="Screenshot 2025-03-28 at 12 55 47 PM" src="https://github.com/user-attachments/assets/1b2fe1c1-5470-400d-9743-b2ae00291b60" />


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
