### PR TITLE
fix: connecting state stays pending after request rejection

### DIFF
--- a/.changeset/fifty-beers-take.md
+++ b/.changeset/fifty-beers-take.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the wallet connection would remain in a pending state after a user rejected the connection request

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -375,20 +375,17 @@ export abstract class AppKitBaseClient {
         }
 
         const fallbackCaipNetwork = this.getCaipNetwork(chainToUse)
-        const res = await adapter
-          .connect({
-            id,
-            info,
-            type,
-            provider,
-            chainId: caipNetwork?.id || fallbackCaipNetwork?.id,
-            rpcUrl:
-              caipNetwork?.rpcUrls?.default?.http?.[0] ||
-              fallbackCaipNetwork?.rpcUrls?.default?.http?.[0]
-          })
-          .catch(error => {
-            console.warn('@appkit: connectExternal: error', error)
-          })
+
+        const res = await adapter.connect({
+          id,
+          info,
+          type,
+          provider,
+          chainId: caipNetwork?.id || fallbackCaipNetwork?.id,
+          rpcUrl:
+            caipNetwork?.rpcUrls?.default?.http?.[0] ||
+            fallbackCaipNetwork?.rpcUrls?.default?.http?.[0]
+        })
 
         if (!res) {
           return

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -263,3 +263,21 @@ describe('syncAdapterConnection', () => {
     expect(getCaipNetwork).toHaveBeenCalledWith('eip155')
   })
 })
+
+describe('connectExternal', () => {
+  it('should throw an error if connection gets declined', async () => {
+    const appKit = new AppKit(mockOptions)
+
+    vi.spyOn(mockEvmAdapter, 'connect').mockRejectedValue(new Error('Connection declined'))
+
+    await expect(
+      (appKit as any).connectionControllerClient['connectExternal']({
+        id: 'test-connector',
+        info: { name: 'Test Connector' },
+        type: 'injected',
+        provider: {},
+        chain: 'eip155'
+      })
+    ).rejects.toThrow('Connection declined')
+  })
+})

--- a/packages/appkit/tests/mocks/Adapter.ts
+++ b/packages/appkit/tests/mocks/Adapter.ts
@@ -81,7 +81,8 @@ export const mockEvmAdapter = {
   on: emitter.on.bind(emitter),
   off: emitter.off.bind(emitter),
   emit: emitter.emit.bind(emitter),
-  removeAllEventListeners: vi.fn()
+  removeAllEventListeners: vi.fn(),
+  connect: vi.fn().mockResolvedValue({ address: '0x123' })
 } as unknown as AdapterBlueprint
 
 export const mockSolanaAdapter = {


### PR DESCRIPTION
# Description

Fixed an issue where the wallet connection would remain in a pending state after a user rejected the connection request

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2668

# Showcase (Optional)

This remains pending forever after rejecting request.

![image](https://github.com/user-attachments/assets/30afefa8-b5a6-442f-b1c2-8af2017a70a0)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
