### PR TITLE
chore: fix incorrect check for modified core controller tests

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -218,7 +218,7 @@ async function checkCorePackage() {
     fail('New controllers were added, but no tests were created')
   }
 
-  if (modified_core_controllers.length && !modified_core_controllers_tests) {
+  if (modified_core_controllers.length && !modified_core_controllers_tests.length) {
     message(`
       The following controllers were modified, but not tests were changed:
       ${modified_core_controllers.join('\n')}


### PR DESCRIPTION
# Description

Spotted a small logic error in `checkCorePackage()`.  
The code was checking `!modified_core_controllers_tests`, but since it's an array, it should’ve been `!modified_core_controllers_tests.length`.  

This fixes the issue so the condition behaves as expected.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [x] Approver of this PR confirms that the changes are tested on the preview link
