### PR TITLE
fix: email on connect redirection to account page instead of connect page

### DIFF
--- a/.changeset/quiet-friends-stay.md
+++ b/.changeset/quiet-friends-stay.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes an issue that can be seen on embedded mode where we are redirecting user to connect page instead of account page after connection

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -299,6 +299,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: /tmp/playwright_cache # Use workspace path
           SKIP_PLAYWRIGHT_WEBSERVER: ${{ inputs.skip-playwright-webserver }}
           BASE_URL: ${{ inputs.demo-base-url }}
+          MAILSAC_API_KEY: ${{ secrets.TESTS_MAILSAC_API_KEY }}
           NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
           CI: true
         working-directory: ./apps/demo/

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -139,6 +139,7 @@ jobs:
         run: pnpm build:demo
         env:
           NEXT_PUBLIC_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_PROJECT_ID }}
+          MAILSAC_API_KEY: ${{ secrets.TESTS_MAILSAC_API_KEY }}
           BASE_URL: ${{ inputs.demo-base-url }}
           NODE_OPTIONS: '--max-old-space-size=4096' # Increase memory for webpack
 

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -10,7 +10,9 @@
     "typecheck": "tsc --noEmit",
     "playwright:start": "pnpm start",
     "playwright:test": "playwright test",
-    "playwright:debug": "pnpm playwright:test --debug"
+    "playwright:test:email": "playwright test --grep email.spec.ts",
+    "playwright:debug": "pnpm playwright:test --debug",
+    "playwright:debug:email": "pnpm playwright:test:email --debug"
   },
   "dependencies": {
     "@dnd-kit/core": "6.3.1",
@@ -65,6 +67,7 @@
     "@types/node": "22.13.4",
     "@types/react": "19.1.3",
     "@types/react-dom": "19.1.3",
+    "@mailsac/api": "1.0.8",
     "@playwright/test": "1.48.2",
     "eslint": "8.56.0",
     "eslint-config-next": "14.1.0",

--- a/apps/demo/tests/email.spec.ts
+++ b/apps/demo/tests/email.spec.ts
@@ -1,0 +1,55 @@
+import { test } from '@playwright/test'
+
+import { DemoPage } from './pages/DemoPage'
+import { Email } from './utils/email'
+import { ModalValidator } from './validators'
+
+// eslint-disable-next-line init-declarations
+let demoPage: DemoPage
+let email: Email
+let tempEmail: string
+let validator: ModalValidator
+
+test.describe.configure({ mode: 'serial' })
+
+test.beforeAll(async ({ browser }) => {
+  const context = await browser.newContext()
+  const browserPage = await context.newPage()
+
+  demoPage = new DemoPage(browserPage)
+  validator = new ModalValidator(browserPage)
+
+  await demoPage.load()
+})
+
+test.afterAll(async () => {
+  await demoPage.page.close()
+})
+
+// Test case 1: Disable chain with chain option
+test('should connect with email as expected', async ({ context }) => {
+  const mailsacApiKey = process.env['MAILSAC_API_KEY']
+
+  if (!mailsacApiKey) {
+    throw new Error('MAILSAC_API_KEY is not set')
+  }
+
+  email = new Email(mailsacApiKey)
+  tempEmail = await email.getEmailAddressToUse()
+
+  // Iframe should not be injected until needed
+  validator.expectSecureSiteFrameNotInjected()
+  await demoPage.emailFlow({
+    emailAddress: tempEmail,
+    context,
+    mailsacApiKey,
+    clickConnectButton: false
+  })
+
+  await validator.expectConnected()
+})
+
+test('should stay connected after page refresh', async () => {
+  await demoPage.page.reload()
+  await validator.expectConnected()
+})

--- a/apps/demo/tests/email.spec.ts
+++ b/apps/demo/tests/email.spec.ts
@@ -4,7 +4,7 @@ import { DemoPage } from './pages/DemoPage'
 import { Email } from './utils/email'
 import { ModalValidator } from './validators'
 
-// eslint-disable-next-line init-declarations
+/* eslint-disable init-declarations */
 let demoPage: DemoPage
 let email: Email
 let tempEmail: string

--- a/apps/demo/tests/network.spec.ts
+++ b/apps/demo/tests/network.spec.ts
@@ -1,5 +1,7 @@
 import { test } from '@playwright/test'
 
+import { ConstantsUtil } from '@reown/appkit-common'
+
 import { NETWORK_OPTIONS } from '@/lib/networks'
 
 import { DemoPage } from './pages/DemoPage'
@@ -9,8 +11,12 @@ let demoPage: DemoPage
 
 test.describe.configure({ mode: 'serial' })
 
-const evmNetworks = NETWORK_OPTIONS.filter(n => n.namespace === 'eip155').map(n => n.network)
-const solanaNetworks = NETWORK_OPTIONS.filter(n => n.namespace === 'solana').map(n => n.network)
+const evmNetworks = NETWORK_OPTIONS.filter(n => n.namespace === ConstantsUtil.CHAIN.EVM).map(
+  n => n.network
+)
+const solanaNetworks = NETWORK_OPTIONS.filter(n => n.namespace === ConstantsUtil.CHAIN.SOLANA).map(
+  n => n.network
+)
 
 test.beforeAll(async ({ browser }) => {
   const context = await browser.newContext()
@@ -26,7 +32,7 @@ test.afterAll(async () => {
 })
 
 // Test case 1: Disable chain with chain option
-test('Disable chain with chain option', async () => {
+test('it should disable chain with chain option as expected', async () => {
   // Open networks page on AppKit
   await demoPage.openNetworks()
 
@@ -46,7 +52,7 @@ test('Disable chain with chain option', async () => {
 })
 
 // Test case 2: Disable chain with network option
-test('Disable chain with network option', async () => {
+test('it should disable chain with network option as expected', async () => {
   // Open networks page on AppKit
   await demoPage.openNetworks()
 
@@ -76,7 +82,7 @@ test('Disable chain with network option', async () => {
 })
 
 // Test case 3: Refresh page keeps state
-test('Refresh page keeps state', async () => {
+test('it should refresh page keeps state as expected', async () => {
   // Refresh the page
   await demoPage.page.reload()
 

--- a/apps/demo/tests/pages/DemoPage.ts
+++ b/apps/demo/tests/pages/DemoPage.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import type { BrowserContext, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 

--- a/apps/demo/tests/pages/DemoPage.ts
+++ b/apps/demo/tests/pages/DemoPage.ts
@@ -1,9 +1,11 @@
-import type { Page } from '@playwright/test'
+import type { BrowserContext, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import type { ChainNamespace } from '@reown/appkit-common'
 
 import { BASE_URL } from '../constants'
+import { Email } from '../utils/email'
+import { DeviceRegistrationPage } from './DeviceRegistirationPage'
 
 export class DemoPage {
   public readonly page: Page
@@ -63,5 +65,111 @@ export class DemoPage {
       ? expect(networkSwitch).toBeVisible()
       : expect(networkSwitch).not.toBeVisible()
     await visibilityCheck
+  }
+
+  async emailFlow({
+    emailAddress,
+    context,
+    mailsacApiKey,
+    clickConnectButton = true
+  }: {
+    emailAddress: string
+    context: BrowserContext
+    mailsacApiKey: string
+    clickConnectButton?: boolean
+  }): Promise<void> {
+    const email = new Email(mailsacApiKey)
+
+    await email.deleteAllMessages(emailAddress)
+    await this.loginWithEmail(emailAddress, undefined, clickConnectButton)
+
+    const firstMessageId = await email.getLatestMessageId(emailAddress)
+    if (!firstMessageId) {
+      throw new Error('No messageId found')
+    }
+
+    const firstEmailBody = await email.getEmailBody(emailAddress, firstMessageId)
+    let otp = ''
+    if (email.isApproveEmail(firstEmailBody)) {
+      const url = email.getApproveUrlFromBody(firstEmailBody)
+
+      await email.deleteAllMessages(emailAddress)
+      const newPage = await context.newPage()
+
+      const drp = new DeviceRegistrationPage(newPage, url)
+      await drp.load()
+
+      await drp.approveDevice()
+      await drp.close()
+
+      const secondMessageId = await email.getLatestMessageId(emailAddress)
+      if (!secondMessageId) {
+        throw new Error('No messageId found')
+      }
+
+      const secondEmailBody = await email.getEmailBody(emailAddress, secondMessageId)
+      if (email.isApproveEmail(secondEmailBody)) {
+        throw new Error('Unexpected approve email after already approved')
+      }
+      otp = email.getOtpCodeFromBody(secondEmailBody)
+    } else {
+      otp = email.getOtpCodeFromBody(firstEmailBody)
+    }
+
+    await this.enterOTP(otp)
+  }
+
+  async loginWithEmail(email: string, validate = true, clickConnectButton = true) {
+    if (clickConnectButton) {
+      // Connect Button doesn't have a proper `disabled` attribute so we need to wait for the button to change the text
+      await this.page
+        .getByTestId('connect-button')
+        .getByRole('button', { name: 'Connect Wallet' })
+        .click()
+    }
+    await this.page.getByTestId('wui-email-input').locator('input').focus()
+    await this.page.getByTestId('wui-email-input').locator('input').fill(email)
+    await this.page.getByTestId('wui-email-input').locator('input').press('Enter')
+    if (validate) {
+      await expect(
+        this.page.getByText(email),
+        `Expected current email: ${email} to be visible on the notification screen`
+      ).toBeVisible({
+        timeout: 20_000
+      })
+    }
+  }
+
+  async enterOTP(otp: string, headerTitle = 'Confirm Email') {
+    await expect(this.page.getByText(headerTitle)).toBeVisible({
+      timeout: 10_000
+    })
+    await expect(this.page.getByText('Enter the code we sent')).toBeVisible({
+      timeout: 10_000
+    })
+
+    const splitted = otp.split('')
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < splitted.length; i++) {
+      const digit = splitted[i]
+      if (!digit) {
+        throw new Error('Invalid OTP')
+      }
+      const otpInput = this.page.getByTestId('wui-otp-input')
+      const wrapper = otpInput.locator('wui-input-numeric').nth(i)
+      await expect(wrapper, `Wrapper element for input ${i} should be visible`).toBeVisible({
+        timeout: 5000
+      })
+      const input = wrapper.locator('input')
+      await expect(input, `Input ${i} should be enabled`).toBeEnabled({
+        timeout: 5000
+      })
+      await input.fill(digit)
+    }
+
+    await expect(this.page.getByText(headerTitle)).not.toBeVisible({
+      timeout: 20_000
+    })
   }
 }

--- a/apps/demo/tests/pages/DeviceRegistirationPage.ts
+++ b/apps/demo/tests/pages/DeviceRegistirationPage.ts
@@ -1,0 +1,25 @@
+import { type Page, expect } from '@playwright/test'
+
+const LOGIN_APPROVED_SUCCESS_TEXT = 'approved'
+
+export class DeviceRegistrationPage {
+  public readonly page: Page
+  public readonly url: string
+  constructor(page: Page, url: string) {
+    this.page = page
+    this.url = url
+  }
+
+  async load() {
+    await this.page.goto(this.url)
+    await this.page.waitForLoadState()
+  }
+
+  async approveDevice() {
+    await this.page.getByRole('button', { name: 'Approve' }).click()
+    await expect(this.page.getByText(LOGIN_APPROVED_SUCCESS_TEXT)).toBeVisible()
+  }
+  async close() {
+    await this.page.close()
+  }
+}

--- a/apps/demo/tests/utils/email.ts
+++ b/apps/demo/tests/utils/email.ts
@@ -1,0 +1,98 @@
+import { Mailsac } from '@mailsac/api'
+
+const EMAIL_CHECK_INTERVAL = 2500
+const MAX_EMAIL_CHECK = 96
+const EMAIL_APPROVE_BUTTON_TEXT = 'Approve this login'
+const APPROVE_URL_REGEX = /https:\/\/register.*/u
+const OTP_CODE_REGEX = /\d{3}\s?\d{3}/u
+const EMAIL_DOMAIN = 'web3modal.msdc.co'
+
+export class Email {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  private readonly mailsac: Mailsac<any>
+  public readonly apiKey: string
+  constructor(apiKey: string) {
+    this.apiKey = apiKey
+    this.mailsac = new Mailsac({ headers: { 'Mailsac-Key': apiKey } })
+  }
+
+  async deleteAllMessages(email: string) {
+    return await this.mailsac.messages.deleteAllMessages(email)
+  }
+
+  timeout(ms: number) {
+    return new Promise(resolve => {
+      setTimeout(resolve, ms)
+    })
+  }
+
+  async getLatestMessageId(email: string): Promise<string> {
+    let checks = 0
+    /* eslint-disable no-await-in-loop */
+    while (checks < MAX_EMAIL_CHECK) {
+      const messages = await this.mailsac.messages.listMessages(email)
+      if (messages.data.length > 0) {
+        const message = messages.data[0]
+        if (!message) {
+          throw new Error(`No message found for address ${email}`)
+        }
+        const id = message._id
+        if (!id) {
+          throw new Error(`Message id not present for address ${email}`)
+        }
+
+        return id
+      }
+      await this.timeout(EMAIL_CHECK_INTERVAL)
+      checks += 1
+    }
+    throw new Error(`No email found for address ${email}`)
+  }
+
+  async getEmailBody(email: string, messageId: string): Promise<string> {
+    const result = await this.mailsac.messages.getBodyPlainText(email, messageId)
+
+    return result.data
+  }
+
+  isApproveEmail(body: string): boolean {
+    return body.includes(EMAIL_APPROVE_BUTTON_TEXT)
+  }
+
+  getApproveUrlFromBody(body: string): string {
+    const match = body.match(APPROVE_URL_REGEX)
+    if (match) {
+      return match[0]
+    }
+
+    throw new Error(`No url found in email: ${body}`)
+  }
+
+  getOtpCodeFromBody(body: string): string {
+    const cleanedBody = body.replace(/https:\/\/s1\.designmodo\.com\/postcards\/[^\s]+\s?/gu, '')
+
+    const match = cleanedBody.match(OTP_CODE_REGEX)
+    if (match) {
+      // Remove empty space in OTP code 111 111
+      return match[0].replace(' ', '')
+    }
+
+    throw new Error(`No code found in email: ${body}`)
+  }
+
+  async getEmailAddressToUse(domain = EMAIL_DOMAIN): Promise<string> {
+    const response = await fetch(
+      'https://id-allocation-service.walletconnect-v1-bridge.workers.dev/allocate'
+    )
+    const { id } = await response.json()
+
+    const email = `w3m-w${id}@${domain}`
+    // eslint-disable-next-line no-console
+
+    return email
+  }
+
+  getSmartAccountEnabledEmail(): string {
+    return 'web3modal-smart-account@mailsac.com'
+  }
+}

--- a/apps/demo/tests/validators.ts
+++ b/apps/demo/tests/validators.ts
@@ -25,7 +25,10 @@ export class ModalValidator {
   }
 
   async expectConnected() {
+    const connectView = this.page.locator('w3m-connect-view').first()
     const profileButton = this.page.locator('wui-profile-button').first()
+
+    await expect(connectView, 'Connect view should be present').not.toBeVisible()
     await expect(profileButton, 'Profile button should be present').toBeVisible({
       timeout: MAX_WAIT
     })

--- a/apps/demo/tests/validators.ts
+++ b/apps/demo/tests/validators.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+export const MAXIMUM_WAIT_CONNECTIONS = 30 * 1000
+
+export function getMaximumWaitConnections(): number {
+  if (process.env['CI']) {
+    return MAXIMUM_WAIT_CONNECTIONS
+  }
+
+  return MAXIMUM_WAIT_CONNECTIONS * 2
+}
+
+const MAX_WAIT = getMaximumWaitConnections()
+
+export class ModalValidator {
+  public readonly page: Page
+  constructor(page: Page) {
+    this.page = page
+  }
+
+  expectSecureSiteFrameNotInjected() {
+    const secureSiteIframe = this.page.frame({ name: 'w3m-secure-iframe' })
+    expect(secureSiteIframe).toBeNull()
+  }
+
+  async expectConnected() {
+    const profileButton = this.page.locator('wui-profile-button').first()
+    await expect(profileButton, 'Profile button should be present').toBeVisible({
+      timeout: MAX_WAIT
+    })
+    await this.page.waitForTimeout(500)
+  }
+}

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1479,9 +1479,6 @@ export abstract class AppKitBaseClient {
 
   public setUser: (typeof AccountController)['setUser'] = (user, chain) => {
     AccountController.setUser(user, chain)
-    if (OptionsController.state.enableEmbedded) {
-      ModalController.close()
-    }
   }
 
   public resetAccount: (typeof AccountController)['resetAccount'] = (chain: ChainNamespace) => {

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1463,6 +1463,12 @@ export abstract class AppKitBaseClient {
 
   public setCaipAddress: (typeof AccountController)['setCaipAddress'] = (caipAddress, chain) => {
     AccountController.setCaipAddress(caipAddress, chain)
+    /**
+     * For the embedded use cases (Demo app), we should call close() when the user is connected to redirect them to Account View.
+     */
+    if (caipAddress && OptionsController.state.enableEmbedded) {
+      this.close()
+    }
   }
 
   public setBalance: (typeof AccountController)['setBalance'] = (balance, balanceSymbol, chain) => {

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -17,7 +17,6 @@ import {
   EventsController,
   type Features,
   type Metadata,
-  ModalController,
   PublicStateController,
   type RemoteFeatures
 } from '@reown/appkit-controllers'

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -152,10 +152,6 @@ export class AppKit extends AppKitBaseClient {
       this.setSmartAccountDeployed(Boolean(user.smartAccountDeployed), namespace)
       this.setPreferredAccountType(preferredAccountType, namespace)
 
-      if (OptionsController.state.enableEmbedded) {
-        ModalController.close()
-      }
-
       const userAccounts = user.accounts?.map(account =>
         CoreHelperUtil.createAccount(
           namespace,

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -17,6 +17,7 @@ import {
   EventsController,
   type Features,
   type Metadata,
+  ModalController,
   PublicStateController,
   type RemoteFeatures
 } from '@reown/appkit-controllers'
@@ -147,10 +148,13 @@ export class AppKit extends AppKitBaseClient {
         })
       }
       this.setCaipAddress(caipAddress, namespace)
-
       this.setUser({ ...(AccountController.state.user || {}), ...user }, namespace)
       this.setSmartAccountDeployed(Boolean(user.smartAccountDeployed), namespace)
       this.setPreferredAccountType(preferredAccountType, namespace)
+
+      if (OptionsController.state.enableEmbedded) {
+        ModalController.close()
+      }
 
       const userAccounts = user.accounts?.map(account =>
         CoreHelperUtil.createAccount(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
         specifier: 2.15.2
         version: 2.15.2(@tanstack/query-core@5.75.5)(@tanstack/react-query@5.75.5(react@19.1.0))(@types/react@19.1.3)(bufferutil@4.0.9)(db0@0.3.1)(ioredis@5.6.0)(react@19.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.29.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.23.8))(zod@3.23.8)
     devDependencies:
+      '@mailsac/api':
+        specifier: 1.0.8
+        version: 1.0.8
       '@playwright/test':
         specifier: 1.48.2
         version: 1.48.2


### PR DESCRIPTION
# Description

When connected with email, there is an issue for `enableEmbedded` cases (where we see on demo.reown.com), which is redirecting user to first Connect screen then Account screen which is looking odd.

We are calling `this.setUser` method in `onSocialConnected` event handler, which does set user to the namespace object only, doesn't make the AppKit connected. When this function got called, we are calling `ModalController.close()` which is actually detecting that AppKit is not connected yet, and redirecting user to Connect screen rather than Account screen. See:

```js
provider.onSocialConnected(({ userName }) => {
      this.setUser(
        { ...(AccountController.state.user || {}), username: userName },
        ChainController.state.activeChain
      )
    })
```

This PR fixes account redirection issue along introducing email tests for Demo app

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

Before:


https://github.com/user-attachments/assets/d04c24b2-30e6-4d5e-a542-c0ece87fe9bd


After: 

https://github.com/user-attachments/assets/2d111cd0-5d2d-40c7-bccc-3ba32835b67b



# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
