### PR TITLE
fix: subscribe to up in wagmi to sync connection state

### DIFF
--- a/apps/laboratory/tests/multichain/multichain-wagmi-solana.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-wagmi-solana.spec.ts
@@ -101,3 +101,20 @@ test('it should disconnect as expected', async () => {
   await modalPage.disconnect()
   await modalValidator.expectDisconnected()
 })
+
+test('it should also connect wagmi and sign a message if connecting from a different namespace', async () => {
+  await modalPage.switchNetworkWithNetworkButton('Solana')
+  await modalPage.closeModal()
+  await modalPage.qrCodeFlow(modalPage, walletPage)
+  await modalValidator.expectConnected()
+
+  await modalPage.sign('eip155')
+  await walletValidator.expectReceivedSign({ chainName: 'Ethereum' })
+  await walletPage.handleRequest({ accept: true })
+  await modalValidator.expectAcceptedSign()
+
+  await modalPage.sign('solana')
+  await walletValidator.expectReceivedSign({ chainName: 'Solana' })
+  await walletPage.handleRequest({ accept: true })
+  await modalValidator.expectAcceptedSign()
+})

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.2'
+export const PACKAGE_VERSION = '1.7.3'


### PR DESCRIPTION
# Description
- Subscribe to UP connections that happen outside wagmi context and reconnects to keep internal state in sync

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2693


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
