### PR TITLE
fix: only show namespace networks on receive screen

### DIFF
--- a/.changeset/odd-buttons-jam.md
+++ b/.changeset/odd-buttons-jam.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where Receive screen would show networks from other namespaces

--- a/packages/scaffold-ui/src/views/w3m-wallet-compatible-networks-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-compatible-networks-view/index.ts
@@ -79,7 +79,11 @@ export class W3mWalletCompatibleNetworksView extends LitElement {
       sortedNetworks = [caipNetwork]
     }
 
-    return sortedNetworks.map(
+    const namespaceNetworks = sortedNetworks.filter(
+      network => network.chainNamespace === caipNetwork?.chainNamespace
+    )
+
+    return namespaceNetworks.map(
       network => html`
         <wui-list-network
           imageSrc=${ifDefined(AssetUtil.getNetworkImage(network))}

--- a/packages/scaffold-ui/src/views/w3m-wallet-receive-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-receive-view/index.ts
@@ -118,7 +118,9 @@ export class W3mWalletReceiveView extends LitElement {
     const requestedCaipNetworks = ChainController.getAllRequestedCaipNetworks()
     const isNetworkEnabledForSmartAccounts = ChainController.checkIfSmartAccountEnabled()
     const caipNetwork = ChainController.state.activeCaipNetwork
-
+    const namespaceNetworks = requestedCaipNetworks.filter(
+      network => network?.chainNamespace === caipNetwork?.chainNamespace
+    )
     if (
       this.preferredAccountTypes?.[caipNetwork?.chainNamespace as ChainNamespace] ===
         W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT &&
@@ -134,7 +136,7 @@ export class W3mWalletReceiveView extends LitElement {
         .networkImages=${[AssetUtil.getNetworkImage(caipNetwork) ?? '']}
       ></wui-compatible-network>`
     }
-    const slicedNetworks = requestedCaipNetworks
+    const slicedNetworks = namespaceNetworks
       ?.filter(network => network?.assets?.imageId)
       ?.slice(0, 5)
     const imagesArray = slicedNetworks.map(AssetUtil.getNetworkImage).filter(Boolean) as string[]

--- a/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
@@ -12,10 +12,7 @@ import {
   CoreHelperUtil,
   type NetworkControllerClient,
   RouterController,
-  SnackController,
-  ThemeController,
-  type ThemeControllerState,
-  type ThemeVariables
+  SnackController
 } from '@reown/appkit-controllers'
 import { W3mFrameRpcConstants } from '@reown/appkit-wallet/utils'
 

--- a/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
@@ -162,7 +162,6 @@ describe('W3mWalletReceiveView', () => {
     const qrCode = element.shadowRoot?.querySelector('wui-qr-code')
     expect(qrCode).to.exist
     expect(qrCode?.getAttribute('uri')).to.equal(mockAddress)
-    expect(qrCode?.getAttribute('theme')).to.equal('light')
 
     // Check if compatible network section is rendered
     const compatibleNetwork = element.shadowRoot?.querySelector('wui-compatible-network')

--- a/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-receive-view.test.ts
@@ -1,0 +1,276 @@
+import { expect, fixture, html } from '@open-wc/testing'
+import { afterEach, beforeEach, describe, it, vi, expect as viExpect } from 'vitest'
+
+import type { CaipAddress, CaipNetwork, ChainNamespace } from '@reown/appkit-common'
+import {
+  AccountController,
+  type AccountControllerState,
+  AssetUtil,
+  ChainController,
+  type ChainControllerState,
+  type ConnectionControllerClient,
+  CoreHelperUtil,
+  type NetworkControllerClient,
+  RouterController,
+  SnackController,
+  ThemeController,
+  type ThemeControllerState,
+  type ThemeVariables
+} from '@reown/appkit-controllers'
+import { W3mFrameRpcConstants } from '@reown/appkit-wallet/utils'
+
+import { W3mWalletReceiveView } from '../../src/views/w3m-wallet-receive-view'
+
+const mockNetwork: CaipNetwork = {
+  id: 1,
+  name: 'Ethereum',
+  chainNamespace: 'eip155',
+  caipNetworkId: 'eip155:1',
+  nativeCurrency: {
+    name: 'Ethereum',
+    symbol: 'ETH',
+    decimals: 18
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://ethereum.rpc.com']
+    }
+  },
+  assets: {
+    imageId: 'ethereum',
+    imageUrl: 'https://example.com/ethereum.png'
+  }
+}
+
+const mockAddress = '0x123456789abcdef123456789abcdef123456789a'
+const mockProfileName = 'Test User'
+
+const mockNetworkControllerClient: NetworkControllerClient = {
+  switchCaipNetwork: vi.fn(),
+  getApprovedCaipNetworksData: vi.fn().mockResolvedValue({
+    approvedCaipNetworkIds: ['eip155:1'],
+    supportsAllNetworks: true
+  })
+}
+
+const mockConnectionControllerClient: ConnectionControllerClient = {
+  connectWalletConnect: vi.fn(),
+  connectExternal: vi.fn(),
+  reconnectExternal: vi.fn(),
+  checkInstalled: vi.fn(),
+  disconnect: vi.fn(),
+  signMessage: vi.fn(),
+  sendTransaction: vi.fn(),
+  estimateGas: vi.fn(),
+  parseUnits: vi.fn(),
+  formatUnits: vi.fn(),
+  writeContract: vi.fn(),
+  getEnsAddress: vi.fn(),
+  getEnsAvatar: vi.fn(),
+  grantPermissions: vi.fn(),
+  revokePermissions: vi.fn(),
+  getCapabilities: vi.fn(),
+  walletGetAssets: vi.fn()
+}
+
+// Create partial mock states to satisfy TypeScript
+const mockAccountControllerState: Partial<AccountControllerState> = {
+  address: mockAddress,
+  profileName: mockProfileName,
+  preferredAccountTypes: {
+    eip155: W3mFrameRpcConstants.ACCOUNT_TYPES.EOA
+  },
+  currentTab: 0,
+  addressLabels: new Map(),
+  allAccounts: []
+}
+
+const mockChainControllerState: Partial<ChainControllerState> = {
+  activeCaipNetwork: mockNetwork,
+  activeCaipAddress: `eip155:1:${mockAddress}` as CaipAddress,
+  activeChain: 'eip155' as ChainNamespace,
+  chains: new Map([
+    [
+      'eip155',
+      {
+        namespace: 'eip155' as ChainNamespace,
+        networkControllerClient: mockNetworkControllerClient,
+        connectionControllerClient: mockConnectionControllerClient
+      }
+    ]
+  ]),
+  universalAdapter: {
+    networkControllerClient: mockNetworkControllerClient,
+    connectionControllerClient: mockConnectionControllerClient
+  },
+  noAdapters: false,
+  isSwitchingNamespace: false
+}
+
+const mockRequestedNetworks: CaipNetwork[] = [
+  mockNetwork,
+  {
+    ...mockNetwork,
+    id: 2,
+    name: 'Polygon',
+    caipNetworkId: 'eip155:137' as `eip155:${number}`,
+    assets: {
+      imageId: 'polygon',
+      imageUrl: 'https://example.com/polygon.png'
+    }
+  }
+]
+
+describe('W3mWalletReceiveView', () => {
+  beforeEach(() => {
+    // Mock AccountController state
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue(
+      mockAccountControllerState as AccountControllerState
+    )
+
+    // Mock ChainController state
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue(
+      mockChainControllerState as ChainControllerState
+    )
+
+    // Mock asset and chain controller methods
+    vi.spyOn(AssetUtil, 'getNetworkImage').mockReturnValue('https://example.com/network.png')
+    vi.spyOn(ChainController, 'getAllRequestedCaipNetworks').mockReturnValue(mockRequestedNetworks)
+    vi.spyOn(ChainController, 'checkIfSmartAccountEnabled').mockReturnValue(false)
+
+    // Mock other controllers
+    vi.spyOn(CoreHelperUtil, 'copyToClopboard').mockImplementation(() => {})
+    vi.spyOn(SnackController, 'showSuccess').mockImplementation(() => {})
+    vi.spyOn(SnackController, 'showError').mockImplementation(() => {})
+    vi.spyOn(RouterController, 'push').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render with address and QR code', async () => {
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    // Check if chip button with address is rendered
+    const chipButton = element.shadowRoot?.querySelector('wui-chip-button')
+    expect(chipButton).to.exist
+    expect(chipButton?.getAttribute('text')).to.include(mockProfileName)
+
+    // Check if QR code is rendered
+    const qrCode = element.shadowRoot?.querySelector('wui-qr-code')
+    expect(qrCode).to.exist
+    expect(qrCode?.getAttribute('uri')).to.equal(mockAddress)
+    expect(qrCode?.getAttribute('theme')).to.equal('light')
+
+    // Check if compatible network section is rendered
+    const compatibleNetwork = element.shadowRoot?.querySelector('wui-compatible-network')
+    expect(compatibleNetwork).to.exist
+    expect(compatibleNetwork?.getAttribute('text')).to.include('networks')
+  })
+
+  it('should display address when no profile name', async () => {
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...mockAccountControllerState,
+      profileName: undefined
+    } as AccountControllerState)
+
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    const chipButton = element.shadowRoot?.querySelector('wui-chip-button')
+    expect(chipButton).to.exist
+    expect(chipButton?.getAttribute('text')).to.include('0x12')
+    expect(chipButton?.getAttribute('text')).to.include('789a')
+  })
+
+  it('should copy address on button click', async () => {
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    const copyButton = element.shadowRoot?.querySelector(
+      '[data-testid="receive-address-copy-button"]'
+    ) as HTMLElement
+    expect(copyButton).to.exist
+    copyButton?.click()
+
+    viExpect(CoreHelperUtil.copyToClopboard).toHaveBeenCalledWith(mockAddress)
+    viExpect(SnackController.showSuccess).toHaveBeenCalledWith('Address copied')
+  })
+
+  it('should handle error when copying fails', async () => {
+    vi.spyOn(CoreHelperUtil, 'copyToClopboard').mockImplementation(() => {
+      throw new Error('Copy failed')
+    })
+
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    const copyButton = element.shadowRoot?.querySelector(
+      '[data-testid="receive-address-copy-button"]'
+    ) as HTMLElement
+    copyButton?.click()
+
+    viExpect(SnackController.showError).toHaveBeenCalledWith('Failed to copy')
+  })
+
+  it('should navigate to compatible networks view on network click', async () => {
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    const compatibleNetwork = element.shadowRoot?.querySelector(
+      'wui-compatible-network'
+    ) as HTMLElement
+    compatibleNetwork?.click()
+
+    viExpect(RouterController.push).toHaveBeenCalledWith('WalletCompatibleNetworks')
+  })
+
+  it('should display single network for smart accounts', async () => {
+    vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
+      ...mockAccountControllerState,
+      preferredAccountTypes: {
+        eip155: W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT
+      }
+    } as AccountControllerState)
+    vi.spyOn(ChainController, 'checkIfSmartAccountEnabled').mockReturnValue(true)
+
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    await element.updateComplete
+
+    const compatibleNetwork = element.shadowRoot?.querySelector('wui-compatible-network')
+    expect(compatibleNetwork).to.exist
+    expect(compatibleNetwork?.getAttribute('text')).to.include('this network')
+  })
+
+  it('should cleanup subscriptions on disconnect', async () => {
+    const element = await fixture<W3mWalletReceiveView>(
+      html`<w3m-wallet-receive-view></w3m-wallet-receive-view>`
+    )
+
+    const unsubscribeSpy = vi.fn()
+    element['unsubscribe'] = [unsubscribeSpy]
+
+    element.disconnectedCallback()
+    viExpect(unsubscribeSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
# Description
- Receive screen was showing networks from different namespaces, which could cause issues given the address is different 
- Filters displayed networks to only show corresponding namespace networks

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-2694

# Showcase 
https://github.com/user-attachments/assets/2fb68a33-d56e-46c3-84a4-847045886b19


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
