### PR TITLE
fix: embeddedwalletinfo showing for non-embedded wallets 

### DIFF
--- a/.changeset/gentle-papers-obey.md
+++ b/.changeset/gentle-papers-obey.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where embeddedWalletInfo would be populated even when connected to non-embedded wallets

--- a/apps/laboratory/src/components/AppKitInfo.tsx
+++ b/apps/laboratory/src/components/AppKitInfo.tsx
@@ -19,7 +19,7 @@ import { RelayClientInfo } from '@/src/components/RelayClientInfo'
 import { EmbeddedWalletInfo } from './EmbeddedWalletInfo'
 
 export function AppKitInfo() {
-  const { caipAddress, address } = useAppKitAccount()
+  const { caipAddress, address, embeddedWalletInfo } = useAppKitAccount()
   const { chainId } = useAppKitNetwork()
 
   const isEIP155 = caipAddress?.startsWith('eip155:')
@@ -33,6 +33,8 @@ export function AppKitInfo() {
       return null
     }
   }, [caipAddress, isEIP155])
+
+  console.log('>> embeddedWalletInfo', embeddedWalletInfo)
 
   return (
     <Card marginTop={10} marginBottom={10}>
@@ -75,6 +77,17 @@ export function AppKitInfo() {
                 Chain Id
               </Heading>
               <Text data-testid="w3m-chain-id">{chainId}</Text>
+            </Box>
+          )}
+
+          {embeddedWalletInfo && (
+            <Box>
+              <Heading size="xs" textTransform="uppercase" pb="2">
+                Embedded Wallet Info
+              </Heading>
+              <Text data-testid="w3m-embedded-wallet-info">
+                {JSON.stringify(embeddedWalletInfo, null, 2)}
+              </Text>
             </Box>
           )}
 

--- a/apps/laboratory/src/components/AppKitInfo.tsx
+++ b/apps/laboratory/src/components/AppKitInfo.tsx
@@ -34,8 +34,6 @@ export function AppKitInfo() {
     }
   }, [caipAddress, isEIP155])
 
