### PR TITLE
fix: preferred account type not switching on connect

### DIFF
--- a/.changeset/three-trams-guess.md
+++ b/.changeset/three-trams-guess.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where preferred account type wasn't properly switching on initial connection when using email/social login

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -418,7 +418,9 @@ export class EthersAdapter extends AdapterBlueprint {
 
     if (params.id === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
       const provider = connector['provider'] as W3mFrameProvider
-      const { address, accounts } = await provider.connect()
+      const { address, accounts } = await provider.connect({
+        preferredAccountType: OptionsController.state.defaultAccountTypes.eip155
+      })
 
       return Promise.resolve({
         accounts: (accounts || [{ address, type: 'eoa' }]).map(account =>

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -404,7 +404,9 @@ export class Ethers5Adapter extends AdapterBlueprint {
 
     if (params.id === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
       const provider = connector['provider'] as W3mFrameProvider
-      const { address, accounts } = await provider.connect()
+      const { address, accounts } = await provider.connect({
+        preferredAccountType: OptionsController.state.defaultAccountTypes.eip155
+      })
 
       return Promise.resolve({
         accounts: (accounts || [{ address, type: 'eoa' }]).map(account =>

--- a/packages/adapters/solana/src/providers/AuthProvider.ts
+++ b/packages/adapters/solana/src/providers/AuthProvider.ts
@@ -4,7 +4,7 @@ import base58 from 'bs58'
 
 import type { CaipNetwork } from '@reown/appkit-common'
 import { ConstantsUtil } from '@reown/appkit-common'
-import type { RequestArguments } from '@reown/appkit-controllers'
+import { OptionsController, type RequestArguments } from '@reown/appkit-controllers'
 import type {
   AnyTransaction,
   Connection,
@@ -51,7 +51,8 @@ export class AuthProvider extends ProviderEventEmitter implements SolanaProvider
   public async connect(params: { chainId?: string } = {}) {
     const chainId = params.chainId || this.getActiveChain()?.id
     await this.provider.connect({
-      chainId: withSolanaNamespace(chainId)
+      chainId: withSolanaNamespace(chainId),
+      preferredAccountType: OptionsController.state.defaultAccountTypes.solana
     })
 
     if (!this.publicKey) {

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -43,7 +43,7 @@ import {
   NetworkUtil,
   isReownName
 } from '@reown/appkit-common'
-import { CoreHelperUtil, StorageUtil } from '@reown/appkit-controllers'
+import { CoreHelperUtil, OptionsController, StorageUtil } from '@reown/appkit-controllers'
 import {
   type ConnectorType,
   ConstantsUtil as CoreConstantsUtil,
@@ -119,7 +119,9 @@ export class WagmiAdapter extends AdapterBlueprint {
 
     if (connector.id === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
       const provider = connector['provider'] as W3mFrameProvider
-      const { address, accounts } = await provider.connect()
+      const { address, accounts } = await provider.connect({
+        preferredAccountType: OptionsController.state.defaultAccountTypes.eip155
+      })
 
       return Promise.resolve({
         accounts: (accounts || [{ address, type: 'eoa' }]).map(account =>

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -103,6 +103,7 @@ export abstract class AppKitBaseClient {
   protected universalProviderInitPromise?: Promise<void>
   protected caipNetworks?: [CaipNetwork, ...CaipNetwork[]]
   protected defaultCaipNetwork?: CaipNetwork
+  protected hasSwitchedToPreferredAccountTypeOnConnect = false
 
   public chainAdapters?: Adapters
   public chainNamespaces: ChainNamespace[] = []
@@ -392,6 +393,7 @@ export abstract class AppKitBaseClient {
         ProviderUtil.resetChain(namespace)
         this.setUser(undefined, namespace)
         this.setStatus('disconnected', namespace)
+        this.hasSwitchedToPreferredAccountTypeOnConnect = false
       },
       checkInstalled: (ids?: string[]) => {
         if (!ids) {

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -615,16 +615,21 @@ describe('Base Public methods', () => {
 
     await (appKitWithAuth as any).syncAuthConnector(mockAuthProvider, mainnet.chainNamespace)
 
-    expect(createAccount).toHaveBeenCalledWith(mainnet.chainNamespace, '0x1', 'eoa')
-    expect(createAccount).toHaveBeenCalledWith(mainnet.chainNamespace, '0x2', 'smartAccount')
-    expect(setAllAccounts).toHaveBeenCalledWith(
-      [
-        { address: '0x1', type: 'eoa', namespace: mainnet.chainNamespace },
-        { address: '0x2', type: 'smartAccount', namespace: mainnet.chainNamespace }
-      ],
-      mainnet.chainNamespace
+    await vi.waitFor(
+      () => {
+        expect(createAccount).toHaveBeenCalledWith(mainnet.chainNamespace, '0x1', 'eoa')
+        expect(createAccount).toHaveBeenCalledWith(mainnet.chainNamespace, '0x2', 'smartAccount')
+        expect(setAllAccounts).toHaveBeenCalledWith(
+          [
+            { address: '0x1', type: 'eoa', namespace: mainnet.chainNamespace },
+            { address: '0x2', type: 'smartAccount', namespace: mainnet.chainNamespace }
+          ],
+          mainnet.chainNamespace
+        )
+        expect(setPreferredAccountType).toHaveBeenCalledWith('eoa', mainnet.chainNamespace)
+      },
+      { interval: 100, timeout: 2000 }
     )
-    expect(setPreferredAccountType).toHaveBeenCalledWith('eoa', mainnet.chainNamespace)
   })
 
   it('should get Reown name', async () => {


### PR DESCRIPTION
# Description

Fixed an issue where preferred account type wasn't properly switching on initial connection when using email/social login

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2540

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
