### PR TITLE
refactor: UI tests to `click` a button instead of `focus + space`

### DIFF
--- a/apps/laboratory/tests/shared/pages/WalletPage.ts
+++ b/apps/laboratory/tests/shared/pages/WalletPage.ts
@@ -73,7 +73,6 @@ export class WalletPage {
   async handleSessionProposal(opts: SessionParams) {
     await this.page.waitForLoadState()
     const variant = opts.accept ? `approve` : `reject`
-    // `.click` doesn't work here, so we use `.focus` and `Space`
     await this.performRequestAction(variant)
   }
 
@@ -91,8 +90,7 @@ export class WalletPage {
       timeout: 30000
     })
     await expect(btn).toBeEnabled()
-    await btn.focus()
-    await this.page.keyboard.press('Space')
+    await btn.click()
   }
 
   /**


### PR DESCRIPTION
# Description
Updated UI tests behaviour to use `click` in `react-wallet` as the old `focus+space` doesn't work with the merging of https://github.com/reown-com/web-examples/pull/880 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
