### PR TITLE
feat: swap view opening arguments

### DIFF
--- a/.changeset/few-pugs-pull.md
+++ b/.changeset/few-pugs-pull.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Add `arguments` param for `appkit.open` function and attach swap initial arguments when opening Swap view.

--- a/apps/laboratory/src/components/AppKitHooks.tsx
+++ b/apps/laboratory/src/components/AppKitHooks.tsx
@@ -50,6 +50,17 @@ export function AppKitHooks() {
     switchNetwork(networkToSwitch)
   }
 
+  function handleOpenSwapWithArguments() {
+    open({
+      view: 'Swap',
+      arguments: {
+        amount: '321.123',
+        fromToken: 'USDC',
+        toToken: 'ETH'
+      }
+    })
+  }
+
   return (
     <Box>
       <Heading size="xs" textTransform="uppercase" pb="2">
@@ -80,6 +91,13 @@ export function AppKitHooks() {
             <Button onClick={() => switchNetwork(bitcoin)}>Switch to Bitcoin</Button>
           </>
         )}
+
+        <Button
+          data-testid="open-swap-with-arguments-hook-button"
+          onClick={handleOpenSwapWithArguments}
+        >
+          Open Swap with Arguments
+        </Button>
       </Box>
     </Box>
   )

--- a/apps/laboratory/tests/wallet-features.spec.ts
+++ b/apps/laboratory/tests/wallet-features.spec.ts
@@ -127,3 +127,15 @@ walletFeaturesTest('it should search for a certified wallet', async () => {
   await page.search('MetaMask')
   await validator.expectAllWalletsListSearchItem(METAMASK_WALLET_ID)
 })
+
+walletFeaturesTest('it should show swap view with preselected tokens', async () => {
+  await page.page.getByTestId('open-swap-with-arguments-hook-button').click()
+
+  await expect(page.page.getByTestId('swap-input-token-sourceToken')).toHaveText('USDC')
+  await expect(page.page.getByTestId('swap-input-token-toToken')).toHaveText('ETH')
+  await expect(page.page.getByTestId('swap-input-sourceToken')).toHaveText('321.123')
+  const actionButton = page.page.getByTestId('swap-action-button')
+  await expect(actionButton).toHaveText('Insufficient Balance')
+
+  await page.closeModal()
+})

--- a/apps/laboratory/tests/wallet-features.spec.ts
+++ b/apps/laboratory/tests/wallet-features.spec.ts
@@ -69,6 +69,17 @@ walletFeaturesTest('it should initialize swap as expected', async () => {
   await page.closeModal()
 })
 
