### PR TITLE
fix: appkit cdn not reconnecting after page refresh

### DIFF
--- a/examples/html-wagmi-cdn/src/main.js
+++ b/examples/html-wagmi-cdn/src/main.js
@@ -34,8 +34,8 @@ const modal = createAppKit({
 })
 
 watchConnectors(wagmiAdapter.wagmiConfig, {
-  onChange(data) {
-    if (data.length > 4) {
+  onChange(connectors) {
+    if (connectors.length > 4) {
       reconnect(wagmiAdapter.wagmiConfig)
     }
   }

--- a/examples/html-wagmi-cdn/src/main.js
+++ b/examples/html-wagmi-cdn/src/main.js
@@ -3,7 +3,7 @@ import {
   createAppKit,
   networks
 } from 'https://cdn.jsdelivr.net/npm/@reown/appkit-cdn@1.7.0/dist/appkit.js'
-import { reconnect } from 'https://esm.sh/@wagmi/core@2.x'
+import { reconnect, watchConnectors } from 'https://esm.sh/@wagmi/core@2.x'
 
 // Get projectId
 export const projectId = import.meta.env.VITE_PROJECT_ID || 'b56e18d47c72ab683b10814fe9495694' // this is a public projectId only to use on localhost
@@ -33,7 +33,13 @@ const modal = createAppKit({
   }
 })
 
-reconnect(wagmiAdapter.wagmiConfig)
+watchConnectors(wagmiAdapter.wagmiConfig, {
+  onChange(data) {
+    if (data.length > 4) {
+      reconnect(wagmiAdapter.wagmiConfig)
+    }
+  }
+})
 
 // State objects
 let accountState = {}


### PR DESCRIPTION
# Description

Fixed an issue where WalletConnect wouldn’t reconnect after a page refresh, even if the user was previously connected.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2485

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
