### PR TITLE
fix: wait for magic to initialize

### DIFF
--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -354,12 +354,7 @@ export class AppKit extends AppKitBaseClient {
           this.authProvider?.rejectRpcRequests()
         }
       })
-      if (
-        chainNamespace === ConstantsUtil.CHAIN.EVM &&
-        AccountController.state.preferredAccountTypes?.eip155
-      ) {
-        this.authProvider.setPreferredAccount(AccountController.state.preferredAccountTypes?.eip155)
-      }
+
       this.syncAuthConnector(this.authProvider, chainNamespace)
       this.checkExistingTelegramSocialConnection(chainNamespace)
     }

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -228,19 +228,18 @@ export class AppKit extends AppKitBaseClient {
 
     const theme = ThemeController.getSnapshot()
     const options = OptionsController.getSnapshot()
-    if (isConnected) {
-      provider.syncDappData({
-        metadata: options.metadata as Metadata,
-        sdkVersion: options.sdkVersion,
-        projectId: options.projectId,
-        sdkType: options.sdkType
-      })
-      provider.syncTheme({
-        themeMode: theme.themeMode,
-        themeVariables: theme.themeVariables,
-        w3mThemeVariables: getW3mThemeVariables(theme.themeVariables, theme.themeMode)
-      })
-    }
+
+    provider.syncDappData({
+      metadata: options.metadata as Metadata,
+      sdkVersion: options.sdkVersion,
+      projectId: options.projectId,
+      sdkType: options.sdkType
+    })
+    provider.syncTheme({
+      themeMode: theme.themeMode,
+      themeVariables: theme.themeVariables,
+      w3mThemeVariables: getW3mThemeVariables(theme.themeVariables, theme.themeMode)
+    })
 
     if (chainNamespace && isAuthSupported) {
       if (isConnected && this.connectionControllerClient?.connectExternal) {

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -228,18 +228,19 @@ export class AppKit extends AppKitBaseClient {
 
     const theme = ThemeController.getSnapshot()
     const options = OptionsController.getSnapshot()
-
-    provider.syncDappData({
-      metadata: options.metadata as Metadata,
-      sdkVersion: options.sdkVersion,
-      projectId: options.projectId,
-      sdkType: options.sdkType
-    })
-    provider.syncTheme({
-      themeMode: theme.themeMode,
-      themeVariables: theme.themeVariables,
-      w3mThemeVariables: getW3mThemeVariables(theme.themeVariables, theme.themeMode)
-    })
+    if (isConnected) {
+      provider.syncDappData({
+        metadata: options.metadata as Metadata,
+        sdkVersion: options.sdkVersion,
+        projectId: options.projectId,
+        sdkType: options.sdkType
+      })
+      provider.syncTheme({
+        themeMode: theme.themeMode,
+        themeVariables: theme.themeVariables,
+        w3mThemeVariables: getW3mThemeVariables(theme.themeVariables, theme.themeMode)
+      })
+    }
 
     if (chainNamespace && isAuthSupported) {
       if (isConnected && this.connectionControllerClient?.connectExternal) {

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -411,9 +411,18 @@ export class W3mFrameProvider {
 
   public async disconnect() {
     try {
-      const response = await this.appEvent<'SignOut'>({
-        type: W3mFrameConstants.APP_SIGN_OUT
-      } as W3mFrameTypes.AppEvent)
+      const response = await new Promise<void>(async resolve => {
+        const timeout = setTimeout(() => {
+          console.log('disconnect timeout reached')
+          resolve()
+        }, 3_000)
+        await this.appEvent<'SignOut'>({
+          type: W3mFrameConstants.APP_SIGN_OUT
+        } as W3mFrameTypes.AppEvent)
+        clearTimeout(timeout)
+        resolve()
+      })
+
       this.deleteAuthLoginCache()
 
       return response

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -411,10 +411,16 @@ export class W3mFrameProvider {
 
   public async disconnect() {
     try {
-      const response = await this.appEvent<'SignOut'>({
-        type: W3mFrameConstants.APP_SIGN_OUT
-      } as W3mFrameTypes.AppEvent)
-      this.deleteAuthLoginCache()
+      const response = await new Promise<void>(async resolve => {
+        const timeout = setTimeout(() => {
+          resolve()
+        }, 3_000)
+        await this.appEvent<'SignOut'>({
+          type: W3mFrameConstants.APP_SIGN_OUT
+        } as W3mFrameTypes.AppEvent)
+        clearTimeout(timeout)
+        resolve()
+      })
 
       return response
     } catch (error) {

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -57,16 +57,6 @@ export class W3mFrameProvider {
   }
 
   private async createFrame() {
-    if (this.isInitialized) {
-      return
-    }
-
-    if (this.initPromise) {
-      await this.initPromise
-
-      return
-    }
-
     this.w3mFrame.initFrame()
 
     this.initPromise = new Promise<void>(resolve => {
@@ -81,6 +71,20 @@ export class W3mFrameProvider {
 
     this.isInitialized = true
     this.initPromise = undefined
+  }
+
+  public async init() {
+    if (this.isInitialized) {
+      return
+    }
+
+    if (this.initPromise) {
+      await this.initPromise
+
+      return
+    }
+
+    await this.createFrame()
   }
 
   // -- Extended Methods ------------------------------------------------
@@ -110,7 +114,7 @@ export class W3mFrameProvider {
   public async connectEmail(payload: W3mFrameTypes.Requests['AppConnectEmailRequest']) {
     try {
       W3mFrameHelpers.checkIfAllowedToTriggerEmail()
-      await this.createFrame()
+      await this.init()
       const response = await this.appEvent<'ConnectEmail'>({
         type: W3mFrameConstants.APP_CONNECT_EMAIL,
         payload
@@ -188,7 +192,7 @@ export class W3mFrameProvider {
     payload: W3mFrameTypes.Requests['AppGetSocialRedirectUriRequest']
   ) {
     try {
-      await this.createFrame()
+      await this.init()
 
       return this.appEvent<'GetSocialRedirectUri'>({
         type: W3mFrameConstants.APP_GET_SOCIAL_REDIRECT_URI,
@@ -322,7 +326,7 @@ export class W3mFrameProvider {
 
   public async getUser(payload: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
-      await this.createFrame()
+      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.appEvent<'GetUser'>({
         type: W3mFrameConstants.APP_GET_USER,
@@ -339,7 +343,7 @@ export class W3mFrameProvider {
 
   public async connectSocial(uri: string) {
     try {
-      await this.createFrame()
+      await this.init()
       const response = await this.appEvent<'ConnectSocial'>({
         type: W3mFrameConstants.APP_CONNECT_SOCIAL,
         payload: { uri }
@@ -358,7 +362,7 @@ export class W3mFrameProvider {
 
   public async getFarcasterUri() {
     try {
-      await this.createFrame()
+      await this.init()
       const response = await this.appEvent<'GetFarcasterUri'>({
         type: W3mFrameConstants.APP_GET_FARCASTER_URI
       } as W3mFrameTypes.AppEvent)

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -52,9 +52,6 @@ export class W3mFrameProvider {
 
     this.w3mFrame = new W3mFrame({ projectId, isAppClient: true, chainId, enableLogger })
     this.onTimeout = onTimeout
-    if (this.getLoginEmailUsed()) {
-      this.createFrame()
-    }
   }
 
   private async createFrame() {

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -113,6 +113,7 @@ export class W3mFrameProvider {
 
   public async connectEmail(payload: W3mFrameTypes.Requests['AppConnectEmailRequest']) {
     try {
+      await this.init()
       W3mFrameHelpers.checkIfAllowedToTriggerEmail()
       const response = await this.appEvent<'ConnectEmail'>({
         type: W3mFrameConstants.APP_CONNECT_EMAIL,
@@ -292,6 +293,8 @@ export class W3mFrameProvider {
 
   public async setPreferredAccount(type: W3mFrameTypes.AccountType) {
     try {
+      await this.init()
+
       return this.appEvent<'SetPreferredAccount'>({
         type: W3mFrameConstants.APP_SET_PREFERRED_ACCOUNT,
         payload: { type }
@@ -305,6 +308,7 @@ export class W3mFrameProvider {
   // -- Provider Methods ------------------------------------------------
   public async connect(payload?: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
+      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.getUser({
         chainId,
@@ -339,6 +343,7 @@ export class W3mFrameProvider {
 
   public async connectSocial(uri: string) {
     try {
+      await this.init()
       const response = await this.appEvent<'ConnectSocial'>({
         type: W3mFrameConstants.APP_CONNECT_SOCIAL,
         payload: { uri }
@@ -559,7 +564,6 @@ export class W3mFrameProvider {
   private async appEvent<T extends W3mFrameTypes.ProviderRequestType>(
     event: AppEventType
   ): Promise<W3mFrameTypes.Responses[`Frame${T}Response`]> {
-    await this.init()
     let requestTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
     let iframeReadyTimeout: ReturnType<typeof setTimeout> | undefined = undefined

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -68,7 +68,7 @@ export class W3mFrameProvider {
         }
       })
     })
-
+    await this.initPromise
     this.isInitialized = true
     this.initPromise = undefined
   }

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -153,8 +153,6 @@ export class W3mFrameProvider {
         return { isConnected: false }
       }
 
-      await this.init()
-
       const response = await this.appEvent<'IsConnected'>({
         type: W3mFrameConstants.APP_IS_CONNECTED
       } as W3mFrameTypes.AppEvent)
@@ -334,7 +332,6 @@ export class W3mFrameProvider {
 
   public async getUser(payload: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
-      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.appEvent<'GetUser'>({
         type: W3mFrameConstants.APP_GET_USER,
@@ -571,6 +568,7 @@ export class W3mFrameProvider {
   private async appEvent<T extends W3mFrameTypes.ProviderRequestType>(
     event: AppEventType
   ): Promise<W3mFrameTypes.Responses[`Frame${T}Response`]> {
+    await this.init()
     let requestTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
     let iframeReadyTimeout: ReturnType<typeof setTimeout> | undefined = undefined

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -64,18 +64,16 @@ export class W3mFrameProvider {
       return
     }
 
-    this.w3mFrame.initFrame()
     this.initPromise = new Promise<void>(resolve => {
-      this.w3mFrame.events.onFrameEvent(async event => {
+      this.w3mFrame.events.onFrameEvent(event => {
         if (event.type === W3mFrameConstants.FRAME_READY) {
-          this.initPromise = undefined
-          await new Promise(_resolve => {
-            setTimeout(_resolve, 500)
-          })
           resolve()
         }
       })
     })
+
+    this.w3mFrame.initFrame()
+
     await this.initPromise
     this.initPromise = undefined
     this.isInitialized = true
@@ -104,7 +102,6 @@ export class W3mFrameProvider {
 
   public async reload() {
     try {
-      await this.init()
       await this.appEvent<'Reload'>({
         type: W3mFrameConstants.APP_RELOAD
       } as W3mFrameTypes.AppEvent)
@@ -117,7 +114,6 @@ export class W3mFrameProvider {
   public async connectEmail(payload: W3mFrameTypes.Requests['AppConnectEmailRequest']) {
     try {
       W3mFrameHelpers.checkIfAllowedToTriggerEmail()
-      await this.init()
       const response = await this.appEvent<'ConnectEmail'>({
         type: W3mFrameConstants.APP_CONNECT_EMAIL,
         payload
@@ -195,8 +191,6 @@ export class W3mFrameProvider {
     payload: W3mFrameTypes.Requests['AppGetSocialRedirectUriRequest']
   ) {
     try {
-      await this.init()
-
       return this.appEvent<'GetSocialRedirectUri'>({
         type: W3mFrameConstants.APP_GET_SOCIAL_REDIRECT_URI,
         payload
@@ -298,8 +292,6 @@ export class W3mFrameProvider {
 
   public async setPreferredAccount(type: W3mFrameTypes.AccountType) {
     try {
-      await this.init()
-
       return this.appEvent<'SetPreferredAccount'>({
         type: W3mFrameConstants.APP_SET_PREFERRED_ACCOUNT,
         payload: { type }
@@ -313,7 +305,6 @@ export class W3mFrameProvider {
   // -- Provider Methods ------------------------------------------------
   public async connect(payload?: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
-      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.getUser({
         chainId,
@@ -332,7 +323,6 @@ export class W3mFrameProvider {
 
   public async getUser(payload: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
-      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.appEvent<'GetUser'>({
         type: W3mFrameConstants.APP_GET_USER,
@@ -349,7 +339,6 @@ export class W3mFrameProvider {
 
   public async connectSocial(uri: string) {
     try {
-      await this.init()
       const response = await this.appEvent<'ConnectSocial'>({
         type: W3mFrameConstants.APP_CONNECT_SOCIAL,
         payload: { uri }
@@ -368,7 +357,6 @@ export class W3mFrameProvider {
 
   public async getFarcasterUri() {
     try {
-      await this.init()
       const response = await this.appEvent<'GetFarcasterUri'>({
         type: W3mFrameConstants.APP_GET_FARCASTER_URI
       } as W3mFrameTypes.AppEvent)
@@ -571,6 +559,7 @@ export class W3mFrameProvider {
   private async appEvent<T extends W3mFrameTypes.ProviderRequestType>(
     event: AppEventType
   ): Promise<W3mFrameTypes.Responses[`Frame${T}Response`]> {
+    await this.init()
     let requestTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
     let iframeReadyTimeout: ReturnType<typeof setTimeout> | undefined = undefined

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -309,6 +309,11 @@ export class W3mFrameProvider {
   public async connect(payload?: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
+
+      if (payload?.preferredAccountType) {
+        await this.setPreferredAccount(payload.preferredAccountType as W3mFrameTypes.AccountType)
+      }
+
       const response = await this.getUser({
         chainId,
         preferredAccountType: payload?.preferredAccountType

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -298,6 +298,8 @@ export class W3mFrameProvider {
 
   public async setPreferredAccount(type: W3mFrameTypes.AccountType) {
     try {
+      await this.init()
+
       return this.appEvent<'SetPreferredAccount'>({
         type: W3mFrameConstants.APP_SET_PREFERRED_ACCOUNT,
         payload: { type }
@@ -311,6 +313,7 @@ export class W3mFrameProvider {
   // -- Provider Methods ------------------------------------------------
   public async connect(payload?: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
+      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.getUser({
         chainId,
@@ -329,6 +332,7 @@ export class W3mFrameProvider {
 
   public async getUser(payload: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
+      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.appEvent<'GetUser'>({
         type: W3mFrameConstants.APP_GET_USER,

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -52,6 +52,9 @@ export class W3mFrameProvider {
 
     this.w3mFrame = new W3mFrame({ projectId, isAppClient: true, chainId, enableLogger })
     this.onTimeout = onTimeout
+    if (this.getLoginEmailUsed()) {
+      this.createFrame()
+    }
   }
 
   private async createFrame() {
@@ -110,6 +113,7 @@ export class W3mFrameProvider {
 
   public async connectEmail(payload: W3mFrameTypes.Requests['AppConnectEmailRequest']) {
     try {
+      await this.init()
       W3mFrameHelpers.checkIfAllowedToTriggerEmail()
       const response = await this.appEvent<'ConnectEmail'>({
         type: W3mFrameConstants.APP_CONNECT_EMAIL,
@@ -188,6 +192,7 @@ export class W3mFrameProvider {
     payload: W3mFrameTypes.Requests['AppGetSocialRedirectUriRequest']
   ) {
     try {
+      await this.init()
       return this.appEvent<'GetSocialRedirectUri'>({
         type: W3mFrameConstants.APP_GET_SOCIAL_REDIRECT_URI,
         payload
@@ -332,6 +337,7 @@ export class W3mFrameProvider {
 
   public async getUser(payload: W3mFrameTypes.Requests['AppGetUserRequest']) {
     try {
+      await this.init()
       const chainId = payload?.chainId || this.getLastUsedChainId() || 1
       const response = await this.appEvent<'GetUser'>({
         type: W3mFrameConstants.APP_GET_USER,
@@ -348,6 +354,7 @@ export class W3mFrameProvider {
 
   public async connectSocial(uri: string) {
     try {
+      await this.init()
       const response = await this.appEvent<'ConnectSocial'>({
         type: W3mFrameConstants.APP_CONNECT_SOCIAL,
         payload: { uri }
@@ -568,7 +575,6 @@ export class W3mFrameProvider {
   private async appEvent<T extends W3mFrameTypes.ProviderRequestType>(
     event: AppEventType
   ): Promise<W3mFrameTypes.Responses[`Frame${T}Response`]> {
-    await this.init()
     let requestTimeout: ReturnType<typeof setTimeout> | undefined = undefined
 
     let iframeReadyTimeout: ReturnType<typeof setTimeout> | undefined = undefined

--- a/packages/wallet/tests/W3mFrameProvider.test.ts
+++ b/packages/wallet/tests/W3mFrameProvider.test.ts
@@ -26,6 +26,7 @@ describe('W3mFrameProvider', () => {
 
   it('should connect email', async () => {
     provider['w3mFrame'].frameLoadPromise = Promise.resolve()
+    provider.isInitialized = true
     const payload = { email: 'test@example.com' }
     W3mFrameHelpers.checkIfAllowedToTriggerEmail.mockReturnValue(true)
     const responsePayload = { action: 'VERIFY_OTP' }
@@ -52,6 +53,7 @@ describe('W3mFrameProvider', () => {
 
   it('should connect otp', async () => {
     provider['w3mFrame'].frameLoadPromise = Promise.resolve()
+    provider.isInitialized = true
     const payload = { otp: '123456' }
     const postAppEventSpy = vi
       .spyOn(provider['w3mFrame'].events, 'postAppEvent')
@@ -71,6 +73,7 @@ describe('W3mFrameProvider', () => {
 
   it('should connect', async () => {
     provider['w3mFrame'].frameLoadPromise = Promise.resolve()
+    provider.isInitialized = true
     const payload = { chainId: 1 }
     const responsePayload = { address: '0xd34db33f', chainId: 1, email: 'test@walletconnect.com' }
 
@@ -124,15 +127,16 @@ describe('W3mFrameProvider', () => {
 
     vi.spyOn(testProvider['w3mFrame'].events, 'postAppEvent').mockImplementation(() => {})
 
+    testProvider.isInitialized = true
     testProvider['w3mFrame'].iframeIsReady = true
     testProvider['w3mFrame'].frameLoadPromise = Promise.resolve()
 
     testProvider.connectEmail({ email: 'test@example.com' }).catch(() => {})
 
     await Promise.resolve()
-
-    vi.advanceTimersByTime(30_000)
-
+    await Promise.resolve()
+    vi.advanceTimersByTime(31_000)
+    await Promise.resolve()
     await Promise.resolve()
 
     expect(onTimeoutMock).toHaveBeenCalledWith('iframe_request_timeout')
@@ -176,9 +180,14 @@ describe('W3mFrameProvider', () => {
       abortController: testAbortController
     })
 
+    testProvider.isInitialized = true
+    testProvider['w3mFrame'].frameLoadPromise = Promise.resolve()
+
     testProvider.connectEmail({ email: 'test@example.com' }).catch(() => {})
 
-    vi.runAllTimers()
+    await Promise.resolve()
+
+    vi.advanceTimersByTime(31_000)
 
     await Promise.resolve()
 


### PR DESCRIPTION
# Description
This PR improves embeded wallet communication by awaiting iframe to load before sending messages to it.
Also removes the initial `setPreferredAccount` request that was sent on provider init. Now `setPreferredAccount` is sent as part of `getUser` 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
context https://reown-inc.slack.com/archives/C07C28F0ALX/p1746712558714139

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
