### PR TITLE
fix: swap screen freezes when swap allowance fails

### DIFF
--- a/.changeset/orange-dancers-listen.md
+++ b/.changeset/orange-dancers-listen.md
@@ -21,4 +21,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where the swap screen would freeze when swap allowance failed
+Fixed an issue where the swap screen froze if allowance approval failed

--- a/.changeset/orange-dancers-listen.md
+++ b/.changeset/orange-dancers-listen.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the swap screen would freeze when swap allowance failed

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -287,11 +287,9 @@ export class W3mSwapView extends LitElement {
     SwapController.switchTokens()
   }
 
-  private onSwapPreview() {
+  private async onSwapPreview() {
     if (this.fetchError) {
-      SwapController.swapTokens()
-
-      return
+      await SwapController.swapTokens()
     }
     EventsController.sendEvent({
       type: 'track',


### PR DESCRIPTION
# Description

Fixed an issue where the swap screen froze if allowance approval failed

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2225

# Showcase (Optional)

**Before:**

https://github.com/user-attachments/assets/13cc9586-dce5-4a9b-af81-1bd1943c2454

**After:**

https://github.com/user-attachments/assets/93c20328-e5ca-4139-bd64-6beb42d4b0a7

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
