### PR TITLE
fix: phantom mobile wallet select logics to handle evm and bitcoin

### DIFF
--- a/.changeset/shiny-seas-lose.md
+++ b/.changeset/shiny-seas-lose.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes Phantom mobile wallet redirection for EVM/Bitcoin chains

--- a/apps/laboratory/tests/mobile-wallet-features.spec.ts
+++ b/apps/laboratory/tests/mobile-wallet-features.spec.ts
@@ -44,13 +44,16 @@ mobileWalletFeaturesTest(
     await modalPage.openAllWallets()
     await modalPage.page.waitForTimeout(500)
     await modalPage.search(library === 'bitcoin' ? 'okx' : 'trust')
-    await modalPage.clickAllWalletsListSearchItem(
+    await modalValidator.expectAllWalletsListSearchItem(
       library === 'bitcoin' ? OKX_WALLET_ID : TRUST_WALLET_ID
     )
   }
 )
 
-mobileWalletFeaturesTest('it should show open button', async () => {
+mobileWalletFeaturesTest('it should show open button', async ({ library }) => {
+  await modalPage.clickAllWalletsListSearchItem(
+    library === 'bitcoin' ? OKX_WALLET_ID : TRUST_WALLET_ID
+  )
   await modalValidator.expectOpenButton({ disabled: true })
   await modalPage.page.waitForTimeout(2000)
   await modalValidator.expectOpenButton({ disabled: false })

--- a/packages/controllers/src/controllers/ConnectorController.ts
+++ b/packages/controllers/src/controllers/ConnectorController.ts
@@ -330,9 +330,7 @@ const controller = {
   selectWalletConnector(wallet: WcWallet) {
     const connector = ConnectorController.getConnector(wallet.id, wallet.rdns)
 
-    if (ChainController.state.activeChain === ConstantsUtil.CHAIN.SOLANA) {
-      MobileWalletUtil.handleSolanaDeeplinkRedirect(connector?.name || wallet.name || '')
-    }
+    MobileWalletUtil.handleSolanaDeeplinkRedirect(connector?.name || wallet.name || '')
 
     if (connector) {
       RouterController.push('ConnectingExternal', { connector })

--- a/packages/controllers/src/controllers/ConnectorController.ts
+++ b/packages/controllers/src/controllers/ConnectorController.ts
@@ -330,7 +330,7 @@ const controller = {
   selectWalletConnector(wallet: WcWallet) {
     const connector = ConnectorController.getConnector(wallet.id, wallet.rdns)
 
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(connector?.name || wallet.name || '')
+    MobileWalletUtil.handleMobileDeeplinkRedirect(connector?.name || wallet.name || '')
 
     if (connector) {
       RouterController.push('ConnectingExternal', { connector })

--- a/packages/controllers/src/utils/MobileWallet.ts
+++ b/packages/controllers/src/utils/MobileWallet.ts
@@ -4,12 +4,12 @@ import { ChainController } from '../controllers/ChainController.js'
 
 export const MobileWalletUtil = {
   /**
-   * Handles mobile wallet redirection for wallets that have Universal Links.
+   * Handles mobile wallet redirection for wallets that have Universal Links and doesn't support WalletConnect Deep Links.
    *
    * @param {Object} properties - The properties object.
    * @param {string} properties.name - The name of the wallet.
    */
-  handleSolanaDeeplinkRedirect(name: string): void {
+  handleMobileDeeplinkRedirect(name: string): void {
     /**
      * Universal Links requires explicit user interaction to open the wallet app.
      * Previously we've been calling this with the life-cycle methods in the Solana clients by listening the SELECT_WALLET event of EventController.

--- a/packages/controllers/src/utils/MobileWallet.ts
+++ b/packages/controllers/src/utils/MobileWallet.ts
@@ -10,22 +10,23 @@ export const MobileWalletUtil = {
    * @param {string} properties.name - The name of the wallet.
    */
   handleSolanaDeeplinkRedirect(name: string): void {
+    /**
+     * Universal Links requires explicit user interaction to open the wallet app.
+     * Previously we've been calling this with the life-cycle methods in the Solana clients by listening the SELECT_WALLET event of EventController.
+     * But this breaks the UL functionality for some wallets like Phantom.
+     */
+    const href = window.location.href
+    const encodedHref = encodeURIComponent(href)
+
+    if (name === 'Phantom' && !('phantom' in window)) {
+      const protocol = href.startsWith('https') ? 'https' : 'http'
+      const host = href.split('/')[2]
+      const encodedRef = encodeURIComponent(`${protocol}://${host}`)
+
+      window.location.href = `https://phantom.app/ul/browse/${encodedHref}?ref=${encodedRef}`
+    }
+
     if (ChainController.state.activeChain === ConstantsUtil.CHAIN.SOLANA) {
-      /**
-       * Universal Links requires explicit user interaction to open the wallet app.
-       * Previously we've been calling this with the life-cycle methods in the Solana clients by listening the SELECT_WALLET event of EventController.
-       * But this breaks the UL functionality for some wallets like Phantom.
-       */
-      const href = window.location.href
-      const encodedHref = encodeURIComponent(href)
-      if (name === 'Phantom' && !('phantom' in window)) {
-        const protocol = href.startsWith('https') ? 'https' : 'http'
-        const host = href.split('/')[2]
-        const encodedRef = encodeURIComponent(`${protocol}://${host}`)
-
-        window.location.href = `https://phantom.app/ul/browse/${encodedHref}?ref=${encodedRef}`
-      }
-
       if (name === 'Coinbase Wallet' && !('coinbaseSolana' in window)) {
         window.location.href = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
       }

--- a/packages/controllers/tests/controllers/ConnectorController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectorController.test.ts
@@ -5,6 +5,7 @@ import { ConstantsUtil, getW3mThemeVariables } from '@reown/appkit-common'
 import {
   type AuthConnector,
   ChainController,
+  type ChainControllerState,
   ConnectorController,
   type Metadata,
   OptionsController,
@@ -13,8 +14,11 @@ import {
   type ThemeMode,
   type ThemeVariables
 } from '../../exports/index.js'
+import { MobileWalletUtil } from '../../src/utils/MobileWallet.js'
 
 // -- Setup --------------------------------------------------------------------
+const ORIGINAL_HREF = 'https://example.com/path'
+
 const authProvider = {
   syncDappData: (_args: { metadata: Metadata; sdkVersion: SdkVersion; projectId: string }) =>
     Promise.resolve(),
@@ -104,6 +108,11 @@ const zerionConnector = {
 describe('ConnectorController', () => {
   beforeEach(() => {
     ChainController.state.activeChain = ConstantsUtil.CHAIN.EVM
+    vi.stubGlobal('window', {
+      location: {
+        href: ORIGINAL_HREF
+      }
+    })
   })
 
   beforeEach(() => {
@@ -337,10 +346,9 @@ describe('ConnectorController', () => {
       id: 'connector',
       name: 'Connector',
       type: 'INJECTED' as const,
-      chain: 'solana' as const
+      chain: ConstantsUtil.CHAIN.SOLANA
     }
     vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(mockConnector)
-
     vi.spyOn(RouterController, 'push')
 
     ConnectorController.selectWalletConnector({ name: 'Connector', id: 'connector' })
@@ -349,6 +357,83 @@ describe('ConnectorController', () => {
       connector: mockConnector
     })
   })
+
+  it('should call mobile wallet util when selecting wallet is Phantom ', () => {
+    const mockConnector = {
+      id: 'phantom',
+      name: 'Phantom',
+      type: 'INJECTED' as const,
+      chain: ConstantsUtil.CHAIN.SOLANA
+    }
+    const handleMobileDeeplinkRedirectSpy = vi.spyOn(
+      MobileWalletUtil,
+      'handleMobileDeeplinkRedirect'
+    )
+    vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(mockConnector)
+    vi.spyOn(RouterController, 'push')
+
+    ConnectorController.selectWalletConnector({ name: mockConnector.name, id: mockConnector.id })
+
+    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
+    const encodedRef = encodeURIComponent('https://example.com')
+    const expectedUrl = `https://phantom.app/ul/browse/${encodedHref}?ref=${encodedRef}`
+
+    expect(window.location.href).toBe(expectedUrl)
+    expect(handleMobileDeeplinkRedirectSpy).toHaveBeenCalledWith(mockConnector.name)
+  })
+
+  it('should call mobile wallet util when selecting wallet is Coinbase only on Solana ', () => {
+    const mockConnector = {
+      id: 'coinbase',
+      name: 'Coinbase Wallet',
+      type: 'INJECTED' as const,
+      chain: ConstantsUtil.CHAIN.EVM
+    }
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      activeChain: ConstantsUtil.CHAIN.SOLANA
+    } as unknown as ChainControllerState)
+    const handleMobileDeeplinkRedirectSpy = vi.spyOn(
+      MobileWalletUtil,
+      'handleMobileDeeplinkRedirect'
+    )
+    vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(mockConnector)
+    vi.spyOn(RouterController, 'push')
+
+    ConnectorController.selectWalletConnector({ name: mockConnector.name, id: mockConnector.id })
+
+    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
+    const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
+
+    expect(window.location.href).toBe(expectedUrl)
+    expect(handleMobileDeeplinkRedirectSpy).toHaveBeenCalledWith(mockConnector.name)
+  })
+
+  it('should not call redirect when selected wallet is Coinbase and active chain is not Solana ', () => {
+    const mockConnector = {
+      id: 'coinbase',
+      name: 'Coinbase Wallet',
+      type: 'INJECTED' as const,
+      chain: ConstantsUtil.CHAIN.EVM
+    }
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      activeChain: ConstantsUtil.CHAIN.EVM
+    } as unknown as ChainControllerState)
+    const handleMobileDeeplinkRedirectSpy = vi.spyOn(
+      MobileWalletUtil,
+      'handleMobileDeeplinkRedirect'
+    )
+    vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(mockConnector)
+    vi.spyOn(RouterController, 'push')
+
+    ConnectorController.selectWalletConnector({ name: mockConnector.name, id: mockConnector.id })
+
+    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
+    const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
+
+    expect(window.location.href).toBe(ORIGINAL_HREF)
+    expect(handleMobileDeeplinkRedirectSpy).toHaveBeenCalledWith(mockConnector.name)
+  })
+
   it('should route to ConnectingWalletConnect when selecting wallet if there is not a connector', () => {
     vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(undefined)
     vi.spyOn(RouterController, 'push')

--- a/packages/controllers/tests/controllers/ConnectorController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectorController.test.ts
@@ -427,9 +427,6 @@ describe('ConnectorController', () => {
 
     ConnectorController.selectWalletConnector({ name: mockConnector.name, id: mockConnector.id })
 
-    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
-    const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
-
     expect(window.location.href).toBe(ORIGINAL_HREF)
     expect(handleMobileDeeplinkRedirectSpy).toHaveBeenCalledWith(mockConnector.name)
   })

--- a/packages/controllers/tests/utils/MobileWallet.test.ts
+++ b/packages/controllers/tests/utils/MobileWallet.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConstantsUtil } from '@reown/appkit-common'
+
 import {
   ChainController,
   type ChainControllerState
@@ -61,12 +63,28 @@ describe('MobileWalletUtil', () => {
   })
 
   it('should redirect to Coinbase Wallet when it is not installed', () => {
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
+      activeChain: ConstantsUtil.CHAIN.SOLANA
+    } as unknown as ChainControllerState)
     MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.coinbase.name)
 
     const encodedHref = encodeURIComponent(ORIGINAL_HREF)
     const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
 
     expect(window.location.href).toBe(expectedUrl)
+  })
+
+  it('should redirect to Coinbase Wallet if active namespace is Solana', () => {
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
+      activeChain: ConstantsUtil.CHAIN.EVM
+    } as unknown as ChainControllerState)
+
+    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.coinbase.name)
+
+    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
+    const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
+
+    expect(window.location.href).not.toBe(expectedUrl)
   })
 
   it('should not redirect when Coinbase Wallet is installed', () => {

--- a/packages/controllers/tests/utils/MobileWallet.test.ts
+++ b/packages/controllers/tests/utils/MobileWallet.test.ts
@@ -41,7 +41,7 @@ describe('MobileWalletUtil', () => {
   })
 
   it('should redirect to Phantom app when Phantom is not installed', () => {
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.phantom.name)
+    MobileWalletUtil.handleMobileDeeplinkRedirect(WALLETS.phantom.name)
 
     const encodedHref = encodeURIComponent(ORIGINAL_HREF)
     const encodedRef = encodeURIComponent('https://example.com')
@@ -57,7 +57,7 @@ describe('MobileWalletUtil', () => {
     })
 
     const originalHref = window.location.href
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.phantom.name)
+    MobileWalletUtil.handleMobileDeeplinkRedirect(WALLETS.phantom.name)
 
     expect(window.location.href).toBe(originalHref)
   })
@@ -66,7 +66,7 @@ describe('MobileWalletUtil', () => {
     vi.spyOn(ChainController, 'state', 'get').mockReturnValueOnce({
       activeChain: ConstantsUtil.CHAIN.SOLANA
     } as unknown as ChainControllerState)
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.coinbase.name)
+    MobileWalletUtil.handleMobileDeeplinkRedirect(WALLETS.coinbase.name)
 
     const encodedHref = encodeURIComponent(ORIGINAL_HREF)
     const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
@@ -79,7 +79,7 @@ describe('MobileWalletUtil', () => {
       activeChain: ConstantsUtil.CHAIN.EVM
     } as unknown as ChainControllerState)
 
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.coinbase.name)
+    MobileWalletUtil.handleMobileDeeplinkRedirect(WALLETS.coinbase.name)
 
     const encodedHref = encodeURIComponent(ORIGINAL_HREF)
     const expectedUrl = `https://go.cb-w.com/dapp?cb_url=${encodedHref}`
@@ -94,14 +94,14 @@ describe('MobileWalletUtil', () => {
     })
 
     const originalHref = window.location.href
-    MobileWalletUtil.handleSolanaDeeplinkRedirect(WALLETS.coinbase.name)
+    MobileWalletUtil.handleMobileDeeplinkRedirect(WALLETS.coinbase.name)
 
     expect(window.location.href).toBe(originalHref)
   })
 
   it('should not redirect for unknown wallet names', () => {
     const originalHref = window.location.href
-    MobileWalletUtil.handleSolanaDeeplinkRedirect('other')
+    MobileWalletUtil.handleMobileDeeplinkRedirect('other')
 
     expect(window.location.href).toBe(originalHref)
   })


### PR DESCRIPTION
# Description

Since Phantom doesn't have WC implementation, having UL redirection available for all namespaces is required to make it work for EVM/Bitcoin use cases, besides Solana. This PR removes active chain check for Phantom on `MobileWallet.handleSolanaDeeplinkRedirect` function. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
