### PR TITLE
chore: remove activity and nft tabs for account view when using solana

### DIFF
--- a/.changeset/moody-keys-bet.md
+++ b/.changeset/moody-keys-bet.md
@@ -21,4 +21,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Removed activity and nft tabs from account modal when using Solana
+Removed activity and nft tabs from account modal when using solana

--- a/.changeset/moody-keys-bet.md
+++ b/.changeset/moody-keys-bet.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Removed activity and nft tabs from account modal when using Solana

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -271,9 +271,9 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
   }
 
   private tabsTemplate() {
-    const isSolana = ChainController.state.activeChain === CommonConstantsUtil.CHAIN.SOLANA
+    const isEVM = ChainController.state.activeChain === CommonConstantsUtil.CHAIN.EVM
 
-    if (isSolana) {
+    if (!isEVM) {
       return null
     }
 

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -24,7 +24,7 @@ import '@reown/appkit-ui/wui-tabs'
 import '@reown/appkit-ui/wui-tooltip'
 import { W3mFrameRpcConstants } from '@reown/appkit-wallet/utils'
 
-import { ConstantsUtil } from '../../utils/ConstantsUtil.js'
+import { HelpersUtil } from '../../utils/HelpersUtil.js'
 import '../w3m-account-activity-widget/index.js'
 import '../w3m-account-nfts-widget/index.js'
 import '../w3m-account-tokens-widget/index.js'
@@ -271,9 +271,9 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
   }
 
   private tabsTemplate() {
-    const isEVM = ChainController.state.activeChain === CommonConstantsUtil.CHAIN.EVM
+    const tabsByNamespace = HelpersUtil.getTabsByNamespace(ChainController.state.activeChain)
 
-    if (!isEVM) {
+    if (tabsByNamespace.length === 0) {
       return null
     }
 
@@ -283,7 +283,7 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
       localTabWidth=${CoreHelperUtil.isMobile() && window.innerWidth < MODAL_MOBILE_VIEW_PX
         ? `${(window.innerWidth - TABS_PADDING) / TABS}px`
         : '104px'}
-      .tabs=${ConstantsUtil.ACCOUNT_TABS}
+      .tabs=${tabsByNamespace}
     ></wui-tabs>`
   }
 

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -119,16 +119,7 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
         data-testid="w3m-profile-button"
       ></wui-profile-button>
 
-      ${this.tokenBalanceTemplate()} ${this.orderedWalletFeatures()}
-
-      <wui-tabs
-        .onTabChange=${this.onTabChange.bind(this)}
-        .activeTab=${this.currentTab}
-        localTabWidth=${CoreHelperUtil.isMobile() && window.innerWidth < MODAL_MOBILE_VIEW_PX
-          ? `${(window.innerWidth - TABS_PADDING) / TABS}px`
-          : '104px'}
-        .tabs=${ConstantsUtil.ACCOUNT_TABS}
-      ></wui-tabs>
+      ${this.tokenBalanceTemplate()} ${this.orderedWalletFeatures()} ${this.tabsTemplate()}
       ${this.listContentTemplate()}
     </wui-flex>`
   }
@@ -277,6 +268,23 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
     }
 
     return html`<wui-balance dollars="0" pennies="00"></wui-balance>`
+  }
+
+  private tabsTemplate() {
+    const isSolana = ChainController.state.activeChain === CommonConstantsUtil.CHAIN.SOLANA
+
+    if (isSolana) {
+      return null
+    }
+
+    return html`<wui-tabs
+      .onTabChange=${this.onTabChange.bind(this)}
+      .activeTab=${this.currentTab}
+      localTabWidth=${CoreHelperUtil.isMobile() && window.innerWidth < MODAL_MOBILE_VIEW_PX
+        ? `${(window.innerWidth - TABS_PADDING) / TABS}px`
+        : '104px'}
+      .tabs=${ConstantsUtil.ACCOUNT_TABS}
+    ></wui-tabs>`
   }
 
   private onTabChange(index: number) {

--- a/packages/scaffold-ui/src/utils/HelpersUtil.ts
+++ b/packages/scaffold-ui/src/utils/HelpersUtil.ts
@@ -1,0 +1,15 @@
+import { type ChainNamespace, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
+
+import { ConstantsUtil } from './ConstantsUtil.js'
+
+export const HelpersUtil = {
+  getTabsByNamespace(namespace?: ChainNamespace) {
+    const isEVM = Boolean(namespace) && namespace === CommonConstantsUtil.CHAIN.EVM
+
+    if (!isEVM) {
+      return []
+    }
+
+    return ConstantsUtil.ACCOUNT_TABS
+  }
+}

--- a/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
@@ -1,5 +1,5 @@
 import { elementUpdated, fixture } from '@open-wc/testing'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { html } from 'lit'
 
@@ -12,7 +12,6 @@ import {
 } from '@reown/appkit-controllers'
 
 import { W3mAccountWalletFeaturesWidget } from '../../src/partials/w3m-account-wallet-features-widget'
-import { ConstantsUtil } from '../../src/utils/ConstantsUtil'
 import { HelpersUtil } from '../utils/HelpersUtil'
 
 // --- Constants ---------------------------------------------------- //

--- a/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-account-wallet-features-widget.test.ts
@@ -1,12 +1,18 @@
 import { elementUpdated, fixture } from '@open-wc/testing'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { html } from 'lit'
 
 import { ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
-import { AccountController, CoreHelperUtil, RouterController } from '@reown/appkit-controllers'
+import {
+  AccountController,
+  ChainController,
+  CoreHelperUtil,
+  RouterController
+} from '@reown/appkit-controllers'
 
 import { W3mAccountWalletFeaturesWidget } from '../../src/partials/w3m-account-wallet-features-widget'
+import { ConstantsUtil } from '../../src/utils/ConstantsUtil'
 import { HelpersUtil } from '../utils/HelpersUtil'
 
 // --- Constants ---------------------------------------------------- //
@@ -28,7 +34,7 @@ describe('W3mAccountWalletFeaturesWidget', () => {
   })
 
   afterEach(() => {
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
   it('it should not return any components if address is not provided in AccountController', () => {
@@ -83,6 +89,44 @@ describe('W3mAccountWalletFeaturesWidget', () => {
     button.click()
 
     expect(pushSpy).toHaveBeenCalledWith('AccountSettings')
+  })
+
+  it('should show tabs for eip155 namespace', async () => {
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...AccountController.state,
+      address: MOCK_ADDRESS
+    })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      ...ChainController.state,
+      activeChain: CommonConstantsUtil.CHAIN.EVM
+    })
+
+    const element: W3mAccountWalletFeaturesWidget = await fixture(
+      html`<w3m-account-wallet-features-widget></w3m-account-wallet-features-widget>`
+    )
+
+    await elementUpdated(element)
+    const tabs = HelpersUtil.querySelect(element, 'wui-tabs')
+    expect(tabs).not.toBeNull()
+  })
+
+  it('should not show tabs for solana namespace', async () => {
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...AccountController.state,
+      address: MOCK_ADDRESS
+    })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      ...ChainController.state,
+      activeChain: CommonConstantsUtil.CHAIN.SOLANA
+    })
+
+    const element: W3mAccountWalletFeaturesWidget = await fixture(
+      html`<w3m-account-wallet-features-widget></w3m-account-wallet-features-widget>`
+    )
+
+    await elementUpdated(element)
+    const tabs = HelpersUtil.querySelect(element, 'wui-tabs')
+    expect(tabs).toBeNull()
   })
 
   it('should redirect to Profile view if has more than one account', async () => {


### PR DESCRIPTION
# Description

Removed activity and nft tabs from account modal when using solana

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2528

# Showcase (Optional)

![Screenshot 2025-04-07 at 15 43 06](https://github.com/user-attachments/assets/99f45e07-fd27-4294-9e51-0fd36fc27829)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
