### PR TITLE
fix: hide recent wallets listed in `excludeWalletIds`

### DIFF
--- a/.changeset/tricky-spiders-enter.md
+++ b/.changeset/tricky-spiders-enter.md
@@ -1,0 +1,24 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where recent wallets were not hidden when included in `excludeWalletIds`

--- a/packages/scaffold-ui/src/partials/w3m-connect-recent-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-recent-widget/index.ts
@@ -16,6 +16,8 @@ import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 import '@reown/appkit-ui/wui-list-wallet'
 
+import { WalletUtil } from '../../utils/WalletUtil.js'
+
 @customElement('w3m-connect-recent-widget')
 export class W3mConnectRecentWidget extends LitElement {
   // -- Members ------------------------------------------- //
@@ -47,6 +49,7 @@ export class W3mConnectRecentWidget extends LitElement {
     const recentWallets = StorageUtil.getRecentWallets()
 
     const filteredRecentWallets = recentWallets
+      .filter(wallet => !WalletUtil.isExcluded(wallet))
       .filter(wallet => !this.hasWalletConnector(wallet))
       .filter(wallet => this.isWalletCompatibleWithCurrentChain(wallet))
 

--- a/packages/scaffold-ui/src/utils/WalletUtil.ts
+++ b/packages/scaffold-ui/src/utils/WalletUtil.ts
@@ -6,6 +6,7 @@ import {
   StorageUtil
 } from '@reown/appkit-controllers'
 import type { ConnectMethod, Connector, Features, WcWallet } from '@reown/appkit-controllers'
+import { HelpersUtil } from '@reown/appkit-utils'
 
 import { ConnectorUtil } from './ConnectorUtil.js'
 import { ConstantsUtil } from './ConstantsUtil.js'
@@ -108,5 +109,17 @@ export const WalletUtil = {
     }
 
     return ConstantsUtil.DEFAULT_CONNECT_METHOD_ORDER
+  },
+  isExcluded(wallet: WcWallet) {
+    const isRDNSExcluded =
+      Boolean(wallet.rdns) && ApiController.state.excludedWallets.some(w => w.rdns === wallet.rdns)
+
+    const isNameExcluded =
+      Boolean(wallet.name) &&
+      ApiController.state.excludedWallets.some(w =>
+        HelpersUtil.isLowerCaseMatch(w.name, wallet.name)
+      )
+
+    return isRDNSExcluded || isNameExcluded
   }
 }


### PR DESCRIPTION
# Description

Fixed an issue where recent wallets were not hidden when included in `excludeWalletIds`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2318

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
