### PR TITLE
fix: wallet info not set on connection

### DIFF
--- a/.changeset/puny-streets-care.md
+++ b/.changeset/puny-streets-care.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where walletInfo would not be set on initial connection

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -364,7 +364,6 @@ export abstract class AppKitBaseClient {
           )
         })
         await this.syncWalletConnectAccount()
-        this.syncConnectedWalletInfo(activeChain as ChainNamespace)
       },
       connectExternal: async ({ id, info, type, provider, chain, caipNetwork }) => {
         const activeChain = ChainController.state.activeChain as ChainNamespace
@@ -908,6 +907,7 @@ export abstract class AppKitBaseClient {
         this.setStatus('disconnected', chainNamespace)
       }
 
+      this.syncConnectedWalletInfo(chainNamespace)
       await ChainController.setApprovedCaipNetworksData(chainNamespace)
     })
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -364,6 +364,7 @@ export abstract class AppKitBaseClient {
           )
         })
         await this.syncWalletConnectAccount()
+        this.syncConnectedWalletInfo(activeChain as ChainNamespace)
       },
       connectExternal: async ({ id, info, type, provider, chain, caipNetwork }) => {
         const activeChain = ChainController.state.activeChain as ChainNamespace
@@ -405,6 +406,7 @@ export abstract class AppKitBaseClient {
         const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
         this.setAllAccounts(accounts, chainToUse)
         this.setStatus('connected', chainToUse)
+        this.syncConnectedWalletInfo(chainToUse)
       },
       reconnectExternal: async ({ id, info, type, provider }) => {
         const namespace = ChainController.state.activeChain as ChainNamespace
@@ -412,6 +414,7 @@ export abstract class AppKitBaseClient {
         if (adapter?.reconnect) {
           await adapter?.reconnect({ id, info, type, provider, chainId: this.getCaipNetwork()?.id })
           StorageUtil.addConnectedNamespace(namespace)
+          this.syncConnectedWalletInfo(namespace)
         }
       },
       disconnect: async (chainNamespace?: ChainNamespace) => {
@@ -426,6 +429,7 @@ export abstract class AppKitBaseClient {
         ProviderUtil.resetChain(namespace)
         this.setUser(undefined, namespace)
         this.setStatus('disconnected', namespace)
+        this.setConnectedWalletInfo(undefined, namespace)
       },
       checkInstalled: (ids?: string[]) => {
         if (!ids) {

--- a/packages/appkit/tests/mocks/Adapter.ts
+++ b/packages/appkit/tests/mocks/Adapter.ts
@@ -82,7 +82,10 @@ export const mockEvmAdapter = {
   off: emitter.off.bind(emitter),
   emit: emitter.emit.bind(emitter),
   removeAllEventListeners: vi.fn(),
-  connect: vi.fn().mockResolvedValue({ address: '0x123' })
+  connect: vi.fn().mockResolvedValue({ address: '0x123' }),
+  reconnect: vi.fn().mockResolvedValue({ address: '0x123' }),
+  connectWalletConnect: vi.fn().mockResolvedValue({ clientId: 'test-client' }),
+  disconnect: vi.fn().mockResolvedValue(undefined)
 } as unknown as AdapterBlueprint
 
 export const mockSolanaAdapter = {


### PR DESCRIPTION
# Description

- `useWalletInfo` and `appkit.getWalletInfo` were not returning information after connecting a wallet
- Call `syncWalletInfo` on all connection types. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-2715


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
