### PR TITLE
chore: adds dynamic locator and element getters in the modal validator

### DIFF
--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 import type { CaipNetworkId } from '@reown/appkit'
 
@@ -15,13 +15,41 @@ export class ModalValidator {
     this.page = page
   }
 
+  async getLocator(selector: string, timeout = 5000, interval = 500): Promise<Locator> {
+    const start = Date.now()
+    while (Date.now() - start < timeout) {
+      const element = this.page.locator(selector)
+      if (element) {
+        return element
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await this.page.waitForTimeout(interval) // Wait before rechecking
+    }
+    throw new Error(`Element ${selector} did not become visible within ${timeout}ms`)
+  }
+
+  async getByTestId(testId: string | RegExp, timeout = 5000, interval = 500): Promise<Locator> {
+    const start = Date.now()
+    while (Date.now() - start < timeout) {
+      const element = this.page.getByTestId(testId)
+      if (element) {
+        return element
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await this.page.waitForTimeout(interval) // Wait before rechecking
+    }
+    throw new Error(
+      `Element with data-testid="${testId}" did not become visible within ${timeout}ms`
+    )
+  }
+
   async expectConnected() {
-    const accountButton = this.page.locator('appkit-account-button').first()
+    const accountButton = (await this.getLocator('appkit-account-button')).first()
     await expect(accountButton, 'Account button should be present').toBeAttached({
       timeout: MAX_WAIT
     })
     await expect(
-      this.page.getByTestId('connect-button'),
+      await this.getByTestId('connect-button'),
       'Connect button should not be present'
     ).toBeHidden({
       timeout: MAX_WAIT
@@ -30,12 +58,12 @@ export class ModalValidator {
   }
 
   async expectLoading() {
-    const accountButton = this.page.locator('appkit-connect-button')
+    const accountButton = await this.getLocator('appkit-connect-button')
     await expect(accountButton, 'Account button should be present').toBeAttached({
       timeout: MAX_WAIT
     })
     await expect(
-      this.page.getByTestId('connect-button'),
+      await this.getByTestId('connect-button'),
       'Connect button should show connecting state'
     ).toHaveText('Connecting...', {
       timeout: MAX_WAIT
@@ -43,7 +71,7 @@ export class ModalValidator {
   }
 
   async expectBalanceFetched(currency: 'SOL' | 'ETH' | 'BTC' | 'POL') {
-    const accountButton = this.page.locator('appkit-account-button').first()
+    const accountButton = (await this.getLocator('appkit-account-button')).first()
     await expect(accountButton, `Account button should show balance as ${currency}`).toContainText(
       `0.000 ${currency}`
     )
@@ -51,24 +79,24 @@ export class ModalValidator {
 
   async expectAuthenticated() {
     await expect(
-      this.page.getByTestId('w3m-authentication-status'),
+      await this.getByTestId('w3m-authentication-status'),
       'Authentication status should be: authenticated'
     ).toContainText('authenticated', { timeout: 10000 })
   }
 
   async expectOnSignInEventCalled(toBe: boolean) {
-    await expect(this.page.getByTestId('siwe-event-onSignIn')).toContainText(`${toBe}`)
+    await expect(await this.getByTestId('siwe-event-onSignIn')).toContainText(`${toBe}`)
   }
 
   async expectUnauthenticated() {
     await expect(
-      this.page.getByTestId('w3m-authentication-status'),
+      await this.getByTestId('w3m-authentication-status'),
       'Authentication status should be: unauthenticated'
     ).toContainText('unauthenticated', { timeout: 10000 })
   }
 
   async expectOnSignOutEventCalled(toBe: boolean) {
-    await expect(this.page.getByTestId('siwe-event-onSignOut')).toContainText(`${toBe}`)
+    await expect(await this.getByTestId('siwe-event-onSignOut')).toContainText(`${toBe}`)
   }
 
   async expectSignatureDeclined() {
@@ -79,7 +107,9 @@ export class ModalValidator {
   }
 
   async expectDisconnected(namespace?: string) {
-    const connectButton = this.page.getByTestId(`connect-button${namespace ? `-${namespace}` : ''}`)
+    const connectButton = await this.getByTestId(
+      `connect-button${namespace ? `-${namespace}` : ''}`
+    )
     await expect(connectButton, 'Connect button should be present').toBeVisible({
       timeout: MAX_WAIT
     })
@@ -98,7 +128,7 @@ export class ModalValidator {
 
   async expectSingleAccount() {
     await expect(
-      this.page.getByTestId('single-account-avatar'),
+      await this.getByTestId('single-account-avatar'),
       'Single account widget should be present'
     ).toBeVisible({
       timeout: MAX_WAIT
@@ -112,20 +142,20 @@ export class ModalValidator {
   }
 
   async expectAddress(expectedAddress: string) {
-    const address = this.page.getByTestId('w3m-address')
+    const address = await this.getByTestId('w3m-address')
 
     await expect(address, 'Correct address should be present').toHaveText(expectedAddress)
   }
 
   async expectCaipAddressHaveCorrectNetworkId(caipNetworkId: CaipNetworkId) {
-    const address = this.page.getByTestId('w3m-caip-address')
+    const address = await this.getByTestId('w3m-caip-address')
     await expect(address, 'Correct CAIP address should be present').toContainText(
       caipNetworkId.toString()
     )
   }
 
   async expectNetwork(network: string) {
-    const networkButton = this.page.getByTestId('w3m-account-select-network')
+    const networkButton = await this.getByTestId('w3m-account-select-network')
     await expect(networkButton, `Network button should contain text ${network}`).toHaveText(
       network,
       {
@@ -135,7 +165,7 @@ export class ModalValidator {
   }
 
   async expectWalletButtonHook(id: string, disabled: boolean) {
-    const walletButtonHook = this.page.getByTestId(`wallet-button-hook-${id}`)
+    const walletButtonHook = await this.getByTestId(`wallet-button-hook-${id}`)
     await expect(walletButtonHook).toBeVisible({ timeout: 20_000 })
 
     if (disabled) {
@@ -150,7 +180,7 @@ export class ModalValidator {
     await expect(this.page.getByText(ConstantsUtil.SigningSucceededToastTitle)).toBeVisible({
       timeout: 30 * 1000
     })
-    const closeButton = this.page.locator('#toast-close-button')
+    const closeButton = await this.getLocator('#toast-close-button')
 
     await expect(closeButton).toBeVisible()
     await closeButton.click()
@@ -160,7 +190,7 @@ export class ModalValidator {
     await expect(this.page.getByText('Success')).toBeVisible({
       timeout: MAX_WAIT
     })
-    const closeButton = this.page.locator('#toast-close-button')
+    const closeButton = await this.getLocator('#toast-close-button')
     await expect(closeButton).toBeVisible({ timeout: MAX_WAIT })
     await closeButton.click()
   }
@@ -168,34 +198,34 @@ export class ModalValidator {
   async expectRejectedSign() {
     // We use Chakra Toast and it's not quite straightforward to set the `data-testid` attribute on the toast element.
     await expect(this.page.getByText(ConstantsUtil.SigningFailedToastTitle)).toBeVisible()
-    const closeButton = this.page.locator('#toast-close-button')
+    const closeButton = await this.getLocator('#toast-close-button')
 
     await expect(closeButton).toBeVisible()
     await closeButton.click()
   }
 
   async expectSwitchedNetwork(network: string) {
-    const switchNetworkButton = this.page.getByTestId(`w3m-network-switch-${network}`)
+    const switchNetworkButton = await this.getByTestId(`w3m-network-switch-${network}`)
     await expect(switchNetworkButton).toBeVisible()
   }
 
   async expectNetworkButton(network: string) {
-    const alertBarText = this.page.getByTestId('w3m-network-button')
+    const alertBarText = await this.getByTestId('w3m-network-button')
     await expect(alertBarText).toHaveText(network)
   }
 
   async expectSwitchChainView(chainName: string) {
-    const title = this.page.getByTestId(`w3m-switch-active-chain-to-${chainName}`)
+    const title = await this.getByTestId(`w3m-switch-active-chain-to-${chainName}`)
     await expect(title).toBeVisible()
   }
 
   async expectSwitchChainWithNetworkButton(chainName: string) {
-    const switchNetworkViewLocator = this.page.locator('wui-network-button')
+    const switchNetworkViewLocator = await this.getLocator('wui-network-button')
     await expect(switchNetworkViewLocator).toHaveText(chainName)
   }
 
   async expectSwitchedNetworkWithNetworkView() {
-    const switchNetworkViewLocator = this.page.locator('w3m-network-switch-view')
+    const switchNetworkViewLocator = await this.getLocator('w3m-network-switch-view')
     await expect(switchNetworkViewLocator).toBeVisible()
     await expect(switchNetworkViewLocator).not.toBeVisible({
       timeout: 20_000
@@ -203,7 +233,7 @@ export class ModalValidator {
   }
 
   async expectSwitchedNetworkOnNetworksView(name: string) {
-    const networkOptions = this.page.getByTestId(`w3m-network-switch-${name}`)
+    const networkOptions = await this.getByTestId(`w3m-network-switch-${name}`)
     await expect(networkOptions.locator('wui-icon')).toBeVisible()
   }
 
@@ -219,42 +249,42 @@ export class ModalValidator {
   }
 
   async expectAllWalletsListSearchItem(id: string) {
-    const allWalletsListSearchItem = this.page.getByTestId(`wallet-search-item-${id}`)
+    const allWalletsListSearchItem = await this.getByTestId(`wallet-search-item-${id}`)
     await expect(allWalletsListSearchItem).toBeVisible()
   }
 
   async expectNoSocials() {
-    const socialList = this.page.getByTestId('wui-list-social')
+    const socialList = await this.getByTestId('wui-list-social')
     await expect(socialList).toBeHidden()
   }
 
   async expectAllWallets() {
-    const allWallets = this.page.getByTestId('all-wallets')
+    const allWallets = await this.getByTestId('all-wallets')
     await expect(allWallets).toBeVisible()
   }
 
   async expectNoTryAgainButton() {
-    const secondaryButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
+    const secondaryButton = await this.getByTestId('w3m-connecting-widget-secondary-button')
     await expect(secondaryButton).toBeHidden()
   }
 
   async expectTryAgainButton() {
-    const secondaryButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
+    const secondaryButton = await this.getByTestId('w3m-connecting-widget-secondary-button')
     await expect(secondaryButton).toBeVisible()
   }
 
   async expectAlertBarText(text: string) {
-    const alertBarText = this.page.getByTestId('wui-alertbar-text')
+    const alertBarText = await this.getByTestId('wui-alertbar-text')
     await expect(alertBarText).toHaveText(text)
   }
 
   async expectEmailLogin() {
-    const emailInput = this.page.getByTestId('wui-email-input')
+    const emailInput = await this.getByTestId('wui-email-input')
     await expect(emailInput).toBeVisible()
   }
 
   async expectEmailLineSeparator() {
-    const emailInput = this.page.getByTestId('w3m-email-login-or-separator')
+    const emailInput = await this.getByTestId('w3m-email-login-or-separator')
     await expect(emailInput).toBeVisible()
   }
 
@@ -270,14 +300,14 @@ export class ModalValidator {
   }
 
   async expectExternalVisible() {
-    const externalConnector = this.page.getByTestId(
+    const externalConnector = await this.getByTestId(
       /^wallet-selector-external-externalTestConnector/u
     )
     await expect(externalConnector).toBeVisible()
   }
 
   async expectCoinbaseNotVisible() {
-    const coinbaseConnector = this.page.getByTestId(/^wallet-selector-external-coinbaseWalletSDK/u)
+    const coinbaseConnector = await this.getByTestId(/^wallet-selector-external-coinbaseWalletSDK/u)
     await expect(coinbaseConnector).not.toBeVisible()
   }
 
@@ -294,8 +324,8 @@ export class ModalValidator {
       timeout: MAX_WAIT
     })
 
-    expect(this.page.getByTestId('switch-address-item').first()).toBeVisible()
-    const accounts = await this.page.getByTestId('switch-address-item').all()
+    expect((await this.getByTestId('switch-address-item')).first()).toBeVisible()
+    const accounts = await (await this.getByTestId('switch-address-item')).all()
 
     expect(accounts.length).toBeGreaterThan(1)
   }
@@ -311,12 +341,12 @@ export class ModalValidator {
   }
 
   async expectAccountPageVisible() {
-    const switchNetworkButton = this.page.getByTestId('w3m-account-select-network')
+    const switchNetworkButton = await this.getByTestId('w3m-account-select-network')
     await expect(switchNetworkButton).toBeVisible()
   }
 
   async expectOnrampButton(visible: boolean) {
-    const onrampButton = this.page.getByTestId('w3m-account-default-onramp-button')
+    const onrampButton = await this.getByTestId('w3m-account-default-onramp-button')
     if (visible) {
       await expect(onrampButton).toBeVisible()
     } else {
@@ -325,19 +355,19 @@ export class ModalValidator {
   }
 
   async expectWalletGuide(_library: string, guide: 'get-started' | 'explore') {
-    const walletGuide = this.page.getByTestId(
+    const walletGuide = await this.getByTestId(
       guide === 'explore' ? 'w3m-wallet-guide-explore' : 'w3m-wallet-guide-get-started'
     )
     await expect(walletGuide).toBeVisible()
   }
 
   async expectAccountNameFound(name: string) {
-    const suggestion = this.page.getByTestId('account-name-suggestion').getByText(name)
+    const suggestion = (await this.getByTestId('account-name-suggestion')).getByText(name)
     await expect(suggestion).toBeVisible()
   }
 
   async expectHeaderText(text: string) {
-    const headerText = this.page.getByTestId('w3m-header-text')
+    const headerText = await this.getByTestId('w3m-header-text')
     await expect(headerText).toHaveText(text)
   }
 
@@ -364,12 +394,12 @@ export class ModalValidator {
       timeout: 10 * 1000
     })
     if (isConfirmed) {
-      const closeButton = this.page.locator('#toast-close-button')
+      const closeButton = await this.getLocator('#toast-close-button')
 
       await expect(closeButton).toBeVisible()
       await closeButton.click()
     } else if (allowedRetry) {
-      const callStatusButton = this.page.getByTestId('get-calls-status-button')
+      const callStatusButton = await this.getByTestId('get-calls-status-button')
       await expect(callStatusButton).toBeVisible()
       await callStatusButton.click()
       this.expectCallStatusSuccessOrRetry(sendCallsId, false)
@@ -379,69 +409,71 @@ export class ModalValidator {
   }
 
   async expectNetworkVisible(name: string) {
-    const network = this.page.getByTestId(`w3m-network-switch-${name}`)
+    const network = await this.getByTestId(`w3m-network-switch-${name}`)
     await expect(network).toBeVisible()
     await expect(network).toBeDisabled()
   }
 
   async expectNetworksDisabled(name: string) {
-    const disabledNetwork = this.page.getByTestId(`w3m-network-switch-${name}`)
+    const disabledNetwork = await this.getByTestId(`w3m-network-switch-${name}`)
     await expect(disabledNetwork.locator('button')).toBeDisabled()
   }
 
   async expectToBeConnectedInstantly() {
     // Wait for the page to be loaded
-    const initializeBoundary = this.page.getByTestId('w3m-page-loading')
+    const initializeBoundary = await this.getByTestId('w3m-page-loading')
     await expect(initializeBoundary).toBeHidden()
-    const accountButton = this.page.locator('appkit-account-button')
+    const accountButton = await this.getLocator('appkit-account-button')
     await expect(accountButton, 'Account button should be present').toBeAttached({
       timeout: 1000
     })
   }
 
   async expectConnectButtonLoading() {
-    const connectButton = this.page.getByTestId('connect-button')
+    const connectButton = await this.getByTestId('connect-button')
     await expect(connectButton).toContainText('Connecting...')
   }
 
   async expectAccountButtonReady(namespace?: string) {
-    const accountButton = this.page.getByTestId(`account-button${namespace ? `-${namespace}` : ''}`)
+    const accountButton = await this.getByTestId(
+      `account-button${namespace ? `-${namespace}` : ''}`
+    )
     await expect(accountButton).toBeVisible({ timeout: MAX_WAIT })
   }
 
   async expectAccountSwitched(oldAddress: string) {
-    const address = this.page.getByTestId('w3m-address')
+    const address = await this.getByTestId('w3m-address')
     await expect(address).not.toHaveText(oldAddress)
   }
 
   async expectSocialsVisible() {
-    const socials = this.page.getByTestId('w3m-social-login-widget')
+    const socials = await this.getByTestId('w3m-social-login-widget')
     await expect(socials).toBeVisible()
   }
 
   async expectModalNotVisible() {
-    const modal = this.page.getByTestId('w3m-modal')
+    const modal = await this.getByTestId('w3m-modal')
     await expect(modal).toBeHidden()
   }
 
   async expectSnackbar(message: string) {
-    await expect(this.page.getByTestId('wui-snackbar-message')).toHaveText(message, {
+    await expect(await this.getByTestId('wui-snackbar-message')).toHaveText(message, {
       timeout: MAX_WAIT
     })
   }
 
   async expectEmail() {
-    const email = this.page.getByTestId('w3m-email')
+    const email = await this.getByTestId('w3m-email')
     await expect(email).toBeVisible({ timeout: MAX_WAIT })
   }
 
   async expectAccountType() {
-    const authAccountType = this.page.getByTestId('w3m-account-type')
+    const authAccountType = await this.getByTestId('w3m-account-type')
     await expect(authAccountType).toBeVisible({ timeout: MAX_WAIT })
   }
 
   async expectSmartAccountStatus() {
-    const smartAccountStatus = this.page.getByTestId('w3m-sa-account-status')
+    const smartAccountStatus = await this.getByTestId('w3m-sa-account-status')
     await expect(smartAccountStatus).toBeVisible({ timeout: MAX_WAIT })
   }
 


### PR DESCRIPTION
# Description
Added `locator` & `element` getters that try to get an element from the page every n ms until a timeout is hit rather than once

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