+walletFeaturesTest('it should show swap view with preselected tokens', async () => {
+  await page.page.getByTestId('open-swap-with-arguments-hook-button').click()
+
+  await expect(page.page.getByTestId('swap-input-token-sourceToken')).toHaveText('USDC')
+  await expect(page.page.getByTestId('swap-input-token-toToken')).toHaveText('ETH')
+  await expect(page.page.getByTestId('swap-input-sourceToken')).toHaveValue('321.123')
+  await expect(page.page.getByTestId('swap-action-button')).toHaveText('Insufficient balance')
+
+  await page.closeModal()
+})
+
 walletFeaturesTest('it should initialize onramp as expected', async () => {
   await page.openAccount()
   const walletFeatureButton = await page.getWalletFeaturesButton('onramp')
@@ -126,16 +137,4 @@ walletFeaturesTest('it should search for a certified wallet', async () => {
   await page.clickCertifiedToggle()
   await page.search('MetaMask')
   await validator.expectAllWalletsListSearchItem(METAMASK_WALLET_ID)
-})
-
-walletFeaturesTest('it should show swap view with preselected tokens', async () => {
-  await page.page.getByTestId('open-swap-with-arguments-hook-button').click()
-
-  await expect(page.page.getByTestId('swap-input-token-sourceToken')).toHaveText('USDC')
-  await expect(page.page.getByTestId('swap-input-token-toToken')).toHaveText('ETH')
-  await expect(page.page.getByTestId('swap-input-sourceToken')).toHaveText('321.123')
-  const actionButton = page.page.getByTestId('swap-action-button')
-  await expect(actionButton).toHaveText('Insufficient Balance')
-
-  await page.closeModal()
 })

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -22,7 +22,6 @@ import type {
   EstimateGasTransactionArgs,
   EventsControllerState,
   Features,
-  ModalControllerArguments,
   ModalControllerState,
   NetworkControllerClient,
   OptionsControllerState,
@@ -1472,16 +1471,15 @@ export abstract class AppKitBaseClient {
       ConnectionController.setUri(options.uri)
     }
 
-    const data: ModalControllerArguments['open']['data'] = {}
-
-    switch (options?.view) {
-      case 'Swap':
-        data.swap = options.arguments
-        break
-      default:
+    if (options?.arguments) {
+      switch (options?.view) {
+        case 'Swap':
+          return ModalController.open({ ...options, data: { swap: options.arguments } })
+        default:
+      }
     }
 
-    await ModalController.open({ ...options, data })
+    return ModalController.open(options)
   }
 
   public async close() {

--- a/packages/appkit/src/client/appkit-core.ts
+++ b/packages/appkit/src/client/appkit-core.ts
@@ -9,7 +9,11 @@ import {
 } from '@reown/appkit-controllers'
 
 import type { AdapterBlueprint } from '../adapters/ChainAdapterBlueprint.js'
-import { AppKitBaseClient } from './appkit-base-client.js'
+import {
+  AppKitBaseClient,
+  type OpenOptions as BaseOpenOptions,
+  type Views
+} from './appkit-base-client.js'
 
 declare global {
   interface Window {
@@ -21,21 +25,7 @@ declare global {
 export { AccountController }
 
 // -- Types --------------------------------------------------------------------
-export interface OpenOptions {
-  view?:
-    | 'Account'
-    | 'Connect'
-    | 'Networks'
-    | 'ApproveTransaction'
-    | 'OnRampProviders'
-    | 'ConnectingWalletConnectBasic'
-    | 'Swap'
-    | 'WhatIsAWallet'
-    | 'WhatIsANetwork'
-    | 'AllWallets'
-    | 'WalletSend'
-  uri?: string
-}
+export type OpenOptions<View extends Views> = Omit<BaseOpenOptions<View>, 'namespace'>
 
 // -- Helpers -------------------------------------------------------------------
 let isInitialized = false
@@ -51,7 +41,7 @@ export class AppKit extends AppKitBaseClient {
   public adapter?: ChainAdapter
 
   // -- Overrides --------------------------------------------------------------
-  public override async open(options?: OpenOptions) {
+  public override async open<View extends Views>(options?: OpenOptions<View>) {
     // Only open modal when not connected
     const isConnected = ConnectorController.isConnected()
 

--- a/packages/appkit/src/library/react/index.ts
+++ b/packages/appkit/src/library/react/index.ts
@@ -15,24 +15,12 @@ import type {
 } from '@reown/appkit-scaffold-ui'
 import { ProviderUtil } from '@reown/appkit-utils'
 
-import type { AppKitBaseClient as AppKit } from '../../client/appkit-base-client.js'
+import type {
+  AppKitBaseClient as AppKit,
+  OpenOptions,
+  Views
+} from '../../client/appkit-base-client.js'
 import type { AppKitOptions } from '../../utils/TypesUtil.js'
-
-type OpenOptions = {
-  view?:
-    | 'Account'
-    | 'Connect'
-    | 'Networks'
-    | 'ApproveTransaction'
-    | 'OnRampProviders'
-    | 'Swap'
-    | 'WhatIsAWallet'
-    | 'WhatIsANetwork'
-    | 'AllWallets'
-    | 'WalletSend'
-  uri?: string
-  namespace?: ChainNamespace
-}
 
 type ThemeModeOptions = AppKitOptions['themeMode']
 
@@ -123,7 +111,7 @@ export function useAppKit() {
     throw new Error('Please call "createAppKit" before using "useAppKit" hook')
   }
 
-  async function open(options?: OpenOptions) {
+  async function open<View extends Views>(options?: OpenOptions<View>) {
     await modal?.open(options)
   }
 

--- a/packages/appkit/src/library/vue/index.ts
+++ b/packages/appkit/src/library/vue/index.ts
@@ -14,28 +14,16 @@ import type {
 } from '@reown/appkit-scaffold-ui'
 import { ProviderUtil } from '@reown/appkit-utils'
 
-import type { AppKitBaseClient as AppKit } from '../../client/appkit-base-client.js'
+import type {
+  AppKitBaseClient as AppKit,
+  OpenOptions,
+  Views
+} from '../../client/appkit-base-client.js'
 import type { AppKitOptions } from '../../utils/TypesUtil.js'
 
 export interface AppKitEvent {
   timestamp: number
   data: Event
-}
-
-type OpenOptions = {
-  view?:
-    | 'Account'
-    | 'Connect'
-    | 'Networks'
-    | 'ApproveTransaction'
-    | 'OnRampProviders'
-    | 'Swap'
-    | 'WhatIsAWallet'
-    | 'WhatIsANetwork'
-    | 'AllWallets'
-    | 'WalletSend'
-  uri?: string
-  namespace?: ChainNamespace
 }
 
 type ThemeModeOptions = AppKitOptions['themeMode']
@@ -135,7 +123,7 @@ export function useAppKit() {
     throw new Error('Please call "createAppKit" before using "useAppKit" composable')
   }
 
-  async function open(options?: OpenOptions) {
+  async function open<View extends Views>(options?: OpenOptions<View>) {
     await modal?.open(options)
   }
 

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -87,6 +87,29 @@ describe('Base Public methods', () => {
     }
   })
 
+  it.each([
+    {
+      view: 'Swap',
+      viewArguments: { fromToken: 'USDC', toToken: 'ETH', amount: '100' },
+      data: { swap: { fromToken: 'USDC', toToken: 'ETH', amount: '100' } }
+    }
+  ] as const)('should open swap view with arguments', async ({ view, viewArguments, data }) => {
+    const open = vi.spyOn(ModalController, 'open')
+
+    const appkit = new AppKit(mockOptions)
+    await appkit.open({
+      view,
+      arguments: viewArguments
+    })
+
+    expect(open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        view,
+        data
+      })
+    )
+  })
+
   it('should filter connectors by namespace when opening modal', async () => {
     const openSpy = vi.spyOn(ModalController, 'open')
     const setFilterByNamespaceSpy = vi.spyOn(ConnectorController, 'setFilterByNamespace')

--- a/packages/controllers/src/controllers/ModalController.ts
+++ b/packages/controllers/src/controllers/ModalController.ts
@@ -28,6 +28,7 @@ export interface ModalControllerArguments {
   open: {
     view?: RouterControllerState['view']
     namespace?: ChainNamespace
+    data?: RouterControllerState['data']
   }
 }
 
@@ -86,7 +87,7 @@ export const ModalController = {
         RouterController.reset('ConnectingWalletConnectBasic')
       }
     } else if (options?.view) {
-      RouterController.reset(options.view)
+      RouterController.reset(options.view, options.data)
     } else if (caipAddress) {
       RouterController.reset('Account')
     } else {

--- a/packages/controllers/src/controllers/RouterController.ts
+++ b/packages/controllers/src/controllers/RouterController.ts
@@ -9,7 +9,7 @@ import { ChainController } from './ChainController.js'
 import { ConnectorController } from './ConnectorController.js'
 import { ModalController } from './ModalController.js'
 import { OptionsController } from './OptionsController.js'
-import type { SwapInputTarget } from './SwapController.js'
+import type { SwapInputArguments, SwapInputTarget } from './SwapController.js'
 
 // -- Types --------------------------------------------- //
 type TransactionAction = {
@@ -103,6 +103,7 @@ export interface RouterControllerState {
     switchToChain?: ChainNamespace
     navigateTo?: RouterControllerState['view']
     navigateWithReplace?: boolean
+    swap?: SwapInputArguments
   }
   transactionStack: TransactionAction[]
 }

--- a/packages/controllers/src/controllers/SwapController.ts
+++ b/packages/controllers/src/controllers/SwapController.ts
@@ -28,6 +28,12 @@ export const TO_AMOUNT_DECIMALS = 6
 // -- Types --------------------------------------------- //
 export type SwapInputTarget = 'sourceToken' | 'toToken'
 
+export type SwapInputArguments = Partial<{
+  fromToken: string
+  toToken: string
+  amount: string
+}>
+
 type TransactionParams = {
   data: string
   to: string

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit'
-import { state } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 
 import { NumberUtil } from '@reown/appkit-common'
 import {
@@ -20,6 +20,7 @@ import '@reown/appkit-ui/wui-icon'
 import '@reown/appkit-ui/wui-text'
 import { W3mFrameRpcConstants } from '@reown/appkit-wallet/utils'
 
+import type { SwapInputArguments } from '../../../../controllers/dist/types/src/controllers/SwapController.js'
 import '../../partials/w3m-swap-details/index.js'
 import '../../partials/w3m-swap-input-skeleton/index.js'
 import '../../partials/w3m-swap-input/index.js'
@@ -32,6 +33,8 @@ export class W3mSwapView extends LitElement {
   private unsubscribe: ((() => void) | undefined)[] = []
 
   // -- State & Properties -------------------------------- //
+  @property({ type: Object }) initialParams = RouterController.state.data?.swap
+
   @state() private interval?: ReturnType<typeof setInterval>
 
   @state() private detailsOpen = false
@@ -117,6 +120,7 @@ export class W3mSwapView extends LitElement {
   public override firstUpdated() {
     SwapController.initializeState()
     this.watchTokensAndValues()
+    this.handleSwapParameters()
   }
 
   public override disconnectedCallback() {
@@ -315,6 +319,89 @@ export class W3mSwapView extends LitElement {
       }
     })
     RouterController.push('SwapPreview')
+  }
+  /**
+   * Processes token and amount parameters for swap
+   */
+  private async handleSwapParameters(): Promise<void> {
+    if (!this.initialParams) {
+      return
+    }
+
+    // Wait for initialization to complete
+    if (!SwapController.state.initialized) {
+      const waitForInitialization = new Promise<void>(resolve => {
+        const unsubscribe = SwapController.subscribeKey('initialized', initialized => {
+          if (initialized) {
+            unsubscribe?.()
+            resolve()
+          }
+        })
+      })
+      await waitForInitialization
+    }
+
+    await this.setSwapParameters(this.initialParams)
+  }
+
+  /**
+   * Sets the swap parameters based on URL parameters
+   * @param sourceTokenSymbol - The symbol of the source token
+   * @param toTokenSymbol - The symbol of the destination token
+   * @param amount - The amount to swap
+   */
+  private async setSwapParameters({
+    amount,
+    fromToken,
+    toToken
+  }: Omit<SwapInputArguments, 'caipNetworkId'>): Promise<void> {
+    // Wait for token list to be available
+    if (!SwapController.state.tokens || !SwapController.state.myTokensWithBalance) {
+      const waitForTokens = new Promise<void>(resolve => {
+        const unsubscribe = SwapController.subscribeKey('myTokensWithBalance', tokens => {
+          if (tokens && tokens.length > 0) {
+            unsubscribe?.()
+            resolve()
+          }
+        })
+
+        // Set a timeout to resolve anyway after 5 seconds
+        setTimeout(() => {
+          unsubscribe?.()
+          resolve()
+        }, 5000)
+      })
+
+      await waitForTokens
+    }
+
+    const allTokens = [
+      ...(SwapController.state.tokens || []),
+      ...(SwapController.state.myTokensWithBalance || [])
+    ]
+
+    // Find source token by symbol
+    if (fromToken) {
+      const token = allTokens.find(t => t.symbol.toLowerCase() === fromToken.toLowerCase())
+
+      if (token) {
+        SwapController.setSourceToken(token)
+      }
+    }
+
+    // Find destination token by symbol
+    if (toToken) {
+      const token = allTokens.find(t => t.symbol.toLowerCase() === toToken.toLowerCase())
+
+      if (token) {
+        SwapController.setToToken(token)
+      }
+    }
+
+    // Set amount if provided
+    if (amount && !isNaN(Number(amount))) {
+      SwapController.setSourceTokenAmount(amount)
+    }
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -117,10 +117,10 @@ export class W3mSwapView extends LitElement {
     )
   }
 
-  public override firstUpdated() {
+  public override async firstUpdated() {
     SwapController.initializeState()
     this.watchTokensAndValues()
-    this.handleSwapParameters()
+    await this.handleSwapParameters()
   }
 
   public override disconnectedCallback() {

--- a/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
@@ -1,5 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing'
-import { afterEach, beforeEach, describe, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, it, vi, expect as vitestExpect } from 'vitest'
 
 import {
   AccountController,
@@ -101,7 +101,11 @@ describe('W3mSwapView', () => {
       networkTokenSymbol: '',
       inputError: undefined,
       slippage: 0.5,
-      tokens: [mockToken],
+      tokens: [
+        mockToken,
+        Object.assign({}, mockToken, { symbol: 'AAAA' }),
+        Object.assign({}, mockToken, { symbol: 'BBBB' })
+      ],
       suggestedTokens: undefined,
       popularTokens: undefined,
       foundTokens: undefined,
@@ -123,6 +127,9 @@ describe('W3mSwapView', () => {
     vi.spyOn(SwapController, 'switchTokens').mockImplementation(() => {})
     vi.spyOn(SwapController, 'resetState').mockImplementation(() => {})
     vi.spyOn(RouterController, 'push').mockImplementation(() => {})
+    vi.spyOn(SwapController, 'setSourceToken').mockImplementation(() => {})
+    vi.spyOn(SwapController, 'setToToken').mockImplementation(() => {})
+    vi.spyOn(SwapController, 'setSourceTokenAmount').mockImplementation(() => {})
 
     vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
       ...AccountController.state,
@@ -323,5 +330,27 @@ describe('W3mSwapView', () => {
     // Verify methods were called when address changed
     expect(vi.mocked(SwapController.resetState).mock.calls.length).to.equal(1)
     expect(vi.mocked(SwapController.initializeState).mock.calls.length).to.equal(1)
+  })
+
+  it('should set initial state with preselected tokens', async () => {
+    const element = await fixture<W3mSwapView>(
+      html`<w3m-swap-view
+        initialParams='{"fromToken": "AAAA","toToken":"BBBB","amount":"321.123"}'
+      ></w3m-swap-view>`
+    )
+
+    await element.updateComplete
+
+    vitestExpect(SwapController.setSourceToken).toHaveBeenCalledWith(
+      vitestExpect.objectContaining({
+        symbol: 'AAAA'
+      })
+    )
+    vitestExpect(SwapController.setToToken).toHaveBeenCalledWith(
+      vitestExpect.objectContaining({
+        symbol: 'BBBB'
+      })
+    )
+    vitestExpect(SwapController.setSourceTokenAmount).toHaveBeenCalledWith('321.123')
   })
 })


### PR DESCRIPTION
# Description

Add `arguments` param for `appkit.open` function and attach swap initial arguments when opening Swap view.
This allows to open the `Swap` view with predefined tokens and input amount.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

https://github.com/user-attachments/assets/a349c3e1-5cba-465a-b5bb-6acb64d5ceb4

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