-  console.log('>> embeddedWalletInfo', embeddedWalletInfo)
-
   return (
     <Card marginTop={10} marginBottom={10}>
       <CardHeader>

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1585,6 +1585,7 @@ export abstract class AppKitBaseClient {
     const authConnector = ConnectorController.getAuthConnector(namespace)
     const accountState = ChainController.getAccountData(namespace)
     const activeChain = ChainController.state.activeChain as ChainNamespace
+    const activeConnectorId = ConnectorController.state.activeConnector?.id
 
     if (!accountState) {
       return undefined
@@ -1596,27 +1597,28 @@ export abstract class AppKitBaseClient {
       address: CoreHelperUtil.getPlainAddress(accountState.caipAddress),
       isConnected: Boolean(accountState.caipAddress),
       status: accountState.status,
-      embeddedWalletInfo: authConnector
-        ? {
-            user: accountState.user
-              ? {
-                  ...accountState.user,
-                  /*
-                   * Getting the username from the chain controller works well for social logins,
-                   * but Farcaster uses a different connection flow and doesn’t emit the username via events.
-                   * Since the username is stored in local storage before the chain controller updates,
-                   * it’s safe to use the local storage value here.
-                   */
-                  username: StorageUtil.getConnectedSocialUsername()
-                }
-              : undefined,
-            authProvider:
-              accountState.socialProvider ||
-              ('email' as AccountControllerState['socialProvider'] | 'email'),
-            accountType: accountState.preferredAccountTypes?.[namespace || activeChain],
-            isSmartAccountDeployed: Boolean(accountState.smartAccountDeployed)
-          }
-        : undefined
+      embeddedWalletInfo:
+        authConnector && activeConnectorId === ConstantsUtil.CONNECTOR_ID.AUTH
+          ? {
+              user: accountState.user
+                ? {
+                    ...accountState.user,
+                    /*
+                     * Getting the username from the chain controller works well for social logins,
+                     * but Farcaster uses a different connection flow and doesn’t emit the username via events.
+                     * Since the username is stored in local storage before the chain controller updates,
+                     * it’s safe to use the local storage value here.
+                     */
+                    username: StorageUtil.getConnectedSocialUsername()
+                  }
+                : undefined,
+              authProvider:
+                accountState.socialProvider ||
+                ('email' as AccountControllerState['socialProvider'] | 'email'),
+              accountType: accountState.preferredAccountTypes?.[namespace || activeChain],
+              isSmartAccountDeployed: Boolean(accountState.smartAccountDeployed)
+            }
+          : undefined
     }
   }
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1591,8 +1591,6 @@ export abstract class AppKitBaseClient {
       return undefined
     }
 
-    console.log('>> getAccount', authConnector, activeConnectorId)
-
     return {
       allAccounts: accountState.allAccounts,
       caipAddress: accountState.caipAddress,

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1585,7 +1585,7 @@ export abstract class AppKitBaseClient {
     const authConnector = ConnectorController.getAuthConnector(namespace)
     const accountState = ChainController.getAccountData(namespace)
     const activeChain = ChainController.state.activeChain as ChainNamespace
-    const activeConnectorId = ConnectorController.state.activeConnector?.id
+    const activeConnectorId = StorageUtil.getConnectedConnectorId(namespace)
 
     if (!accountState) {
       return undefined

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1591,6 +1591,8 @@ export abstract class AppKitBaseClient {
       return undefined
     }
 
+    console.log('>> getAccount', authConnector, activeConnectorId)
+
     return {
       allAccounts: accountState.allAccounts,
       caipAddress: accountState.caipAddress,

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -1,7 +1,13 @@
 import type UniversalProvider from '@walletconnect/universal-provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AdapterNetworkState, AuthConnector, Connector, SocialProvider } from '@reown/appkit'
+import type {
+  AdapterNetworkState,
+  AuthConnector,
+  Connector,
+  ConnectorControllerState,
+  SocialProvider
+} from '@reown/appkit'
 import {
   type Balance,
   type CaipNetwork,
@@ -1079,9 +1085,18 @@ describe('Base Public methods', () => {
   })
 
   it('should get account information', () => {
-    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({
-      id: 'auth-connector'
-    } as unknown as AuthConnector)
+    const authConnector = {
+      id: 'ID_AUTH',
+      name: 'ID Auth',
+      imageUrl: 'https://example.com/id-auth.png'
+    } as AuthConnector
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(authConnector)
+    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
+      ...ConnectorController.state,
+      allConnectors: [authConnector],
+      connected: true,
+      activeConnector: authConnector
+    } as unknown as ConnectorControllerState)
     vi.spyOn(StorageUtil, 'getConnectedSocialUsername').mockReturnValue('test-username')
     vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
       allAccounts: [{ address: '0x123', type: 'eoa', namespace: 'eip155' }],

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -1,13 +1,7 @@
 import type UniversalProvider from '@walletconnect/universal-provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type {
-  AdapterNetworkState,
-  AuthConnector,
-  Connector,
-  ConnectorControllerState,
-  SocialProvider
-} from '@reown/appkit'
+import type { AdapterNetworkState, AuthConnector, Connector, SocialProvider } from '@reown/appkit'
 import {
   type Balance,
   type CaipNetwork,
@@ -1091,12 +1085,7 @@ describe('Base Public methods', () => {
       imageUrl: 'https://example.com/id-auth.png'
     } as AuthConnector
     vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(authConnector)
-    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
-      ...ConnectorController.state,
-      allConnectors: [authConnector],
-      connected: true,
-      activeConnector: authConnector
-    } as unknown as ConnectorControllerState)
+    vi.spyOn(StorageUtil, 'getConnectedConnectorId').mockReturnValue('ID_AUTH')
     vi.spyOn(StorageUtil, 'getConnectedSocialUsername').mockReturnValue('test-username')
     vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
       allAccounts: [{ address: '0x123', type: 'eoa', namespace: 'eip155' }],

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -40,7 +40,7 @@ export function useAppKitAccount(options?: { namespace?: ChainNamespace }): UseA
 
   const chainAccountState = state.chains.get(chainNamespace)?.accountState
   const authConnector = ConnectorController.getAuthConnector(chainNamespace)
-  const activeConnectorId = ConnectorController.state.activeConnector?.id
+  const activeConnectorId = StorageUtil.getConnectedConnectorId(chainNamespace)
 
   return {
     allAccounts: chainAccountState?.allAccounts || [],

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -1,6 +1,6 @@
 import { useSnapshot } from 'valtio'
 
-import type { ChainNamespace } from '@reown/appkit-common'
+import { type ChainNamespace, ConstantsUtil } from '@reown/appkit-common'
 
 import { ChainController } from '../src/controllers/ChainController.js'
 import { ConnectionController } from '../src/controllers/ConnectionController.js'
@@ -40,6 +40,7 @@ export function useAppKitAccount(options?: { namespace?: ChainNamespace }): UseA
 
   const chainAccountState = state.chains.get(chainNamespace)?.accountState
   const authConnector = ConnectorController.getAuthConnector(chainNamespace)
+  const activeConnectorId = ConnectorController.state.activeConnector?.id
 
   return {
     allAccounts: chainAccountState?.allAccounts || [],
@@ -47,25 +48,26 @@ export function useAppKitAccount(options?: { namespace?: ChainNamespace }): UseA
     address: CoreHelperUtil.getPlainAddress(chainAccountState?.caipAddress),
     isConnected: Boolean(chainAccountState?.caipAddress),
     status: chainAccountState?.status,
-    embeddedWalletInfo: authConnector
-      ? {
-          user: chainAccountState?.user
-            ? {
-                ...chainAccountState.user,
-                /*
-                 * Getting the username from the chain controller works well for social logins,
-                 * but Farcaster uses a different connection flow and doesn’t emit the username via events.
-                 * Since the username is stored in local storage before the chain controller updates,
-                 * it’s safe to use the local storage value here.
-                 */
-                username: StorageUtil.getConnectedSocialUsername()
-              }
-            : undefined,
-          authProvider: chainAccountState?.socialProvider || 'email',
-          accountType: chainAccountState?.preferredAccountTypes?.[chainNamespace],
-          isSmartAccountDeployed: Boolean(chainAccountState?.smartAccountDeployed)
-        }
-      : undefined
+    embeddedWalletInfo:
+      authConnector && activeConnectorId === ConstantsUtil.CONNECTOR_ID.AUTH
+        ? {
+            user: chainAccountState?.user
+              ? {
+                  ...chainAccountState.user,
+                  /*
+                   * Getting the username from the chain controller works well for social logins,
+                   * but Farcaster uses a different connection flow and doesn’t emit the username via events.
+                   * Since the username is stored in local storage before the chain controller updates,
+                   * it’s safe to use the local storage value here.
+                   */
+                  username: StorageUtil.getConnectedSocialUsername()
+                }
+              : undefined,
+            authProvider: chainAccountState?.socialProvider || 'email',
+            accountType: chainAccountState?.preferredAccountTypes?.[chainNamespace],
+            isSmartAccountDeployed: Boolean(chainAccountState?.smartAccountDeployed)
+          }
+        : undefined
   }
 }
 

--- a/packages/controllers/exports/vue.ts
+++ b/packages/controllers/exports/vue.ts
@@ -7,6 +7,7 @@ import { ChainController } from '../src/controllers/ChainController.js'
 import { ConnectionController } from '../src/controllers/ConnectionController.js'
 import { ConnectorController } from '../src/controllers/ConnectorController.js'
 import { CoreHelperUtil } from '../src/utils/CoreHelperUtil.js'
+import { StorageUtil } from '../src/utils/StorageUtil.js'
 import type {
   AccountType,
   ChainAdapter,
@@ -33,7 +34,7 @@ export function useAppKitAccount(options?: {
     _chains: Map<ChainNamespace, ChainAdapter>,
     _chainNamespace: ChainNamespace | undefined
   ) {
-    const activeConnectorId = ConnectorController.state.activeConnector?.id
+    const activeConnectorId = StorageUtil.getConnectedConnectorId(_chainNamespace)
     const authConnector = _chainNamespace
       ? ConnectorController.getAuthConnector(_chainNamespace)
       : undefined

--- a/packages/controllers/exports/vue.ts
+++ b/packages/controllers/exports/vue.ts
@@ -1,6 +1,6 @@
 import { type Ref, onMounted, onUnmounted, ref } from 'vue'
 
-import type { ChainNamespace } from '@reown/appkit-common'
+import { type ChainNamespace, ConstantsUtil } from '@reown/appkit-common'
 
 import { AccountController } from '../src/controllers/AccountController.js'
 import { ChainController } from '../src/controllers/ChainController.js'
@@ -33,6 +33,7 @@ export function useAppKitAccount(options?: {
     _chains: Map<ChainNamespace, ChainAdapter>,
     _chainNamespace: ChainNamespace | undefined
   ) {
+    const activeConnectorId = ConnectorController.state.activeConnector?.id
     const authConnector = _chainNamespace
       ? ConnectorController.getAuthConnector(_chainNamespace)
       : undefined
@@ -47,14 +48,15 @@ export function useAppKitAccount(options?: {
     state.value.isConnected = Boolean(accountState?.caipAddress)
     const activeChainNamespace =
       _chainNamespace || (ChainController.state.activeChain as ChainNamespace)
-    state.value.embeddedWalletInfo = authConnector
-      ? {
-          user: accountState?.user,
-          authProvider: accountState?.socialProvider ?? ('email' as SocialProvider | 'email'),
-          accountType: accountState?.preferredAccountTypes?.[activeChainNamespace],
-          isSmartAccountDeployed: Boolean(accountState?.smartAccountDeployed)
-        }
-      : undefined
+    state.value.embeddedWalletInfo =
+      authConnector && activeConnectorId === ConstantsUtil.CONNECTOR_ID.AUTH
+        ? {
+            user: accountState?.user,
+            authProvider: accountState?.socialProvider ?? ('email' as SocialProvider | 'email'),
+            accountType: accountState?.preferredAccountTypes?.[activeChainNamespace],
+            isSmartAccountDeployed: Boolean(accountState?.smartAccountDeployed)
+          }
+        : undefined
   }
 
   const unsubscribeActiveChain = ChainController.subscribeKey('activeChain', val => {

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CaipNetwork } from '@reown/appkit-common'
 
 import {
+  type AuthConnector,
   ChainController,
   ConnectionController,
   ConnectorController,
+  type ConnectorControllerState,
   StorageUtil
 } from '../../exports/index.js'
 import { useAppKitAccount, useAppKitNetworkCore, useDisconnect } from '../../exports/react.js'
@@ -127,7 +129,18 @@ describe('useAppKitAccount', () => {
   it('should return correct embedded wallet info when connected with social provider', () => {
     const mockCaipAddress = 'eip155:1:0x123...'
     const mockPlainAddress = '0x123...'
-    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValueOnce({} as any)
+    const authConnector = {
+      id: 'ID_AUTH',
+      name: 'ID Auth',
+      imageUrl: 'https://example.com/id-auth.png'
+    } as AuthConnector
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(authConnector)
+    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
+      ...ConnectorController.state,
+      allConnectors: [authConnector],
+      connected: true,
+      activeConnector: authConnector
+    } as unknown as ConnectorControllerState)
     vi.spyOn(StorageUtil, 'getConnectedSocialUsername').mockReturnValue('test-username')
 
     useSnapshot.mockReturnValueOnce({
@@ -174,6 +187,13 @@ describe('useAppKitAccount', () => {
   })
 
   it('should return account state with namespace parameter', async () => {
+    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
+      ...ConnectorController.state,
+      allConnectors: [{}],
+      connected: true,
+      activeConnector: {}
+    } as unknown as ConnectorControllerState)
+
     const mockCaipAddress = 'eip155:1:0x123...'
     const mockPlainAddress = '0x123...'
 

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -135,12 +135,7 @@ describe('useAppKitAccount', () => {
       imageUrl: 'https://example.com/id-auth.png'
     } as AuthConnector
     vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(authConnector)
-    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
-      ...ConnectorController.state,
-      allConnectors: [authConnector],
-      connected: true,
-      activeConnector: authConnector
-    } as unknown as ConnectorControllerState)
+    vi.spyOn(StorageUtil, 'getConnectedConnectorId').mockReturnValue('ID_AUTH')
     vi.spyOn(StorageUtil, 'getConnectedSocialUsername').mockReturnValue('test-username')
 
     useSnapshot.mockReturnValueOnce({

--- a/packages/controllers/tests/hooks/vue.test.ts
+++ b/packages/controllers/tests/hooks/vue.test.ts
@@ -9,7 +9,8 @@ import {
   type AuthConnector,
   ChainController,
   ConnectionController,
-  ConnectorController
+  ConnectorController,
+  StorageUtil
 } from '../../exports/index.js'
 import { useAppKitAccount, useDisconnect } from '../../exports/vue.js'
 import {
@@ -87,7 +88,7 @@ describe('useAppKitAccount', () => {
       type: 'ID_AUTH'
     } as AuthConnector
     ConnectorController.state.connectors = [authConnector]
-    ConnectorController.state.activeConnector = authConnector
+    vi.spyOn(StorageUtil, 'getConnectedConnectorId').mockReturnValue('ID_AUTH')
 
     await nextTick()
 

--- a/packages/controllers/tests/hooks/vue.test.ts
+++ b/packages/controllers/tests/hooks/vue.test.ts
@@ -82,12 +82,12 @@ describe('useAppKitAccount', () => {
     AccountController.setUser({ username: 'test', email: 'testuser@example.com' }, 'eip155')
     AccountController.setSmartAccountDeployed(true, 'eip155')
     AccountController.setPreferredAccountType('smartAccount', 'eip155')
-    ConnectorController.state.connectors = [
-      {
-        id: ConstantsUtil.CONNECTOR_ID.AUTH,
-        type: 'AUTH'
-      } as AuthConnector
-    ]
+    const authConnector = {
+      id: ConstantsUtil.CONNECTOR_ID.AUTH,
+      type: 'ID_AUTH'
+    } as AuthConnector
+    ConnectorController.state.connectors = [authConnector]
+    ConnectorController.state.activeConnector = authConnector
 
     await nextTick()
 


### PR DESCRIPTION
# Description

- When using non-embedded wallets, `embeddedWalletInfo` is bringing wrong information.
- Only expose the field if a Reown embeddedWallet is connected

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes APKT-2218

# Checklist

- [] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
