### PR TITLE
refactor: uses existing accounts from AccountController

### DIFF
--- a/apps/laboratory/src/components/EmbeddedWalletInfo.tsx
+++ b/apps/laboratory/src/components/EmbeddedWalletInfo.tsx
@@ -6,8 +6,7 @@ export function EmbeddedWalletInfo() {
   const { embeddedWalletInfo } = useAppKitAccount()
 
   const { accountType, user, isSmartAccountDeployed } = embeddedWalletInfo ?? {}
-  // eslint-disable-next-line no-console
-  console.log('embeddedWalletInfo', JSON.stringify(embeddedWalletInfo, null, 2))
+
   const email = user?.email
   const username = user?.username
 

--- a/apps/laboratory/src/components/EmbeddedWalletInfo.tsx
+++ b/apps/laboratory/src/components/EmbeddedWalletInfo.tsx
@@ -6,7 +6,8 @@ export function EmbeddedWalletInfo() {
   const { embeddedWalletInfo } = useAppKitAccount()
 
   const { accountType, user, isSmartAccountDeployed } = embeddedWalletInfo ?? {}
-
+  // eslint-disable-next-line no-console
+  console.log('embeddedWalletInfo', JSON.stringify(embeddedWalletInfo, null, 2))
   const email = user?.email
   const username = user?.username
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -430,8 +430,15 @@ export abstract class AppKitBaseClient {
 
         StorageUtil.addConnectedNamespace(chainToUse)
         this.syncProvider({ ...res, chainNamespace: chainToUse })
-        const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
-        this.setAllAccounts(accounts, chainToUse)
+        /*
+         * SyncAllAccounts already set the accounts in the state
+         * and its more efficient to use the stored accounts rather than fetching them again
+         */
+        const syncedAccounts = AccountController.state.allAccounts
+        if (!syncedAccounts || syncedAccounts?.length === 0) {
+          const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
+          this.setAllAccounts(accounts, chainToUse)
+        }
         this.setStatus('connected', chainToUse)
         this.syncConnectedWalletInfo(chainToUse)
       },

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -435,10 +435,11 @@ export abstract class AppKitBaseClient {
          * and its more efficient to use the stored accounts rather than fetching them again
          */
         const syncedAccounts = AccountController.state.allAccounts
-        if (!syncedAccounts || syncedAccounts?.length === 0) {
-          const { accounts } = await adapter.getAccounts({ namespace: chainToUse, id })
-          this.setAllAccounts(accounts, chainToUse)
-        }
+        const { accounts } =
+          syncedAccounts?.length > 0
+            ? { accounts: syncedAccounts }
+            : await adapter.getAccounts({ namespace: chainToUse, id })
+        this.setAllAccounts(accounts, chainToUse)
         this.setStatus('connected', chainToUse)
         this.syncConnectedWalletInfo(chainToUse)
       },

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -437,7 +437,9 @@ export abstract class AppKitBaseClient {
         const syncedAccounts = AccountController.state.allAccounts
         const { accounts } =
           syncedAccounts?.length > 0
-            ? { accounts: syncedAccounts }
+            ? // eslint-disable-next-line line-comment-position
+              // Using new array else the accounts will have the same reference and react will not re-render
+              { accounts: [...syncedAccounts] }
             : await adapter.getAccounts({ namespace: chainToUse, id })
         this.setAllAccounts(accounts, chainToUse)
         this.setStatus('connected', chainToUse)

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -268,7 +268,7 @@ describe('syncConnectedWalletInfo', () => {
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
     })
 
-    it('should call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts is empty', async () => {
+    it('should call adapter.getAccounts() when using connectExternal and AccountController.state.allAccounts is empty', async () => {
       vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
         address: '0x123',
         chainId: '1',

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -228,6 +228,20 @@ describe('syncConnectedWalletInfo', () => {
       vi.spyOn(mockEvmAdapter, 'getAccounts').mockResolvedValue({
         accounts: [{ namespace: 'eip155', address: '0x123', type: 'eoa' }]
       })
+    })
+    it('should call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts is undefined', async () => {
+      vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
+        address: '0x123',
+        chainId: '1',
+        provider: {} as any,
+        id: 'test-connector',
+        type: 'INJECTED'
+      })
+      vi.spyOn(mockEvmAdapter, 'getAccounts').mockResolvedValue({
+        accounts: [{ namespace: 'eip155', address: '0x123', type: 'eoa' }]
+      })
+
+      AccountController.state.allAccounts = undefined
 
       await (appKit as any).connectionControllerClient.connectExternal({
         id: 'test-connector',
@@ -237,6 +251,82 @@ describe('syncConnectedWalletInfo', () => {
         chain: 'eip155'
       })
 
+      expect(AccountController.state.allAccounts).toHaveLength(1)
+      expect(AccountController.state.allAccounts[0]).toMatchObject({
+        address: '0x123',
+        type: 'eoa',
+        namespace: 'eip155'
+      })
+      expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(1)
+      expect(mockEvmAdapter.getAccounts).toHaveBeenCalledWith({
+        namespace: 'eip155',
+        id: 'test-connector'
+      })
+      expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
+    })
+
+    it('should call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts is empty', async () => {
+      vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
+        address: '0x123',
+        chainId: '1',
+        provider: {} as any,
+        id: 'test-connector',
+        type: 'INJECTED'
+      })
+      vi.spyOn(mockEvmAdapter, 'getAccounts').mockResolvedValue({
+        accounts: [{ namespace: 'eip155', address: '0x123', type: 'eoa' }]
+      })
+
+      AccountController.state.allAccounts = []
+
+      await (appKit as any).connectionControllerClient.connectExternal({
+        id: 'test-connector',
+        info: { name: 'Test Connector' },
+        type: 'INJECTED',
+        provider: {} as any,
+        chain: 'eip155'
+      })
+      expect(AccountController.state.allAccounts).toHaveLength(1)
+      expect(AccountController.state.allAccounts[0]).toMatchObject({
+        address: '0x123',
+        type: 'eoa',
+        namespace: 'eip155'
+      })
+      expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(1)
+      expect(mockEvmAdapter.getAccounts).toHaveBeenCalledWith({
+        namespace: 'eip155',
+        id: 'test-connector'
+      })
+      expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
+    })
+
+    it('should not call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts has accounts', async () => {
+      vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
+        address: '0x123',
+        chainId: '1',
+        provider: {} as any,
+        id: 'test-connector',
+        type: 'INJECTED'
+      })
+
+      const allAccounts = [{ type: 'eoa', address: '0x123', namespace: 'eip155' }]
+
+      vi.spyOn(mockEvmAdapter, 'getAccounts').mockResolvedValue({
+        accounts: allAccounts
+      })
+
+      AccountController.state.allAccounts = allAccounts
+
+      await (appKit as any).connectionControllerClient.connectExternal({
+        id: 'test-connector',
+        info: { name: 'Test Connector' },
+        type: 'INJECTED',
+        provider: {} as any,
+        chain: 'eip155'
+      })
+
+      expect(AccountController.state.allAccounts).toHaveLength(0)
+      expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(0)
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
     })
 
@@ -272,81 +362,81 @@ describe('syncConnectedWalletInfo', () => {
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
     })
   })
-})
 
