### PR TITLE
chore: update open pay interface

### DIFF
--- a/apps/laboratory/src/components/AppKitPay.tsx
+++ b/apps/laboratory/src/components/AppKitPay.tsx
@@ -34,8 +34,7 @@ import type {
   AppKitPayErrorMessage,
   Exchange,
   PayResult,
-  PayUrlParams,
-  PaymentAsset
+  PayUrlParams
 } from '@reown/appkit-pay'
 import {
   type ExchangeBuyStatus,
@@ -233,15 +232,14 @@ export function AppKitPay() {
       return
     }
 
-    const paymentAsset: PaymentAsset = {
-      ...paymentDetails,
-      network: paymentDetails.network as PaymentAsset['network'],
-      asset: paymentDetails.asset as PaymentAsset['asset'],
-      amount: paymentDetails.amount
-    }
-
     await open({
-      paymentAsset
+      recipient: paymentDetails.recipient,
+      amount: paymentDetails.amount,
+      paymentAsset: {
+        network: paymentDetails.network as `eip155:${string}`,
+        asset: paymentDetails.asset as AddressOrNative,
+        metadata: paymentDetails.metadata
+      }
     })
   }
 

--- a/packages/pay/src/types/options.ts
+++ b/packages/pay/src/types/options.ts
@@ -12,14 +12,14 @@ export type AssetMetadata = {
 
 export type PaymentAsset = {
   network: CaipNetworkId
-  recipient: string
   asset: AddressOrNative
-  amount: number
   metadata: AssetMetadata
 }
 
 export type PaymentOptions = {
   paymentAsset: PaymentAsset
+  recipient: string
+  amount: number
   openInNewTab?: boolean
   redirectUrl?: {
     success: string

--- a/packages/pay/src/ui/w3m-pay-view/index.ts
+++ b/packages/pay/src/ui/w3m-pay-view/index.ts
@@ -90,7 +90,7 @@ export class W3mPayView extends LitElement {
     const paymentAsset = PayController.getPaymentAsset()
     this.networkName = paymentAsset.network
     this.tokenSymbol = paymentAsset.metadata.symbol
-    this.amount = paymentAsset.amount.toString()
+    this.amount = PayController.state.amount.toString()
   }
 
   private renderPaymentHeader() {

--- a/packages/pay/tests/mocks/State.ts
+++ b/packages/pay/tests/mocks/State.ts
@@ -18,11 +18,7 @@ export const mockExchanges: Exchange[] = [
 
 export const mockPaymentAsset: PaymentAsset = {
   network: 'eip155:1',
-  recipient: '0x1234567890123456789012345678901234567890',
-  // USDC on Ethereum
   asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-  // 10 USDC with 6 decimals
-  amount: 10000000,
   metadata: {
     name: 'USD Coin',
     symbol: 'USDC',

--- a/packages/pay/tests/ui/w3m-pay-view.test.ts
+++ b/packages/pay/tests/ui/w3m-pay-view.test.ts
@@ -32,6 +32,8 @@ describe('W3mPayView', () => {
     PayController.state.isLoading = false
     PayController.state.exchanges = []
     PayController.state.paymentAsset = mockPaymentAsset
+    PayController.state.amount = 10
+    PayController.state.recipient = '0x1234567890123456789012345678901234567890'
 
     // Reset AccountController state
     vi.spyOn(AccountController, 'state', 'get').mockReturnValue({
@@ -68,7 +70,7 @@ describe('W3mPayView', () => {
     const tokenText = element.shadowRoot?.querySelector('wui-text[variant="paragraph-600"]')
     const networkText = element.shadowRoot?.querySelector('wui-text[variant="small-500"]')
 
-    expect(amountText?.textContent).toBe('10000000')
+    expect(amountText?.textContent).toBe('10')
     expect(tokenText?.textContent?.trim()).toBe('USDC')
     expect(networkText?.textContent?.trim()).toBe('on Ethereum')
   })


### PR DESCRIPTION
# Description

Change the pay interface to have 3 separate fields: `recipient`, `amount` and `paymentAsset`

```
await open({
      recipient: paymentDetails.recipient,
      amount: paymentDetails.amount,
      paymentAsset: {
        network: paymentDetails.network as `eip155:${string}`,
        asset: paymentDetails.asset as AddressOrNative,
        metadata: paymentDetails.metadata
      }
    })
```

This allows us in future to export a list of `paymentAssets` if clients prefer to use it in that way   



## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
