### PR TITLE
fix: universal provider example crashes when signing a solana message

### DIFF
--- a/apps/laboratory/app/core/universal-provider/page.tsx
+++ b/apps/laboratory/app/core/universal-provider/page.tsx
@@ -212,7 +212,7 @@ export default function UniversalProviderPage() {
         return
       }
 
-      const signature: string = await provider.request(payload, network)
+      const { signature } = await provider.request<{ signature: string }>(payload, network)
 
       toast({
         title: ConstantsUtil.SigningSucceededToastTitle,


### PR DESCRIPTION
# Description

Fixed an issue where the universal provider solana sign message functionality caused a crash

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2472

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
