### PR TITLE
feat: auth provider switch network while switching to another namespace

### DIFF
--- a/.changeset/olive-seas-juggle.md
+++ b/.changeset/olive-seas-juggle.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue where auth provider's switch network is not getting called when switching to different namespace if that namespace is already connected before

--- a/apps/laboratory/tests/multichain/multichain-ethers-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-ethers-solana-email.spec.ts
@@ -3,6 +3,7 @@ import { type BrowserContext, test } from '@playwright/test'
 import { DEFAULT_CHAIN_NAME } from '../shared/constants'
 import { ModalWalletPage } from '../shared/pages/ModalWalletPage'
 import { Email } from '../shared/utils/email'
+import { getNamespaceByNetworkName } from '../shared/utils/namespace'
 import { ModalWalletValidator } from '../shared/validators/ModalWalletValidator'
 
 /* eslint-disable init-declarations */
@@ -40,7 +41,7 @@ test.afterAll(async () => {
 
 // -- Tests --------------------------------------------------------------------
 test('it should switch networks (including different namespaces) and sign', async () => {
-  const chains = ['Polygon', 'Solana']
+  const chains = ['Polygon', 'Solana', 'OP Mainnet']
 
   async function processChain(index: number) {
     if (index >= chains.length) {
@@ -54,7 +55,7 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await page.closeModal()
 
     // -- Sign ------------------------------------------------------------------
-    await page.sign(chainName === 'Polygon' ? 'eip155' : 'solana')
+    await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet
     const chainNameOnWalletPage = chainName === 'Solana' ? 'Solana Mainnet' : chainName
     await validator.expectReceivedSign({ chainName: chainNameOnWalletPage })

--- a/apps/laboratory/tests/multichain/multichain-ethers5-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-ethers5-solana-email.spec.ts
@@ -3,6 +3,7 @@ import { type BrowserContext, test } from '@playwright/test'
 import { DEFAULT_CHAIN_NAME } from '../shared/constants'
 import { ModalWalletPage } from '../shared/pages/ModalWalletPage'
 import { Email } from '../shared/utils/email'
+import { getNamespaceByNetworkName } from '../shared/utils/namespace'
 import { ModalWalletValidator } from '../shared/validators/ModalWalletValidator'
 
 /* eslint-disable init-declarations */
@@ -40,7 +41,7 @@ test.afterAll(async () => {
 
 // -- Tests --------------------------------------------------------------------
 test('it should switch networks (including different namespaces) and sign', async () => {
-  const chains = ['Polygon', 'Solana']
+  const chains = ['Polygon', 'Solana', 'OP Mainnet']
 
   async function processChain(index: number) {
     if (index >= chains.length) {
@@ -53,7 +54,7 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await page.closeModal()
 
     // -- Sign ------------------------------------------------------------------
-    await page.sign(chainName === 'Polygon' ? 'eip155' : 'solana')
+    await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet
     const chainNameOnWalletPage = chainName === 'Solana' ? 'Solana Mainnet' : chainName
     await validator.expectReceivedSign({ chainName: chainNameOnWalletPage })

--- a/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
@@ -3,6 +3,7 @@ import { type BrowserContext, test } from '@playwright/test'
 import { DEFAULT_CHAIN_NAME } from '../shared/constants'
 import { ModalWalletPage } from '../shared/pages/ModalWalletPage'
 import { Email } from '../shared/utils/email'
+import { getNamespaceByNetworkName } from '../shared/utils/namespace'
 import { ModalWalletValidator } from '../shared/validators/ModalWalletValidator'
 
 /* eslint-disable init-declarations */
@@ -40,7 +41,7 @@ test.afterAll(async () => {
 
 // -- Tests --------------------------------------------------------------------
 test('it should switch networks (including different namespaces) and sign', async () => {
-  const chains = ['Polygon', 'Solana']
+  const chains = ['Polygon', 'Solana', 'OP Mainnet']
 
   async function processChain(index: number) {
     if (index >= chains.length) {
@@ -54,7 +55,7 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await page.closeModal()
 
     // -- Sign ------------------------------------------------------------------
-    await page.sign(chainName === 'Polygon' ? 'eip155' : 'solana')
+    await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet
     const chainNameOnWalletPage = chainName === 'Solana' ? 'Solana Mainnet' : chainName
     await validator.expectReceivedSign({ chainName: chainNameOnWalletPage })

--- a/apps/laboratory/tests/shared/utils/namespace.ts
+++ b/apps/laboratory/tests/shared/utils/namespace.ts
@@ -12,8 +12,11 @@ export function getNamespaceByLibrary(library: string) {
 export function getNamespaceByNetworkName(networkName: string) {
   switch (networkName) {
     case 'Solana':
+    case 'Solana Testnet':
+    case 'Solana Devnet':
       return 'solana'
     case 'Bitcoin':
+    case 'Bitcoin Testnet':
       return 'bip122'
     default:
       return 'eip155'

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.4'
+export const PACKAGE_VERSION = '1.7.5'

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -393,9 +393,10 @@ export class AppKit extends AppKitBaseClient {
 
     const currentNamespace = ChainController.state.activeChain
     const networkNamespace = caipNetwork.chainNamespace
-    const namespaceAddress = this.getAddressByChainNamespace(caipNetwork.chainNamespace)
+    const namespaceAddress = this.getAddressByChainNamespace(networkNamespace)
+    const isSameNamespace = networkNamespace === currentNamespace
 
-    if (caipNetwork.chainNamespace === ChainController.state.activeChain && namespaceAddress) {
+    if (isSameNamespace && namespaceAddress) {
       const adapter = this.getAdapter(networkNamespace)
       const provider = ProviderUtil.getProvider(networkNamespace)
       const providerType = ProviderUtil.getProviderId(networkNamespace)
@@ -432,14 +433,24 @@ export class AppKit extends AppKitBaseClient {
       ) {
         try {
           ChainController.state.activeChain = caipNetwork.chainNamespace
-          await this.connectionControllerClient?.connectExternal?.({
-            id: ConstantsUtil.CONNECTOR_ID.AUTH,
-            provider: this.authProvider,
-            chain: networkNamespace,
-            chainId: caipNetwork.id,
-            type: UtilConstantsUtil.CONNECTOR_TYPE_AUTH as ConnectorType,
-            caipNetwork
-          })
+
+          if (namespaceAddress) {
+            const adapter = this.getAdapter(networkNamespace as ChainNamespace)
+            await adapter?.switchNetwork({
+              caipNetwork,
+              provider: this.authProvider,
+              providerType: newNamespaceProviderType
+            })
+          } else {
+            await this.connectionControllerClient?.connectExternal?.({
+              id: ConstantsUtil.CONNECTOR_ID.AUTH,
+              provider: this.authProvider,
+              chain: networkNamespace,
+              chainId: caipNetwork.id,
+              type: UtilConstantsUtil.CONNECTOR_TYPE_AUTH as ConnectorType,
+              caipNetwork
+            })
+          }
           this.setCaipNetwork(caipNetwork)
         } catch (error) {
           const adapter = this.getAdapter(networkNamespace as ChainNamespace)

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -422,6 +422,8 @@ const controller = {
 
     if (unsupportedNetwork) {
       RouterController.goBack()
+
+      return
     }
 
     const networkControllerClient = ChainController.getNetworkControllerClient(


### PR DESCRIPTION
- **chore: call switch network even if switched network is already connected when using auth provider**
- **fix: potential unnecessary switch network call when unsupported network**
- **chore: update multichain email tests to handle switching to different network on other namespace**
- **chore: appkit version on const**
- **chore: changeset file**

# Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