-describe('syncAdapterConnection', () => {
-  it('should successfully sync adapter connection and account', async () => {
-    const appKit = new AppKit(mockOptions)
-    vi.spyOn(appKit as any, 'getAdapter').mockReturnValue({
-      syncConnection: vi.fn().mockResolvedValue({
+  describe('syncAdapterConnection', () => {
+    it('should successfully sync adapter connection and account', async () => {
+      const appKit = new AppKit(mockOptions)
+      vi.spyOn(appKit as any, 'getAdapter').mockReturnValue({
+        syncConnection: vi.fn().mockResolvedValue({
+          address: '0x123',
+          chainId: '1',
+          provider: {}
+        }),
+        getAccounts: vi.fn().mockResolvedValue({
+          accounts: [{ address: '0x123', type: 'eoa' }]
+        })
+      })
+      vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('test-connector')
+      vi.spyOn(ConnectorController, 'getConnectors').mockReturnValue([
+        { id: 'test-connector' } as Connector
+      ])
+      const getCaipNetwork = vi.spyOn(appKit, 'getCaipNetwork').mockReturnValue({
+        id: '1',
+        rpcUrls: { default: { http: ['https://test.com'] } }
+      } as unknown as CaipNetwork)
+
+      const setStatus = vi.spyOn(appKit, 'setStatus')
+      const setAllAccounts = vi.spyOn(appKit, 'setAllAccounts')
+      const syncAccount = vi.spyOn(appKit as any, 'syncAccount')
+
+      await appKit['syncAdapterConnection']('eip155')
+
+      expect(setStatus).toHaveBeenCalledWith('connected', 'eip155')
+      expect(setAllAccounts).toHaveBeenCalledWith([{ address: '0x123', type: 'eoa' }], 'eip155')
+      expect(syncAccount).toHaveBeenCalledWith({
         address: '0x123',
         chainId: '1',
-        provider: {}
-      }),
-      getAccounts: vi.fn().mockResolvedValue({
-        accounts: [{ address: '0x123', type: 'eoa' }]
-      })
-    })
-    vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('test-connector')
-    vi.spyOn(ConnectorController, 'getConnectors').mockReturnValue([
-      { id: 'test-connector' } as Connector
-    ])
-    const getCaipNetwork = vi.spyOn(appKit, 'getCaipNetwork').mockReturnValue({
-      id: '1',
-      rpcUrls: { default: { http: ['https://test.com'] } }
-    } as unknown as CaipNetwork)
-
-    const setStatus = vi.spyOn(appKit, 'setStatus')
-    const setAllAccounts = vi.spyOn(appKit, 'setAllAccounts')
-    const syncAccount = vi.spyOn(appKit as any, 'syncAccount')
-
-    await appKit['syncAdapterConnection']('eip155')
-
-    expect(setStatus).toHaveBeenCalledWith('connected', 'eip155')
-    expect(setAllAccounts).toHaveBeenCalledWith([{ address: '0x123', type: 'eoa' }], 'eip155')
-    expect(syncAccount).toHaveBeenCalledWith({
-      address: '0x123',
-      chainId: '1',
-      provider: {},
-      chainNamespace: 'eip155'
-    })
-    expect(getCaipNetwork).toHaveBeenCalledWith('eip155')
-  })
-
-  it('should handle missing caipNetwork', async () => {
-    const appKit = new AppKit(mockOptions)
-    vi.spyOn(appKit as any, 'getAdapter').mockReturnValue({
-      syncConnection: vi.fn()
-    })
-    vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('test-connector')
-    vi.spyOn(ConnectorController, 'getConnectors').mockReturnValue([
-      { id: 'test-connector' } as Connector
-    ])
-    const getCaipNetwork = vi.spyOn(appKit, 'getCaipNetwork').mockReturnValue(undefined)
-
-    const setStatus = vi.spyOn(appKit, 'setStatus')
-
-    await appKit['syncAdapterConnection']('eip155')
-
-    expect(setStatus).toHaveBeenCalledWith('disconnected', 'eip155')
-    expect(getCaipNetwork).toHaveBeenCalledWith('eip155')
-  })
-})
-
-describe('connectExternal', () => {
-  it('should throw an error if connection gets declined', async () => {
-    const appKit = new AppKit(mockOptions)
-
-    vi.spyOn(mockEvmAdapter, 'connect').mockRejectedValue(new Error('Connection declined'))
-
-    await expect(
-      (appKit as any).connectionControllerClient['connectExternal']({
-        id: 'test-connector',
-        info: { name: 'Test Connector' },
-        type: 'injected',
         provider: {},
-        chain: 'eip155'
+        chainNamespace: 'eip155'
       })
-    ).rejects.toThrow('Connection declined')
+      expect(getCaipNetwork).toHaveBeenCalledWith('eip155')
+    })
+
+    it('should handle missing caipNetwork', async () => {
+      const appKit = new AppKit(mockOptions)
+      vi.spyOn(appKit as any, 'getAdapter').mockReturnValue({
+        syncConnection: vi.fn()
+      })
+      vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('test-connector')
+      vi.spyOn(ConnectorController, 'getConnectors').mockReturnValue([
+        { id: 'test-connector' } as Connector
+      ])
+      const getCaipNetwork = vi.spyOn(appKit, 'getCaipNetwork').mockReturnValue(undefined)
+
+      const setStatus = vi.spyOn(appKit, 'setStatus')
+
+      await appKit['syncAdapterConnection']('eip155')
+
+      expect(setStatus).toHaveBeenCalledWith('disconnected', 'eip155')
+      expect(getCaipNetwork).toHaveBeenCalledWith('eip155')
+    })
+  })
+
+  describe('connectExternal', () => {
+    it('should throw an error if connection gets declined', async () => {
+      const appKit = new AppKit(mockOptions)
+
+      vi.spyOn(mockEvmAdapter, 'connect').mockRejectedValue(new Error('Connection declined'))
+
+      await expect(
+        (appKit as any).connectionControllerClient['connectExternal']({
+          id: 'test-connector',
+          info: { name: 'Test Connector' },
+          type: 'injected',
+          provider: {},
+          chain: 'eip155'
+        })
+      ).rejects.toThrow('Connection declined')
+    })
   })
 })

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -230,7 +230,7 @@ describe('syncConnectedWalletInfo', () => {
         accounts: [{ namespace: 'eip155', address: '0x123', type: 'eoa' }]
       })
     })
-    it('should call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts is undefined', async () => {
+    it('should call adapter.getAccounts() when using connectExternal and AccountController.state.allAccounts is undefined', async () => {
       vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
         address: '0x123',
         chainId: '1',

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -4,6 +4,7 @@ import type { MockInstance } from 'vitest'
 import type { CaipNetwork } from '@reown/appkit-common'
 import {
   AccountController,
+  type AccountType,
   type Connector,
   ConnectorController,
   type ConnectorType,
@@ -241,6 +242,7 @@ describe('syncConnectedWalletInfo', () => {
         accounts: [{ namespace: 'eip155', address: '0x123', type: 'eoa' }]
       })
 
+      //@ts-ignore
       AccountController.state.allAccounts = undefined
 
       await (appKit as any).connectionControllerClient.connectExternal({
@@ -257,6 +259,7 @@ describe('syncConnectedWalletInfo', () => {
         type: 'eoa',
         namespace: 'eip155'
       })
+      //@ts-expect-error
       expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(1)
       expect(mockEvmAdapter.getAccounts).toHaveBeenCalledWith({
         namespace: 'eip155',
@@ -292,6 +295,7 @@ describe('syncConnectedWalletInfo', () => {
         type: 'eoa',
         namespace: 'eip155'
       })
+      //@ts-expect-error
       expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(1)
       expect(mockEvmAdapter.getAccounts).toHaveBeenCalledWith({
         namespace: 'eip155',
@@ -309,7 +313,7 @@ describe('syncConnectedWalletInfo', () => {
         type: 'INJECTED'
       })
 
-      const allAccounts = [{ type: 'eoa', address: '0x123', namespace: 'eip155' }]
+      const allAccounts = [{ type: 'eoa', address: '0x123', namespace: 'eip155' }] as AccountType[]
 
       vi.spyOn(mockEvmAdapter, 'getAccounts').mockResolvedValue({
         accounts: allAccounts
@@ -325,7 +329,8 @@ describe('syncConnectedWalletInfo', () => {
         chain: 'eip155'
       })
 
-      expect(AccountController.state.allAccounts).toHaveLength(0)
+      expect(AccountController.state.allAccounts).toHaveLength(allAccounts.length)
+      //@ts-expect-error
       expect(mockEvmAdapter.getAccounts.mock.calls).toHaveLength(0)
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
     })

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -304,7 +304,7 @@ describe('syncConnectedWalletInfo', () => {
       expect(syncConnectedWalletInfoSpy).toHaveBeenCalledWith('eip155')
     })
 
-    it('should not call adater.getAccounts() when using connectExternal and AccountController.state.allAccounts has accounts', async () => {
+    it('should not call adapter.getAccounts() when using connectExternal and AccountController.state.allAccounts has accounts', async () => {
       vi.spyOn(mockEvmAdapter, 'connect').mockResolvedValue({
         address: '0x123',
         chainId: '1',


### PR DESCRIPTION
# Description
Reworked `connectExternal` flow to use the accounts from `AccountController` if available instead of calling `adapter.getAccounts` second time and doing duplicate work  

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
