### PR TITLE
fix: CI blink

### DIFF
--- a/packages/controllers/src/controllers/ModalController.ts
+++ b/packages/controllers/src/controllers/ModalController.ts
@@ -109,7 +109,7 @@ export const ModalController = {
    * this prevents accidental closing during transaction approval from secure sites
    * @param force - If true, the modal will close regardless of the current view
    */
-  close(force = false) {  
+  close(force = false) {
     if (force || RouterController.state.view !== 'ApproveTransaction') {
       const isEmbeddedEnabled = OptionsController.state.enableEmbedded
       const isConnected = Boolean(ChainController.state.activeCaipAddress)


### PR DESCRIPTION
# Description

- Makes e2e wait for when moving opening modal and changing to profile screen before moving to next action
- Adds timeout buffer to close action in e2e

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
