### PR TITLE
fix: sats-connect connector doesn't trigger accountChanged event on after connecting

### DIFF
--- a/.changeset/fluffy-toys-vanish.md
+++ b/.changeset/fluffy-toys-vanish.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes XVerse wallet doesn't emitting accountChanged event on connection

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -87,6 +87,8 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
 
     this.bindEvents()
 
+    this.emit('accountsChanged', [address])
+
     return address
   }
 

--- a/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/SatsConnectConnector.test.ts
@@ -112,6 +112,7 @@ describe('SatsConnectConnector', () => {
   })
 
   it('should connect correctly with wallet not connected', async () => {
+    const emitSpy = vi.spyOn(connector, 'emit')
     const spy = vi.spyOn(mocks.wallet, 'request')
 
     spy.mockResolvedValueOnce(
@@ -142,6 +143,7 @@ describe('SatsConnectConnector', () => {
 
     const result = await connector.connect()
 
+    expect(emitSpy).toHaveBeenCalledWith('accountsChanged', ['mock_address'])
     expect(result).toBe('mock_address')
     expect(mocks.wallet.request).toHaveBeenNthCalledWith(1, 'getAddresses', {
       purposes: expect.arrayContaining(['payment', 'ordinals', 'stacks']),


### PR DESCRIPTION

# Description

When using SatsConnect Connector (i.e XVerse) it's not emitting the `accountChanged` event as expected. Thus, the AppKit doesn't get the connected account as expected.

In this PR it's trigering the `accountChanged` event inside the `connect()` function. This has been working before and XVerse team has been informed about this. 

- https://docs.xverse.app/sats-connect/xverse-wallet-events#listen-to-wallet-events

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
