### PR TITLE
fix: `excludeWalletIds` not working with bitcoin wallets

### DIFF
--- a/.changeset/young-beans-raise.md
+++ b/.changeset/young-beans-raise.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where `excludeWalletIds` option wasn't properly filtering Bitcoin wallets

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -352,7 +352,7 @@ export class AppKit extends AppKitBaseClient {
     super.initControllers(options)
 
     if (this.options.excludeWalletIds) {
-      ApiController.initializeExcludedWalletRdns({ ids: this.options.excludeWalletIds })
+      ApiController.initializeExcludedWallets({ ids: this.options.excludeWalletIds })
     }
   }
 

--- a/packages/appkit/tests/client/appkit-core.test.ts
+++ b/packages/appkit/tests/client/appkit-core.test.ts
@@ -81,14 +81,14 @@ describe('AppKitCore', () => {
 
   describe('initialize', () => {
     it('should not initialize excluded wallet rdns if basic is true', () => {
-      vi.spyOn(ApiController, 'initializeExcludedWalletRdns')
+      vi.spyOn(ApiController, 'initializeExcludedWallets')
 
       new AppKit({
         ...mockOptions,
         excludeWalletIds: ['eoa', 'ordinal']
       })
 
-      expect(ApiController.initializeExcludedWalletRdns).not.toHaveBeenCalled()
+      expect(ApiController.initializeExcludedWallets).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -38,7 +38,7 @@ export interface ApiControllerState {
   wallets: WcWallet[]
   search: WcWallet[]
   isAnalyticsEnabled: boolean
-  excludedRDNS: string[]
+  excludedWallets: { rdns: string; name: string }[]
   isFetchingRecommendedWallets: boolean
 }
 
@@ -63,7 +63,7 @@ const state = proxy<ApiControllerState>({
   wallets: [],
   search: [],
   isAnalyticsEnabled: false,
-  excludedRDNS: [],
+  excludedWallets: [],
   isFetchingRecommendedWallets: false
 })
 
@@ -244,7 +244,7 @@ export const ApiController = {
     state.page = page
   },
 
-  async initializeExcludedWalletRdns({ ids }: { ids: string[] }) {
+  async initializeExcludedWallets({ ids }: { ids: string[] }) {
     const caipNetworkIds = ChainController.getRequestedCaipNetworkIds().join(',')
 
     const { data } = await api.get<ApiGetWalletsResponse>({
@@ -261,7 +261,7 @@ export const ApiController = {
     if (data) {
       data.forEach(wallet => {
         if (wallet?.rdns) {
-          state.excludedRDNS.push(wallet.rdns)
+          state.excludedWallets.push({ rdns: wallet.rdns, name: wallet.name })
         }
       })
     }

--- a/packages/controllers/tests/controllers/ApiController.test.ts
+++ b/packages/controllers/tests/controllers/ApiController.test.ts
@@ -104,7 +104,7 @@ describe('ApiController', () => {
       wallets: [],
       search: [],
       isAnalyticsEnabled: false,
-      excludedRDNS: [],
+      excludedWallets: [],
       isFetchingRecommendedWallets: false,
       promises: {}
     })
@@ -514,9 +514,9 @@ describe('ApiController', () => {
     OptionsController.setExcludeWalletIds(excludeWalletIds)
 
     const fetchSpy = vi.spyOn(api, 'get').mockResolvedValue({ data, count: data.length })
-    const fetchWalletsSpy = vi.spyOn(ApiController, 'initializeExcludedWalletRdns')
+    const fetchWalletsSpy = vi.spyOn(ApiController, 'initializeExcludedWallets')
 
-    await ApiController.initializeExcludedWalletRdns({ ids: excludeWalletIds })
+    await ApiController.initializeExcludedWallets({ ids: excludeWalletIds })
 
     expect(fetchSpy).toHaveBeenCalledWith({
       path: '/getWallets',
@@ -531,9 +531,12 @@ describe('ApiController', () => {
     })
 
     expect(fetchWalletsSpy).toHaveBeenCalledOnce()
-    expect(ApiController.state.excludedRDNS).toEqual(['io.metamask', 'app.phantom'])
+    expect(ApiController.state.excludedWallets).toEqual([
+      { name: 'MetaMask', rdns: 'io.metamask' },
+      { name: 'Phantom', rdns: 'app.phantom' }
+    ])
     const result = EIP6963Wallets.filter(
-      wallet => !ApiController.state.excludedRDNS.includes(wallet.rdns)
+      wallet => !ApiController.state.excludedWallets.includes(wallet)
     )
     expect(result).toEqual(filteredWallet)
   })

--- a/packages/controllers/tests/controllers/ApiController.test.ts
+++ b/packages/controllers/tests/controllers/ApiController.test.ts
@@ -536,7 +536,10 @@ describe('ApiController', () => {
       { name: 'Phantom', rdns: 'app.phantom' }
     ])
     const result = EIP6963Wallets.filter(
-      wallet => !ApiController.state.excludedWallets.includes(wallet)
+      wallet =>
+        !ApiController.state.excludedWallets.some(
+          excludedWallet => excludedWallet.rdns === wallet.rdns
+        )
     )
     expect(result).toEqual(filteredWallet)
   })

--- a/packages/scaffold-ui/src/partials/w3m-connect-announced-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-announced-widget/index.ts
@@ -4,7 +4,6 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 
 import type { Connector } from '@reown/appkit-controllers'
 import {
-  ApiController,
   AssetUtil,
   ConnectorController,
   CoreHelperUtil,
@@ -13,6 +12,8 @@ import {
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 import '@reown/appkit-ui/wui-list-wallet'
+
+import { ConnectorUtil } from '../../utils/ConnectorUtil.js'
 
 @customElement('w3m-connect-announced-widget')
 export class W3mConnectAnnouncedWidget extends LitElement {
@@ -47,27 +48,23 @@ export class W3mConnectAnnouncedWidget extends LitElement {
 
     return html`
       <wui-flex flexDirection="column" gap="xs">
-        ${announcedConnectors.map(connector => {
-          if (connector.info?.rdns && ApiController.state.excludedRDNS) {
-            if (ApiController.state.excludedRDNS.includes(connector?.info?.rdns)) {
-              return null
-            }
-          }
-
-          return html`
-            <wui-list-wallet
-              imageSrc=${ifDefined(AssetUtil.getConnectorImage(connector))}
-              name=${connector.name ?? 'Unknown'}
-              @click=${() => this.onConnector(connector)}
-              tagVariant="success"
-              tagLabel="installed"
-              data-testid=${`wallet-selector-${connector.id}`}
-              .installed=${true}
-              tabIdx=${ifDefined(this.tabIdx)}
-            >
-            </wui-list-wallet>
-          `
-        })}
+        ${announcedConnectors
+          .filter(ConnectorUtil.showConnector)
+          .map(
+            connector => html`
+              <wui-list-wallet
+                imageSrc=${ifDefined(AssetUtil.getConnectorImage(connector))}
+                name=${connector.name ?? 'Unknown'}
+                @click=${() => this.onConnector(connector)}
+                tagVariant="success"
+                tagLabel="installed"
+                data-testid=${`wallet-selector-${connector.id}`}
+                .installed=${true}
+                tabIdx=${ifDefined(this.tabIdx)}
+              >
+              </wui-list-wallet>
+            `
+          )}
       </wui-flex>
     `
   }

--- a/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
@@ -43,6 +43,10 @@ export class W3mConnectInjectedWidget extends LitElement {
         ${injectedConnectors.map(connector => {
           const walletRDNS = connector.info?.rdns
 
+          if (!CoreHelperUtil.isMobile() && connector.name === 'Browser Wallet') {
+            return null
+          }
+
           if (!walletRDNS && !ConnectionController.checkInstalled()) {
             this.style.cssText = `display: none`
 

--- a/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
@@ -4,7 +4,6 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 
 import type { Connector, ConnectorWithProviders } from '@reown/appkit-controllers'
 import {
-  ApiController,
   AssetUtil,
   ConnectionController,
   ConnectorController,
@@ -14,6 +13,8 @@ import {
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 import '@reown/appkit-ui/wui-list-wallet'
+
+import { ConnectorUtil } from '../../utils/ConnectorUtil.js'
 
 @customElement('w3m-connect-injected-widget')
 export class W3mConnectInjectedWidget extends LitElement {
@@ -40,22 +41,16 @@ export class W3mConnectInjectedWidget extends LitElement {
     return html`
       <wui-flex flexDirection="column" gap="xs">
         ${injectedConnectors.map(connector => {
-          if (!CoreHelperUtil.isMobile() && connector.name === 'Browser Wallet') {
-            return null
-          }
-
           const walletRDNS = connector.info?.rdns
 
-          if (!walletRDNS && !ConnectionController.checkInstalled(undefined)) {
+          if (!walletRDNS && !ConnectionController.checkInstalled()) {
             this.style.cssText = `display: none`
 
             return null
           }
 
-          if (walletRDNS && ApiController.state.excludedRDNS) {
-            if (ApiController.state.excludedRDNS.includes(walletRDNS)) {
-              return null
-            }
+          if (!ConnectorUtil.showConnector(connector)) {
+            return null
           }
 
           return html`

--- a/packages/scaffold-ui/test/partials/w3m-all-wallets-search.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-all-wallets-search.test.ts
@@ -63,7 +63,7 @@ describe('W3mAllWalletsSearch', () => {
       recommended: [],
       wallets: [],
       isAnalyticsEnabled: false,
-      excludedRDNS: [],
+      excludedWallets: [],
       isFetchingRecommendedWallets: false
     }
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue(mockState)
@@ -92,7 +92,7 @@ describe('W3mAllWalletsSearch', () => {
       allRecommended: [],
       wallets: mockWallets,
       isAnalyticsEnabled: false,
-      excludedRDNS: [],
+      excludedWallets: [],
       isFetchingRecommendedWallets: false
     }
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue(mockState)

--- a/packages/scaffold-ui/test/partials/w3m-all-wallets-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-all-wallets-widget.test.ts
@@ -75,7 +75,7 @@ const mockApiState: ApiControllerState = {
   wallets: [],
   search: [],
   isAnalyticsEnabled: false,
-  excludedRDNS: [],
+  excludedWallets: [],
   isFetchingRecommendedWallets: false
 }
 

--- a/packages/scaffold-ui/test/partials/w3m-connect-announced-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connect-announced-widget.test.ts
@@ -44,7 +44,7 @@ describe('W3mConnectAnnouncedWidget', () => {
   beforeEach(() => {
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
       ...ApiController.state,
-      excludedRDNS: []
+      excludedWallets: []
     })
   })
 
@@ -93,7 +93,7 @@ describe('W3mConnectAnnouncedWidget', () => {
 
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
       ...ApiController.state,
-      excludedRDNS: ['mock.wallet']
+      excludedWallets: [{ name: 'Mock Wallet', rdns: 'mock.wallet' }]
     })
 
     const element: W3mConnectAnnouncedWidget = await fixture(

--- a/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
@@ -84,7 +84,7 @@ describe('W3mConnectInjectedWidget', () => {
   it('should not render excluded RDNS wallets', async () => {
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
       ...ApiController.state,
-      excludedWallets: [{ name: 'Mock Wallet', rdns: 'mock.wallet' }]
+      excludedWallets: [{ name: 'Mock Wallet', rdns: 'mock.injected.wallet' }]
     })
 
     const element: W3mConnectInjectedWidget = await fixture(
@@ -100,6 +100,7 @@ describe('W3mConnectInjectedWidget', () => {
       element,
       `wallet-selector-${MOCK_INJECTED_CONNECTOR.id}`
     )
+
     expect(walletSelector).toBeNull()
   })
 

--- a/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
@@ -44,7 +44,7 @@ describe('W3mConnectInjectedWidget', () => {
   beforeEach(() => {
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
       ...ApiController.state,
-      excludedRDNS: []
+      excludedWallets: []
     })
     vi.spyOn(ConnectionController, 'checkInstalled').mockReturnValue(true)
   })
@@ -84,7 +84,7 @@ describe('W3mConnectInjectedWidget', () => {
   it('should not render excluded RDNS wallets', async () => {
     vi.spyOn(ApiController, 'state', 'get').mockReturnValue({
       ...ApiController.state,
-      excludedRDNS: ['mock.injected.wallet']
+      excludedWallets: [{ name: 'Mock Wallet', rdns: 'mock.wallet' }]
     })
 
     const element: W3mConnectInjectedWidget = await fixture(

--- a/packages/scaffold-ui/test/utils/ConnectorUtil.test.ts
+++ b/packages/scaffold-ui/test/utils/ConnectorUtil.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { OptionsController, type WcWallet } from '@reown/appkit-controllers'
+import {
+  ApiController,
+  ConnectionController,
+  type ConnectorWithProviders,
+  CoreHelperUtil,
+  OptionsController,
+  type WcWallet
+} from '@reown/appkit-controllers'
 
 import { ConnectorUtil } from '../../src/utils/ConnectorUtil'
 
@@ -10,6 +17,21 @@ const FEATURED = { id: 'featured' } as WcWallet
 const CUSTOM = { id: 'custom' } as WcWallet
 const EXTERNAL = { id: 'external' } as WcWallet
 const MULTI_CHAIN = { id: 'multiChain' } as WcWallet
+
+const INJECTED_CONNECTOR = {
+  id: 'injected',
+  type: 'INJECTED',
+  info: { rdns: 'browser.wallet' },
+  name: 'Browser Wallet',
+  chain: { id: 'eip155:1' }
+} as unknown as ConnectorWithProviders
+const ANNOUNCED_CONNECTOR = {
+  id: 'announced',
+  type: 'ANNOUNCED',
+  info: { rdns: 'announced.wallet' },
+  name: 'Announced Wallet',
+  chain: { id: 'eip155:1' }
+} as unknown as ConnectorWithProviders
 
 describe('ConnectorUtil', () => {
   beforeEach(() => {
@@ -154,6 +176,75 @@ describe('ConnectorUtil', () => {
 
       expect(result).toEqual(['injected'])
       expect(result).not.toContain('walletConnect')
+    })
+  })
+
+  describe('showConnector', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should hide browser wallet on desktop', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+
+      expect(ConnectorUtil.showConnector(INJECTED_CONNECTOR)).toBe(false)
+    })
+
+    it('should show browser wallet on mobile', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+      vi.spyOn(ConnectionController, 'checkInstalled').mockReturnValue(true)
+
+      expect(ConnectorUtil.showConnector(INJECTED_CONNECTOR)).toBe(true)
+    })
+
+    it('should hide injected connector when not installed and no rdns', () => {
+      vi.spyOn(ConnectionController, 'checkInstalled').mockReturnValue(false)
+
+      expect(ConnectorUtil.showConnector({ ...INJECTED_CONNECTOR, info: undefined })).toBe(false)
+    })
+
+    it('should hide connector when rdns is excluded', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([
+        { rdns: 'browser.wallet', name: 'Test Wallet' }
+      ])
+
+      expect(ConnectorUtil.showConnector(INJECTED_CONNECTOR)).toBe(false)
+    })
+
+    it('should hide connector when name is excluded', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([
+        { name: 'Browser Wallet', rdns: 'test.wallet' }
+      ])
+
+      expect(ConnectorUtil.showConnector(INJECTED_CONNECTOR)).toBe(false)
+    })
+
+    it('should hide announced connector when excluded with rdns', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([
+        { rdns: 'announced.wallet', name: 'Announced Wallet' }
+      ])
+
+      expect(ConnectorUtil.showConnector(ANNOUNCED_CONNECTOR)).toBe(false)
+    })
+
+    it('should hide announced connector when excluded with name', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([
+        { name: 'Announced Wallet', rdns: 'announced' }
+      ])
+
+      expect(ConnectorUtil.showConnector(ANNOUNCED_CONNECTOR)).toBe(false)
+    })
+
+    it('should show injected connector when not excluded', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([])
+
+      expect(ConnectorUtil.showConnector(INJECTED_CONNECTOR)).toBe(true)
+    })
+
+    it('should show announced connector when not excluded', () => {
+      vi.spyOn(ApiController.state, 'excludedWallets', 'get').mockReturnValue([])
+
+      expect(ConnectorUtil.showConnector(ANNOUNCED_CONNECTOR)).toBe(true)
     })
   })
 })


### PR DESCRIPTION
# Description

Fixed an issue where `excludeWalletIds` option wasn't properly filtering Bitcoin wallets

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2548

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
