### PR TITLE
fix: connected wallet info sets connector id if connector or provider not found

### DIFF
--- a/.changeset/vast-goats-dream.md
+++ b/.changeset/vast-goats-dream.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes connected wallet info state where it's using connector id when connector or provider is not found

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1164,8 +1164,6 @@ export abstract class AppKitBaseClient {
           { name: 'Coinbase Wallet', icon: this.getConnectorImage(connector) },
           chainNamespace
         )
-      } else {
-        this.setConnectedWalletInfo({ name: connectorId }, chainNamespace)
       }
     }
   }

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1130,6 +1130,7 @@ export abstract class AppKitBaseClient {
   protected syncConnectedWalletInfo(chainNamespace: ChainNamespace) {
     const connectorId = ConnectorController.getConnectorId(chainNamespace)
     const providerType = ProviderUtil.getProviderId(chainNamespace)
+
     if (
       providerType === UtilConstantsUtil.CONNECTOR_TYPE_ANNOUNCED ||
       providerType === UtilConstantsUtil.CONNECTOR_TYPE_INJECTED

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -193,16 +193,11 @@ describe('syncConnectedWalletInfo', () => {
     )
   })
 
-  it('should sync connected wallet info for any other provider type', async () => {
+  it('should not sync connected wallet info if connector is not found', async () => {
     vi.spyOn(ProviderUtil, 'getProviderId').mockReturnValue('mock-provider-id' as ConnectorType)
     appKit['syncConnectedWalletInfo']('eip155')
 
-    expect(setConnectedWalletInfoSpy).toHaveBeenCalledWith(
-      {
-        name: 'mock-connector-id'
-      },
-      'eip155'
-    )
+    expect(setConnectedWalletInfoSpy).not.toHaveBeenCalled()
   })
 
   describe('should be called on connection methods', () => {

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -5,6 +5,7 @@ import type {
   AdapterNetworkState,
   AuthConnector,
   Connector,
+  ConnectorType,
   SIWXConfig,
   SocialProvider
 } from '@reown/appkit'
@@ -35,7 +36,7 @@ import {
   StorageUtil,
   ThemeController
 } from '@reown/appkit-controllers'
-import { CaipNetworksUtil } from '@reown/appkit-utils'
+import { CaipNetworksUtil, ConstantsUtil as UtilConstantsUtil } from '@reown/appkit-utils'
 import { ProviderUtil } from '@reown/appkit-utils'
 
 import { AppKit } from '../../src/client/appkit.js'
@@ -827,12 +828,15 @@ describe('Base Public methods', () => {
     const setConnectedWalletInfo = vi.spyOn(AccountController, 'setConnectedWalletInfo')
     const getActiveNetworkProps = vi.spyOn(StorageUtil, 'getActiveNetworkProps')
     const fetchTokenBalance = vi.spyOn(AccountController, 'fetchTokenBalance')
+    vi.spyOn(ProviderUtil, 'getProviderId').mockReturnValue(
+      UtilConstantsUtil.CONNECTOR_TYPE_INJECTED as ConnectorType
+    )
     const mockConnector = {
       id: 'test-wallet',
       name: 'Test Wallet',
       imageUrl: 'test-wallet-icon'
     } as Connector
-    ConnectorController.state.connectors = [mockConnector]
+    ConnectorController.state.allConnectors = [mockConnector]
     vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValueOnce(mockConnector.id)
     const mockAccountData = {
       address: '0x123',
@@ -855,7 +859,14 @@ describe('Base Public methods', () => {
     const appKit = new AppKit(mockOptions)
     await appKit['syncAccount'](mockAccountData)
 
-    expect(setConnectedWalletInfo).toHaveBeenCalledWith({ name: mockConnector.id }, 'eip155')
+    expect(setConnectedWalletInfo).toHaveBeenCalledWith(
+      {
+        name: mockConnector.name,
+        type: UtilConstantsUtil.CONNECTOR_TYPE_INJECTED as ConnectorType,
+        icon: mockConnector.imageUrl
+      },
+      'eip155'
+    )
   })
 
   it('should sync identity only if address changed', async () => {

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -836,7 +836,7 @@ describe('Base Public methods', () => {
       name: 'Test Wallet',
       imageUrl: 'test-wallet-icon'
     } as Connector
-    ConnectorController.state.allConnectors = [mockConnector]
+    vi.spyOn(ConnectorController, 'getConnectors').mockReturnValueOnce([mockConnector])
     vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValueOnce(mockConnector.id)
     const mockAccountData = {
       address: '0x123',


### PR DESCRIPTION
# Description

AppKit does set connector ID as connected wallet info if the connector or provider not found, which is misleading value bc if these are not found it should keep/set the connected value as undefined

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
