### PR TITLE
fix: fix typo in class name from VersionedTranasction to VersionedTransaction

### DIFF
--- a/apps/laboratory/src/components/Solana/SolanaSignAndSendTransactionTest.tsx
+++ b/apps/laboratory/src/components/Solana/SolanaSignAndSendTransactionTest.tsx
@@ -61,9 +61,9 @@ export function SolanaSignAndSendTransaction() {
         }).compileToV0Message()
 
         // Make a versioned transaction
-        const versionedTranasction = new VersionedTransaction(messageV0)
+        const versionedTransaction  = new VersionedTransaction(messageV0)
 
-        signature = await walletProvider.signAndSendTransaction(versionedTranasction)
+        signature = await walletProvider.signAndSendTransaction(versionedTransaction)
       } else {
         // Create a new transaction
         const transaction = new Transaction().add(instruction)


### PR DESCRIPTION
# Description

Corrected a misspelled class name that was causing a runtime error when creating  versioned Solana transactions. This ensures the transaction is properly initialized  using the VersionedTransaction class from @solana/web3.js.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
