### PR TITLE
chore: temporary disables loader validation in ci

### DIFF
--- a/apps/laboratory/tests/email-after-farcaster.spec.ts
+++ b/apps/laboratory/tests/email-after-farcaster.spec.ts
@@ -139,6 +139,7 @@ emailTestAfterFarcaster(
   'it should disconnect correctly after abort login with farcaster',
   async () => {
     await page.page.context().setOffline(false)
+    await page.page.reload()
     await page.goToSettings()
     await page.disconnect()
     await validator.expectDisconnected()

--- a/apps/laboratory/tests/email-after-farcaster.spec.ts
+++ b/apps/laboratory/tests/email-after-farcaster.spec.ts
@@ -114,7 +114,11 @@ emailTestAfterFarcaster(
   'it should show loading on page refresh after abort login with farcaster',
   async () => {
     await page.page.reload()
-    await validator.expectConnectButtonLoading()
+    /*
+     * Disable loading animation check as reload happens before the page is loaded
+     * TODO: figure out how to validate the loader before the page is loaded
+     * await validator.expectConnectButtonLoading()
+     */
     await validator.expectAccountButtonReady()
   }
 )

--- a/apps/laboratory/tests/email.spec.ts
+++ b/apps/laboratory/tests/email.spec.ts
@@ -121,7 +121,11 @@ emailTest('it should show names feature only for EVM networks', async ({ library
 
 emailTest('it should show loading on page refresh', async () => {
   await page.page.reload()
-  await validator.expectConnectButtonLoading()
+  /*
+   * Disable loading animation check as reload happens before the page is loaded
+   * TODO: figure out how to validate the loader before the page is loaded
+   * await validator.expectConnectButtonLoading()
+   */
   await validator.expectAccountButtonReady()
 })
 

--- a/apps/laboratory/tests/smart-account.spec.ts
+++ b/apps/laboratory/tests/smart-account.spec.ts
@@ -138,6 +138,7 @@ smartAccountTest('it should switch to eoa and sign', async ({ library }) => {
 })
 
 smartAccountTest('it should disconnect correctly', async () => {
+  await page.page.reload()
   await page.goToSettings()
   await page.disconnect()
   await validator.expectDisconnected()


### PR DESCRIPTION
# Description

Temporary disable loader validation in CI until we figure a way to register the loader validator mid page init, not after, as by the time `page.reload` finishes, the loader has been shown and hidden

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
