### PR TITLE
fix: connectors not syncing properly when using multichain

### DIFF
--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -14,7 +14,7 @@
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run public-methods.test.ts --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true"
+    "test": "vitest run --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true"
   },
   "exports": {
     ".": {

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -14,7 +14,7 @@
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true"
+    "test": "vitest run public-methods.test.ts --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true"
   },
   "exports": {
     ".": {

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1430,7 +1430,7 @@ export abstract class AppKitBaseClient {
     ChainController.getAccountProp('address', chainNamespace)
 
   public setConnectors: (typeof ConnectorController)['setConnectors'] = connectors => {
-    const allConnectors = [...ConnectorController.getConnectors(), ...connectors]
+    const allConnectors = [...ConnectorController.state.allConnectors, ...connectors]
     ConnectorController.setConnectors(allConnectors)
   }
 

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -1114,4 +1114,46 @@ describe('Base Public methods', () => {
     expect(showUnsupportedChainUI).not.toHaveBeenCalled()
     expect(setActiveCaipNetwork).toHaveBeenCalledWith(mainnet)
   })
+
+  it('should set connectors correctly', () => {
+    // Reset connectors state
+    ConnectorController.state.allConnectors = []
+    ConnectorController.state.connectors = []
+
+    const ethConnector = {
+      id: 'mock',
+      name: 'Mock',
+      type: 'injected',
+      chain: 'eip155'
+    } as unknown as Connector
+
+    const solConnector = {
+      id: 'mock',
+      name: 'Mock',
+      type: 'injected',
+      chain: 'solana'
+    } as unknown as Connector
+
+    const appKit = new AppKit(mockOptions)
+
+    appKit.setConnectors([ethConnector])
+
+    expect(ConnectorController.state.allConnectors).toEqual([ethConnector])
+
+    appKit.setConnectors([solConnector])
+
+    expect(ConnectorController.state.allConnectors).toEqual([ethConnector, solConnector])
+    expect(ConnectorController.state.connectors.length).toEqual(1)
+
+    // Handle merged connectors
+    const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.find(
+      c => c.connectors && c.connectors.length > 0
+    )
+    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
+
+    const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.find(
+      c => c.connectors && c.connectors.length > 0
+    )
+    expect(hasMergedConnectorFromConnectors).toBeDefined()
+  })
 })

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -487,15 +487,15 @@ describe('Base Public methods', () => {
     expect(ConnectorController.state.connectors.length).toEqual(1)
 
     // Handle merged connectors
-    const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.find(
+    const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.some(
       c => c.connectors && c.connectors.length > 0
     )
-    const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.find(
+    const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.some(
       c => c.connectors && c.connectors.length > 0
     )
 
-    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
-    expect(hasMergedConnectorFromConnectors).toBeDefined()
+    expect(hasMergedConnectorFromAllConnectors).toBe(false)
+    expect(hasMergedConnectorFromConnectors).toBe(true)
   })
 
   it('should add connector', () => {

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -1149,11 +1149,11 @@ describe('Base Public methods', () => {
     const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.find(
       c => c.connectors && c.connectors.length > 0
     )
-    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
-
     const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.find(
       c => c.connectors && c.connectors.length > 0
     )
+
+    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
     expect(hasMergedConnectorFromConnectors).toBeDefined()
   })
 })

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -439,23 +439,46 @@ describe('Base Public methods', () => {
     expect(setRequestedCaipNetworks).toHaveBeenCalledWith(requestedNetworks, mainnet.chainNamespace)
   })
 
-  it('should set connectors', () => {
-    const getConnectors = vi.spyOn(ConnectorController, 'getConnectors')
-    const setConnectors = vi.spyOn(ConnectorController, 'setConnectors')
-    const existingConnectors = [
-      { id: 'phantom', name: 'Phantom', chain: 'eip155', type: 'INJECTED' }
-    ] as Connector[]
-    // Mock getConnectors to return existing connectors
-    vi.mocked(getConnectors).mockReturnValue(existingConnectors)
-    const newConnectors = [
-      { id: 'metamask', name: 'MetaMask', chain: 'eip155', type: 'INJECTED' }
-    ] as Connector[]
+  it('should set connectors correctly', () => {
+    // Reset connectors state
+    ConnectorController.state.allConnectors = []
+    ConnectorController.state.connectors = []
+
+    const ethConnector = {
+      id: 'mock',
+      name: 'Mock',
+      type: 'injected',
+      chain: 'eip155'
+    } as unknown as Connector
+
+    const solConnector = {
+      id: 'mock',
+      name: 'Mock',
+      type: 'injected',
+      chain: 'solana'
+    } as unknown as Connector
 
     const appKit = new AppKit(mockOptions)
-    appKit.setConnectors(newConnectors)
 
-    // Verify that setConnectors was called with combined array
-    expect(setConnectors).toHaveBeenCalledWith([...existingConnectors, ...newConnectors])
+    appKit.setConnectors([ethConnector])
+
+    expect(ConnectorController.state.allConnectors).toEqual([ethConnector])
+
+    appKit.setConnectors([solConnector])
+
+    expect(ConnectorController.state.allConnectors).toEqual([ethConnector, solConnector])
+    expect(ConnectorController.state.connectors.length).toEqual(1)
+
+    // Handle merged connectors
+    const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.find(
+      c => c.connectors && c.connectors.length > 0
+    )
+    const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.find(
+      c => c.connectors && c.connectors.length > 0
+    )
+
+    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
+    expect(hasMergedConnectorFromConnectors).toBeDefined()
   })
 
   it('should add connector', () => {
@@ -1113,47 +1136,5 @@ describe('Base Public methods', () => {
 
     expect(showUnsupportedChainUI).not.toHaveBeenCalled()
     expect(setActiveCaipNetwork).toHaveBeenCalledWith(mainnet)
-  })
-
-  it('should set connectors correctly', () => {
-    // Reset connectors state
-    ConnectorController.state.allConnectors = []
-    ConnectorController.state.connectors = []
-
-    const ethConnector = {
-      id: 'mock',
-      name: 'Mock',
-      type: 'injected',
-      chain: 'eip155'
-    } as unknown as Connector
-
-    const solConnector = {
-      id: 'mock',
-      name: 'Mock',
-      type: 'injected',
-      chain: 'solana'
-    } as unknown as Connector
-
-    const appKit = new AppKit(mockOptions)
-
-    appKit.setConnectors([ethConnector])
-
-    expect(ConnectorController.state.allConnectors).toEqual([ethConnector])
-
-    appKit.setConnectors([solConnector])
-
-    expect(ConnectorController.state.allConnectors).toEqual([ethConnector, solConnector])
-    expect(ConnectorController.state.connectors.length).toEqual(1)
-
-    // Handle merged connectors
-    const hasMergedConnectorFromAllConnectors = ConnectorController.state.allConnectors.find(
-      c => c.connectors && c.connectors.length > 0
-    )
-    const hasMergedConnectorFromConnectors = ConnectorController.state.connectors.find(
-      c => c.connectors && c.connectors.length > 0
-    )
-
-    expect(hasMergedConnectorFromAllConnectors).toBeUndefined()
-    expect(hasMergedConnectorFromConnectors).toBeDefined()
   })
 })

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -439,7 +439,24 @@ describe('Base Public methods', () => {
     expect(setRequestedCaipNetworks).toHaveBeenCalledWith(requestedNetworks, mainnet.chainNamespace)
   })
 
-  it('should set connectors correctly', () => {
+  it('should set connectors', () => {
+    const existingConnectors = [
+      { id: 'phantom', name: 'Phantom', chain: 'eip155', type: 'INJECTED' }
+    ] as Connector[]
+    const newConnectors = [
+      { id: 'metamask', name: 'MetaMask', chain: 'eip155', type: 'INJECTED' }
+    ] as Connector[]
+
+    const combinedConnectors = [...existingConnectors, ...newConnectors]
+
+    const appKit = new AppKit(mockOptions)
+    appKit.setConnectors(combinedConnectors)
+
+    expect(ConnectorController.state.connectors).toEqual(combinedConnectors)
+    expect(ConnectorController.state.allConnectors).toEqual(combinedConnectors)
+  })
+
+  it('should set multichain connectors', () => {
     // Reset connectors state
     ConnectorController.state.allConnectors = []
     ConnectorController.state.connectors = []
@@ -447,14 +464,14 @@ describe('Base Public methods', () => {
     const ethConnector = {
       id: 'mock',
       name: 'Mock',
-      type: 'injected',
+      type: 'INJECTED',
       chain: 'eip155'
     } as unknown as Connector
 
     const solConnector = {
       id: 'mock',
       name: 'Mock',
-      type: 'injected',
+      type: 'INJECTED',
       chain: 'solana'
     } as unknown as Connector
 


### PR DESCRIPTION
# Description

Fixed an issue where connectors didn’t sync properly when using multichain

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2648

# Showcase (Optional)

**Before when using SIWX multichain 👇**

![Screenshot 2025-04-08 at 14 21 07](https://github.com/user-attachments/assets/11063376-a7bb-43d8-a247-171c36b4f50e)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
