### PR TITLE
fix: pass chain id to w3m frame provider initialization

### DIFF
--- a/.changeset/bright-queens-spend.md
+++ b/.changeset/bright-queens-spend.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes W3mFrameProvider initialization without current chain id which causes network sync issues betwen AppKit and Secure site

--- a/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
@@ -1,21 +1,65 @@
 import * as React from 'react'
 
-import { Button } from '@chakra-ui/react'
-import { type Address } from 'viem'
+import { Box, Button } from '@chakra-ui/react'
+import { type Address, recoverAddress } from 'viem'
 import { useSignMessage } from 'wagmi'
 
 import { useAppKitAccount } from '@reown/appkit/react'
 
 import { useChakraToast } from '@/src/components/Toast'
 import { ConstantsUtil } from '@/src/utils/ConstantsUtil'
+import { verifySignature } from '@/src/utils/SignatureUtil'
 
 export function WagmiSignMessageTest() {
   const toast = useChakraToast()
-  const { address, isConnected } = useAppKitAccount({ namespace: 'eip155' })
+  const { caipAddress, address, isConnected } = useAppKitAccount({ namespace: 'eip155' })
 
   const { signMessageAsync, isPending } = useSignMessage()
 
+  const [currCaipAddress, setCurrCaipAddress] = React.useState<string | undefined>()
   const [signature, setSignature] = React.useState<string | undefined>()
+
+  async function onVerifySignature() {
+    if (!caipAddress || !signature) {
+      toast({
+        title: 'Verification Failed',
+        description: 'Address and signature required',
+        type: 'error'
+      })
+      return
+    }
+
+    const chainId = Number(caipAddress.split(':')[1])
+    const address = caipAddress.split(':')[2]
+
+    try {
+      const isValid = await verifySignature({
+        address: address as Address,
+        message: 'Hello AppKit!',
+        signature,
+        chainId: chainId as number
+      })
+
+      toast({
+        title: 'Signature Verification',
+        description: isValid ? 'Valid signature' : 'Invalid signature',
+        type: isValid ? 'success' : 'error'
+      })
+    } catch (e) {
+      toast({
+        title: 'Verification Failed',
+        description: 'Failed to verify signature',
+        type: 'error'
+      })
+    }
+  }
+
+  React.useEffect(() => {
+    if (caipAddress !== currCaipAddress) {
+      setCurrCaipAddress(caipAddress)
+      setSignature(undefined)
+    }
+  }, [caipAddress])
 
   async function onSignMessage() {
     if (!address) {
@@ -58,6 +102,16 @@ export function WagmiSignMessageTest() {
       <div data-testid="w3m-signature" hidden>
         {signature}
       </div>
+
+      <Box mt={4}>
+        <Button
+          data-testid="verify-signature-button"
+          onClick={onVerifySignature}
+          isDisabled={!signature}
+        >
+          Verify Signature
+        </Button>
+      </Box>
     </>
   )
 }

--- a/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { Box, Button } from '@chakra-ui/react'
-import { type Address, recoverAddress } from 'viem'
+import { type Address } from 'viem'
 import { useSignMessage } from 'wagmi'
 
 import { useAppKitAccount } from '@reown/appkit/react'

--- a/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiSignMessageTest.tsx
@@ -26,6 +26,7 @@ export function WagmiSignMessageTest() {
         description: 'Address and signature required',
         type: 'error'
       })
+
       return
     }
 
@@ -37,7 +38,7 @@ export function WagmiSignMessageTest() {
         address: address as Address,
         message: 'Hello AppKit!',
         signature,
-        chainId: chainId as number
+        chainId
       })
 
       toast({

--- a/packages/adapters/solana/src/tests/mocks/W3mFrameProvider.ts
+++ b/packages/adapters/solana/src/tests/mocks/W3mFrameProvider.ts
@@ -10,6 +10,7 @@ import { TestConstants } from '../util/TestConstants.js'
 export function mockW3mFrameProvider() {
   const w3mFrame = W3mFrameProviderSingleton.getInstance({
     projectId: 'projectId',
+    chainId: 1,
     abortController: ErrorUtil.EmbeddedWalletAbortController
   })
 

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -7,7 +7,7 @@ import {
   type EmbeddedWalletTimeoutReason
 } from '@reown/appkit-common'
 import { NetworkUtil } from '@reown/appkit-common'
-import { AccountController, AlertController } from '@reown/appkit-controllers'
+import { AccountController, AlertController, ChainController } from '@reown/appkit-controllers'
 import { ErrorUtil } from '@reown/appkit-utils'
 import { W3mFrameProvider } from '@reown/appkit-wallet'
 import { W3mFrameProviderSingleton } from '@reown/appkit/auth-provider'
@@ -50,6 +50,7 @@ export function authConnector(parameters: AuthParameters) {
     if (!socialProvider) {
       socialProvider = W3mFrameProviderSingleton.getInstance({
         projectId: parameters.options.projectId,
+        chainId: ChainController.getActiveCaipNetwork()?.caipNetworkId,
         enableLogger: parameters.options.enableAuthLogger,
         onTimeout: (reason: EmbeddedWalletTimeoutReason) => {
           if (reason === 'iframe_load_failed') {
@@ -157,6 +158,7 @@ export function authConnector(parameters: AuthParameters) {
       if (!this.provider) {
         this.provider = W3mFrameProviderSingleton.getInstance({
           projectId: parameters.options.projectId,
+          chainId: ChainController.getActiveCaipNetwork()?.caipNetworkId,
           enableLogger: parameters.options.enableAuthLogger,
           abortController: ErrorUtil.EmbeddedWalletAbortController,
           onTimeout: (reason: EmbeddedWalletTimeoutReason) => {

--- a/packages/appkit/src/auth-provider/W3MFrameProviderSingleton.ts
+++ b/packages/appkit/src/auth-provider/W3MFrameProviderSingleton.ts
@@ -3,7 +3,7 @@ import { W3mFrameProvider } from '@reown/appkit-wallet'
 
 interface W3mFrameProviderConfig {
   projectId: string
-  chainId: number | CaipNetworkId
+  chainId: number | CaipNetworkId | undefined
   enableLogger?: boolean
   onTimeout?: (reason: EmbeddedWalletTimeoutReason) => void
   abortController: AbortController

--- a/packages/appkit/src/auth-provider/W3MFrameProviderSingleton.ts
+++ b/packages/appkit/src/auth-provider/W3MFrameProviderSingleton.ts
@@ -3,7 +3,7 @@ import { W3mFrameProvider } from '@reown/appkit-wallet'
 
 interface W3mFrameProviderConfig {
   projectId: string
-  chainId?: number | CaipNetworkId
+  chainId: number | CaipNetworkId
   enableLogger?: boolean
   onTimeout?: (reason: EmbeddedWalletTimeoutReason) => void
   abortController: AbortController


### PR DESCRIPTION
# Description

Fixes W3mFrameProvider initialization without current chain id which causes network sync issues betwen AppKit and Secure site

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
