### PR TITLE
Tomas/apkt 2854 usewalletinfo not working on the initial wallet connection

### DIFF
--- a/.changeset/pretty-files-carry.md
+++ b/.changeset/pretty-files-carry.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where walletInfo would be wrongly synced in wagmi on refresh

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -448,7 +448,7 @@ export class WagmiAdapter extends AdapterBlueprint {
       chainId: Number(connection?.chainId),
       address: connection?.accounts[0] as string,
       provider,
-      type: connection?.connector.type as ConnectorType,
+      type: connection?.connector.type?.toUpperCase() as ConnectorType,
       id: connection?.connector.id as string
     }
   }

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -539,7 +539,7 @@ describe('WagmiAdapter', () => {
     })
   })
 
-  describe('WagmiAdapter - connect and disconnect', () => {
+  describe('WagmiAdapter - connect, syncConnection and disconnect', () => {
     it('should connect successfully', async () => {
       const result = await adapter.connect({
         id: 'test-connector',
@@ -549,6 +549,22 @@ describe('WagmiAdapter', () => {
       })
 
       expect(result.address).toBe('0x123')
+      expect(result.chainId).toBe(1)
+    })
+
+    it('should sync connection successfully', async () => {
+      vi.mocked(getConnections).mockReturnValue([
+        { connector: { id: 'test-connector', type: 'injected' }, accounts: ['0x123'], chainId: 1 }
+      ] as any)
+      const result = await adapter.syncConnection({
+        id: 'test-connector',
+        chainId: 1,
+        namespace: 'eip155',
+        rpcUrl: 'https://rpc.walletconnect.org'
+      })
+
+      expect(result.address).toBe('0x123')
+      expect(result.type).toBe('INJECTED')
       expect(result.chainId).toBe(1)
     })
 


### PR DESCRIPTION
# Description

- Fixes issue where reloading the page would cause wagmi to return a wrongly formatted connector id

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
 Closes APKT-2854

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
