### PR TITLE
fix: account modal view opened when using core

### DIFF
--- a/.changeset/few-ghosts-share.md
+++ b/.changeset/few-ghosts-share.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fixed an issue where AppKit Core would open the account modal view when the wallet was connected

--- a/packages/controllers/src/controllers/ModalController.ts
+++ b/packages/controllers/src/controllers/ModalController.ts
@@ -88,10 +88,12 @@ export const ModalController = {
       }
     } else if (options?.view) {
       RouterController.reset(options.view, options.data)
-    } else if (caipAddress) {
-      RouterController.reset('Account')
-    } else {
-      RouterController.reset('Connect')
+    } else if (!OptionsController.state.manualWCControl) {
+      if (caipAddress) {
+        RouterController.reset('Account')
+      } else {
+        RouterController.reset('Connect')
+      }
     }
 
     state.open = true

--- a/packages/controllers/tests/controllers/ModalController.test.ts
+++ b/packages/controllers/tests/controllers/ModalController.test.ts
@@ -4,7 +4,10 @@ import {
   ApiController,
   ChainController,
   ConnectorController,
+  CoreHelperUtil,
+  EventsController,
   ModalController,
+  OptionsController,
   RouterController
 } from '../../exports/index.js'
 
@@ -12,6 +15,7 @@ import {
 describe('ModalController', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValueOnce(false)
   })
 
   it('should have valid default state', () => {
@@ -87,5 +91,47 @@ describe('ModalController', () => {
     await ModalController.open({ namespace: 'bip122' })
 
     expect(resetSpy).toHaveBeenCalledWith('Connect')
+  })
+
+  it('should not open the ConnectingWalletConnectBasic modal view when connected and manualWCControl is true', async () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValueOnce({
+      ...OptionsController.state,
+      manualWCControl: true
+    })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
+      ...ChainController.state,
+      noAdapters: true
+    })
+    vi.spyOn(ChainController, 'getAccountData').mockReturnValueOnce({
+      caipAddress: 'eip155:1:0x123'
+    } as any)
+    vi.spyOn(EventsController, 'sendEvent').mockImplementation(() => {})
+
+    const resetSpy = vi.spyOn(RouterController, 'reset')
+
+    await ModalController.open()
+
+    expect(resetSpy).not.toHaveBeenCalled()
+  })
+
+  it('should open the ConnectingWalletConnectBasic modal view when disconnected and manualWCControl is true', async () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValueOnce({
+      ...OptionsController.state,
+      manualWCControl: true
+    })
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
+      ...ChainController.state,
+      noAdapters: true
+    })
+    vi.spyOn(ChainController, 'getAccountData').mockReturnValueOnce({
+      caipAddress: undefined
+    } as any)
+    vi.spyOn(EventsController, 'sendEvent').mockImplementation(() => {})
+
+    const resetSpy = vi.spyOn(RouterController, 'reset')
+
+    await ModalController.open()
+
+    expect(resetSpy).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
# Description

Fixed an issue where if users try to connect twice with core the account modal view would get open. This is not correct since we don't allow users to open account modal when using core package.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-2783

# Showcase (Optional)

https://github.com/user-attachments/assets/7cd5fad6-4f38-462f-8d93-42e7211692bd



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
