### PR TITLE
chore(e2e-tests): extend a larger timeout

### DIFF
--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -64,7 +64,7 @@ export class ModalValidator {
     await expect(
       this.page.getByTestId('w3m-authentication-status'),
       'Authentication status should be: unauthenticated'
-    ).toContainText('unauthenticated', { timeout: 10000 })
+    ).toContainText('unauthenticated', { timeout: 15000 })
   }
 
   async expectOnSignOutEventCalled(toBe: boolean) {


### PR DESCRIPTION
# Description

We've seen `expectUnauthenticated` fail in many tests when used with Magic embedded wallets. This is a hotfix with little downside trying to extend more timeout to Magic and hence hopefully making these tests more reliable. `expectUnauthenticated` is used as a proxy for "chain switching successful" in many tests.

<img width="685" alt="Screenshot 2025-04-16 at 8 55 00 PM" src="https://github.com/user-attachments/assets/976aab35-5b36-480b-bb0e-6ba9f805f782" />

<img width="749" alt="Screenshot 2025-04-17 at 8 53 23 AM" src="https://github.com/user-attachments/assets/1eb96a6a-abd6-4f8e-82cc-957fe78e530e" />
<img width="976" alt="Screenshot 2025-04-17 at 8 53 34 AM" src="https://github.com/user-attachments/assets/e8f4c9c8-46d7-412a-91f5-bfe27feb80aa" />


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
