### PR TITLE
chore(ci): GitHub Merge Queue compatibility

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
     # The merge queue provides the same benefits
     # as the Require branches to be up to date before merging branch protection,
-    # but does not require a pull request author to update their pull 
+    # but does not require a pull request author to update their pull
     # request branch and wait for status checks to finish before trying to merge.
     # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
     branches:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -5,6 +5,14 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
+  merge_group:
+    # The merge queue provides the same benefits
+    # as the Require branches to be up to date before merging branch protection,
+    # but does not require a pull request author to update their pull 
+    # request branch and wait for status checks to finish before trying to merge.
+    # See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+    branches:
+      - main
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
# Description

The merge queue will no longer require the team to `Require branches to be up to date before` before merging as the merge queue will handle this. It will still require all tests to pass of course.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
