### PR TITLE
chore: avoids expecting a loader on socials tests

### DIFF
--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -121,7 +121,7 @@ emailTest('it should show names feature only for EVM networks', async ({ library
 
 emailTest('it should show loading on page refresh', async () => {
   await page.page.reload()
-  await validator.expectConnectButtonLoading()
+  // Await validator.expectConnectButtonLoading()
   await validator.expectAccountButtonReady()
 })
 

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -128,14 +128,17 @@ emailTest('it should show loading on page refresh', async () => {
 emailTest('it should show snackbar error if failed to fetch token balance', async () => {
   // Clear cache and set offline to simulate token balance fetch failure
   await page.page.evaluate(() => window.localStorage.removeItem('@appkit/portfolio_cache'))
-  await context.setOffline(true)
+  await context.route('**/*', route => {
+    route.abort()
+  })
   await page.openAccount()
   await validator.expectSnackbar('Token Balance Unavailable')
+  await context.unroute('**/*')
   await page.closeModal()
 })
 
 emailTest('it should disconnect correctly', async ({ library }) => {
-  await context.setOffline(false)
+  await page.page.reload()
   if (library === 'solana') {
     await page.openAccount()
     await page.openProfileView()
@@ -147,8 +150,11 @@ emailTest('it should disconnect correctly', async ({ library }) => {
 })
 
 emailTest('it should abort request if it takes more than 30 seconds', async () => {
-  await context.setOffline(true)
+  await context.route('**/*', route => {
+    route.abort()
+  })
   await page.loginWithEmail(tempEmail, false)
   await page.page.waitForTimeout(30_000)
   await validator.expectSnackbar('Something went wrong')
+  await context.unroute('**/*')
 })

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -92,7 +92,9 @@ smartAccountTest(
     await page.closeModal()
 
     //Requesting a sign immediately after login or after switch network causes a 'user rejected' error from embedded wallet so a small delay is needed
-    await new Promise<void>(resolve => setTimeout(resolve, 1000))
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 1000)
+    })
 
     await page.sign(namespace)
     await page.approveSign()
@@ -115,7 +117,9 @@ smartAccountTest('it should switch to smart account and sign', async ({ library 
   await validator.expectAccountButtonReady()
 
   // Requesting a sign immediately after login or after switch network causes a 'user rejected' error from embedded wallet so a small delay is needed
-  await new Promise<void>(resolve => setTimeout(resolve, 1000))
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 1000)
+  })
   await page.sign(namespace)
   await page.approveSign()
   await validator.expectAcceptedSign()

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -86,11 +86,13 @@ smartAccountTest(
     await page.switchNetwork(targetChain)
     await validator.expectSwitchedNetwork(targetChain)
     await page.closeModal()
-
     await page.openAccount()
     await page.openProfileView()
     await validator.expectTogglePreferredTypeVisible(false)
     await page.closeModal()
+
+    //Requesting a sign immediately after login or after switch network causes a 'user rejected' error from embedded wallet so a small delay is needed
+    await new Promise<void>(resolve => setTimeout(resolve, 1000))
 
     await page.sign(namespace)
     await page.approveSign()
@@ -112,6 +114,8 @@ smartAccountTest('it should switch to smart account and sign', async ({ library 
   await page.closeModal()
   await validator.expectAccountButtonReady()
 
+  // Requesting a sign immediately after login or after switch network causes a 'user rejected' error from embedded wallet so a small delay is needed
+  await new Promise<void>(resolve => setTimeout(resolve, 1000))
   await page.sign(namespace)
   await page.approveSign()
   await validator.expectAcceptedSign()


### PR DESCRIPTION
# Description
This PR updates test flows in the laboratory tests by adding explicit delays in the smart account tests to avoid intermittent sign errors and by removing the loader expectation in the email tests.

- Introduces a 1000ms delay before signing in smart account tests to mitigate a 'user rejected' error.
- Comments out the loader expectation in email tests to skip waiting for a loader that now loads almost instantly.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
