### PR TITLE
chore: use main domain if the deployment is production

### DIFF
--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -37,6 +37,11 @@ export const DOCS_URL = 'https://docs.reown.com/appkit/overview'
 export const REPO_URL = 'https://github.com/reown-com/appkit'
 
 export function getPublicUrl() {
+  const isProduction = process.env['NODE_ENV'] === 'production'
+  if (isProduction) {
+    return 'https://appkit-lab.reown.org'
+  }
+
   const publicUrl = process.env['NEXT_PUBLIC_PUBLIC_URL']
   if (publicUrl) {
     return publicUrl

--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -39,7 +39,7 @@ export const REPO_URL = 'https://github.com/reown-com/appkit'
 export function getPublicUrl() {
   const isProduction = process.env['NODE_ENV'] === 'production'
   if (isProduction) {
-    return 'https://appkit-lab.reown.org'
+    return 'https://appkit-lab.reown.com'
   }
 
   const publicUrl = process.env['NEXT_PUBLIC_PUBLIC_URL']


### PR DESCRIPTION
# Description

When we use `NEXT_PUBLIC_VERCEL_URL` on production, we are getting some domain mismatch about the app's metadata on the wallet views:

<img width="1310" alt="Screenshot 2025-04-02 at 11 09 53" src="https://github.com/user-attachments/assets/c2fb0dc2-c537-4824-9364-8da978346197" />

This is because we are using the `NEXT_PUBLIC_VERCEL_URL` env in the lab app which is automatically being set by Vercel as Preview domain

This PR changes to use `appkit-lab.reown.org` if the production is deployment.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
