### PR TITLE
feat: add unisat, bitget and binance web3 wallet bitcoin connector

### DIFF
--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -139,6 +139,16 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
     if (bitgetConnector) {
       this.addConnector(bitgetConnector)
     }
+
+    const binanceWeb3Wallet = UnisatConnector.getWallet({
+      id: 'binancew3w',
+      name: 'Binance Web3 Wallet',
+      requestedChains: this.networks,
+      getActiveNetwork
+    })
+    if (binanceWeb3Wallet) {
+      this.addConnector(binanceWeb3Wallet)
+    }
   }
 
   override syncConnection(

--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -10,6 +10,7 @@ import { BitcoinWalletConnectConnector } from './connectors/BitcoinWalletConnect
 import { LeatherConnector } from './connectors/LeatherConnector.js'
 import { OKXConnector } from './connectors/OKXConnector.js'
 import { SatsConnectConnector } from './connectors/SatsConnectConnector.js'
+import { UnisatConnector } from './connectors/UnisatConnector.js'
 import { WalletStandardConnector } from './connectors/WalletStandardConnector.js'
 import { BitcoinApi } from './utils/BitcoinApi.js'
 import type { BitcoinConnector } from './utils/BitcoinConnector.js'
@@ -117,6 +118,26 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
     })
     if (okxConnector) {
       this.addConnector(okxConnector)
+    }
+
+    const unisatConnector = UnisatConnector.getWallet({
+      id: 'unisat',
+      name: 'Unisat Wallet',
+      requestedChains: this.networks,
+      getActiveNetwork
+    })
+    if (unisatConnector) {
+      this.addConnector(unisatConnector)
+    }
+
+    const bitgetConnector = UnisatConnector.getWallet({
+      id: 'bitget',
+      name: 'Bitget Wallet',
+      requestedChains: this.networks,
+      getActiveNetwork
+    })
+    if (bitgetConnector) {
+      this.addConnector(bitgetConnector)
     }
   }
 

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
-import { type CaipNetwork } from '@reown/appkit-common'
+import { type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
 import { CoreHelperUtil, type RequestArguments } from '@reown/appkit-controllers'
 import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
 
@@ -9,10 +9,8 @@ import { AddressPurpose } from '../utils/BitcoinConnector.js'
 import { ProviderEventEmitter } from '../utils/ProviderEventEmitter.js'
 import { UnitsUtil } from '../utils/UnitsUtil.js'
 
-type WalletId = 'unisat' | 'bitget' | 'binancew3w'
-
 export class UnisatConnector extends ProviderEventEmitter implements BitcoinConnector {
-  public id: WalletId
+  public id: UnisatConnector.Id
   public name
   public readonly chain = 'bip122'
   public readonly type = 'ANNOUNCED'
@@ -42,7 +40,13 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
   }
 
   public get chains() {
-    return this.requestedChains.filter(chain => chain.caipNetworkId === bitcoin.caipNetworkId)
+    if (this.id === 'unisat') {
+      return this.requestedChains.filter(chain => chain.caipNetworkId === bitcoin.caipNetworkId)
+    }
+
+    return this.requestedChains.filter(
+      chain => chain.chainNamespace === ConstantsUtil.CHAIN.BITCOIN
+    )
   }
 
   public async connect(): Promise<string> {
@@ -167,7 +171,7 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
         break
       case 'bitget':
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        wallet = (window as any)?.bitget?.unisat
+        wallet = (window as any)?.bitkeep?.unisat
         break
       case 'binancew3w':
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -203,9 +207,10 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
 export namespace UnisatConnector {
   export type Chain = 'BITCOIN_MAINNET' | 'BITCOIN_TESTNET' | 'FRACTAL_BITCOIN_MAINNET'
   export type Network = 'livenet' | 'testnet'
+  export type Id = 'unisat' | 'bitget' | 'binancew3w'
 
   export type ConstructorParams = {
-    id: WalletId
+    id: Id
     name: string
     wallet: Wallet
     requestedChains: CaipNetwork[]

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
+import { type CaipNetwork } from '@reown/appkit-common'
+import { CoreHelperUtil, type RequestArguments } from '@reown/appkit-controllers'
+import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
+
+import { MethodNotSupportedError } from '../errors/MethodNotSupportedError.js'
+import type { BitcoinConnector } from '../utils/BitcoinConnector.js'
+import { AddressPurpose } from '../utils/BitcoinConnector.js'
+import { ProviderEventEmitter } from '../utils/ProviderEventEmitter.js'
+import { UnitsUtil } from '../utils/UnitsUtil.js'
+
+export class UnisatConnector extends ProviderEventEmitter implements BitcoinConnector {
+  public id: 'unisat' | 'bitget'
+  public name
+  public readonly chain = 'bip122'
+  public readonly type = 'ANNOUNCED'
+  public readonly imageUrl: string
+
+  public readonly provider = this
+
+  private readonly wallet: UnisatConnector.Wallet
+  private readonly requestedChains: CaipNetwork[] = []
+  private readonly getActiveNetwork: () => CaipNetwork | undefined
+
+  constructor({
+    id,
+    name,
+    wallet,
+    requestedChains,
+    getActiveNetwork,
+    imageUrl
+  }: UnisatConnector.ConstructorParams) {
+    super()
+    this.id = id
+    this.name = name
+    this.wallet = wallet
+    this.requestedChains = requestedChains
+    this.getActiveNetwork = getActiveNetwork
+    this.imageUrl = imageUrl
+  }
+
+  public get chains() {
+    return this.requestedChains.filter(chain => chain.caipNetworkId === bitcoin.caipNetworkId)
+  }
+
+  public async connect(): Promise<string> {
+    const [account] = await this.wallet.requestAccounts()
+
+    if (!account) {
+      throw new Error('No account found')
+    }
+
+    this.bindEvents()
+
+    this.emit('accountsChanged', [account])
+
+    return account
+  }
+
+  public async disconnect(): Promise<void> {
+    this.unbindEvents()
+
+    return Promise.resolve()
+  }
+
+  public async getAccountAddresses(): Promise<BitcoinConnector.AccountAddress[]> {
+    const accounts = await this.wallet.requestAccounts()
+
+    const publicKey = await this.wallet.getPublicKey()
+
+    const accountList = accounts.map(account => ({
+      address: account,
+      purpose: AddressPurpose.Payment,
+      publicKey
+    }))
+
+    return accountList
+  }
+
+  public async signMessage(params: BitcoinConnector.SignMessageParams): Promise<string> {
+    const protocol = params.protocol === 'bip322' ? 'bip322-simple' : params.protocol
+
+    return this.wallet.signMessage(params.message, protocol)
+  }
+
+  public async sendTransfer(params: BitcoinConnector.SendTransferParams): Promise<string> {
+    const network = this.getActiveNetwork()
+
+    if (!network) {
+      throw new Error('No active network available')
+    }
+
+    const from = (await this.wallet.getAccounts())[0]
+
+    if (!from) {
+      throw new Error('No account available')
+    }
+
+    const result = await this.wallet.sendBitcoin(
+      params.recipient,
+      Number(UnitsUtil.parseSatoshis(params.amount, network))
+    )
+
+    return result
+  }
+
+  public async signPSBT(
+    params: BitcoinConnector.SignPSBTParams
+  ): Promise<BitcoinConnector.SignPSBTResponse> {
+    const psbtHex = Buffer.from(params.psbt, 'base64').toString('hex')
+
+    const signedPsbtHex = await this.wallet.signPsbt(psbtHex)
+
+    let txid: string | undefined = undefined
+    if (params.broadcast) {
+      txid = await this.wallet.pushPsbt(signedPsbtHex)
+    }
+
+    return {
+      psbt: Buffer.from(signedPsbtHex, 'hex').toString('base64'),
+      txid
+    }
+  }
+
+  public async switchNetwork(caipNetworkId: string): Promise<void> {
+    const network = this.getNetwork(caipNetworkId)
+
+    await this.wallet.switchChain(network)
+  }
+
+  public request<T>(_args: RequestArguments): Promise<T> {
+    return Promise.reject(new MethodNotSupportedError(this.id, 'request'))
+  }
+
+  private bindEvents(): void {
+    this.unbindEvents()
+
+    this.wallet.on('accountsChanged', account => {
+      if (typeof account === 'object' && account && 'address' in account) {
+        this.emit('accountsChanged', [account.address])
+      }
+    })
+  }
+
+  private unbindEvents(): void {
+    this.wallet.removeListener('accountsChanged', account => {
+      if (typeof account === 'object' && account && 'address' in account) {
+        this.emit('accountsChanged', [account.address])
+      }
+    })
+  }
+
+  public static getWallet(params: UnisatConnector.GetWalletParams): UnisatConnector | undefined {
+    if (!CoreHelperUtil.isClient()) {
+      return undefined
+    }
+
+    const wallet =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      params.id === 'unisat' ? (window as any)?.unisat : (window as any)?.bitkeep.unisat
+
+    if (wallet) {
+      return new UnisatConnector({ wallet, imageUrl: '', ...params })
+    }
+
+    return undefined
+  }
+
+  public async getPublicKey(): Promise<string> {
+    return this.wallet.getPublicKey()
+  }
+
+  private getNetwork(caipNetwork: string): UnisatConnector.Chain {
+    switch (caipNetwork) {
+      case bitcoin.caipNetworkId:
+        return 'BITCOIN_MAINNET'
+      case bitcoinTestnet.caipNetworkId:
+        return 'BITCOIN_TESTNET'
+      default:
+        throw new Error('LeatherConnector: unsupported network')
+    }
+  }
+}
+
+export namespace UnisatConnector {
+  export type Chain = 'BITCOIN_MAINNET' | 'BITCOIN_TESTNET' | 'FRACTAL_BITCOIN_MAINNET'
+  export type Network = 'livenet' | 'testnet'
+
+  export type ConstructorParams = {
+    id: 'unisat' | 'bitget'
+    name: string
+    wallet: Wallet
+    requestedChains: CaipNetwork[]
+    getActiveNetwork: () => CaipNetwork | undefined
+    imageUrl: string
+  }
+
+  export type Wallet = {
+    /*
+     * This interface doesn't include all available methods
+     * Reference: https://www.okx.com/web3/build/docs/sdks/chains/bitcoin/provider
+     */
+
+    requestAccounts: () => Promise<string[]>
+    getPublicKey: () => Promise<string>
+    sendBitcoin: (
+      to: string,
+      value: number,
+      options?: { feeRate: number; memo?: string; memos?: string[] }
+    ) => Promise<string>
+    signPsbt: (
+      psbtHex: string,
+      options?: {
+        autoFinalized?: boolean
+        toSignInputs: Array<
+          | {
+              index: number
+              address: string
+              sighashTypes?: number[]
+              disableTweakSigner?: boolean
+              useTweakedSigner?: boolean
+            }
+          | {
+              index: number
+              publicKey: string
+              sighashTypes?: number[]
+              disableTweakSigner?: boolean
+              useTweakedSigner?: boolean
+            }
+        >
+      }
+    ) => Promise<string>
+    switchChain(chain: Chain): Promise<{ enum: Chain; name: string; network: Network }>
+    getAccounts(): Promise<string[]>
+    signMessage(signStr: string, type?: 'ecdsa' | 'bip322-simple'): Promise<string>
+    pushPsbt(psbtHex: string): Promise<string>
+    on(event: string, listener: (param?: unknown) => void): void
+    removeListener(event: string, listener: (param?: unknown) => void): void
+  }
+
+  export type GetWalletParams = Omit<ConstructorParams, 'wallet' | 'imageUrl'>
+}

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector.ts
@@ -9,8 +9,10 @@ import { AddressPurpose } from '../utils/BitcoinConnector.js'
 import { ProviderEventEmitter } from '../utils/ProviderEventEmitter.js'
 import { UnitsUtil } from '../utils/UnitsUtil.js'
 
+type WalletId = 'unisat' | 'bitget' | 'binancew3w'
+
 export class UnisatConnector extends ProviderEventEmitter implements BitcoinConnector {
-  public id: 'unisat' | 'bitget'
+  public id: WalletId
   public name
   public readonly chain = 'bip122'
   public readonly type = 'ANNOUNCED'
@@ -155,9 +157,25 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
       return undefined
     }
 
-    const wallet =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      params.id === 'unisat' ? (window as any)?.unisat : (window as any)?.bitkeep.unisat
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, init-declarations
+    let wallet: any
+
+    switch (params.id) {
+      case 'unisat':
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        wallet = (window as any)?.unisat
+        break
+      case 'bitget':
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        wallet = (window as any)?.bitget?.unisat
+        break
+      case 'binancew3w':
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        wallet = (window as any)?.binancew3w?.bitcoin
+        break
+      default:
+        throw new Error(`Unsupported wallet id: ${params.id}`)
+    }
 
     if (wallet) {
       return new UnisatConnector({ wallet, imageUrl: '', ...params })
@@ -177,7 +195,7 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
       case bitcoinTestnet.caipNetworkId:
         return 'BITCOIN_TESTNET'
       default:
-        throw new Error('LeatherConnector: unsupported network')
+        throw new Error('UnisatConnector: unsupported network')
     }
   }
 }
@@ -187,7 +205,7 @@ export namespace UnisatConnector {
   export type Network = 'livenet' | 'testnet'
 
   export type ConstructorParams = {
-    id: 'unisat' | 'bitget'
+    id: WalletId
     name: string
     wallet: Wallet
     requestedChains: CaipNetwork[]

--- a/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
@@ -1,0 +1,300 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CaipNetwork } from '@reown/appkit-common'
+import { CoreHelperUtil } from '@reown/appkit-controllers'
+import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
+
+import { UnisatConnector } from '../../src/connectors/UnisatConnector'
+import { MethodNotSupportedError } from '../../src/errors/MethodNotSupportedError'
+
+function mockUnisatWallet(): {
+  [K in keyof UnisatConnector.Wallet]: Mock<UnisatConnector.Wallet[K]>
+} {
+  return {
+    requestAccounts: vi.fn(() => Promise.resolve(['mock_address'])),
+    getAccounts: vi.fn(() => Promise.resolve(['mock_address'])),
+    signMessage: vi.fn(() => Promise.resolve('mock_signature')),
+    signPsbt: vi.fn(() => Promise.resolve(Buffer.from('mock_psbt').toString('hex'))),
+    pushPsbt: vi.fn(() => Promise.resolve('mock_txhash')),
+    sendBitcoin: vi.fn(() => Promise.resolve('mock_txhash')),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getPublicKey: vi.fn(() => Promise.resolve('mock_public_key')),
+    switchChain: vi.fn(() =>
+      Promise.resolve({
+        enum: 'BITCOIN_MAINNET',
+        name: 'Bitcoin Mainnet',
+        network: 'livenet'
+      })
+    )
+  }
+}
+
+describe('UnisatConnector', () => {
+  let wallet: ReturnType<typeof mockUnisatWallet>
+  let requestedChains: CaipNetwork[]
+  let connector: UnisatConnector
+  let getActiveNetwork: Mock<() => CaipNetwork | undefined>
+  let imageUrl: string
+
+  beforeEach(() => {
+    imageUrl = 'mock_image_url'
+    requestedChains = [bitcoin, bitcoinTestnet]
+    getActiveNetwork = vi.fn(() => bitcoin)
+    wallet = mockUnisatWallet()
+    connector = new UnisatConnector({
+      id: 'unisat',
+      name: 'Unisat Wallet',
+      wallet,
+      requestedChains,
+      getActiveNetwork,
+      imageUrl
+    })
+  })
+
+  it('should validate metadata', () => {
+    expect(connector.id).toBe('unisat')
+    expect(connector.name).toBe('Unisat Wallet')
+    expect(connector.chain).toBe('bip122')
+    expect(connector.type).toBe('ANNOUNCED')
+    expect(connector.imageUrl).toBe('mock_image_url')
+  })
+
+  it('should return only mainnet chain', () => {
+    expect(connector.chains).toEqual([bitcoin])
+  })
+
+  describe('connect', () => {
+    it('should connect and return address', async () => {
+      const address = await connector.connect()
+      expect(address).toBe('mock_address')
+      expect(wallet.requestAccounts).toHaveBeenCalled()
+    })
+
+    it('should emit accountsChanged on connect', async () => {
+      const listener = vi.fn()
+      connector.on('accountsChanged', listener)
+      await connector.connect()
+      expect(listener).toHaveBeenCalledWith(['mock_address'])
+    })
+
+    it('should bind events', async () => {
+      await connector.connect()
+      expect(wallet.on).toHaveBeenCalledWith('accountsChanged', expect.any(Function))
+    })
+  })
+
+  describe('disconnect', () => {
+    it('should resolve and unbind events', async () => {
+      await connector.disconnect()
+      expect(wallet.removeListener).toHaveBeenCalled()
+    })
+  })
+
+  describe('getAccountAddresses', () => {
+    it('should get account addresses', async () => {
+      const accounts = await connector.getAccountAddresses()
+
+      console.log(accounts)
+
+      expect(accounts).toEqual([
+        { address: 'mock_address', purpose: 'payment', publicKey: 'mock_public_key' }
+      ])
+      expect(wallet.requestAccounts).toHaveBeenCalled()
+    })
+  })
+
+  describe('signMessage', () => {
+    it('should sign a message', async () => {
+      const signature = await connector.signMessage({ address: 'mock_address', message: 'message' })
+
+      expect(signature).toBe('mock_signature')
+      expect(wallet.signMessage).toHaveBeenCalledWith('message', undefined)
+    })
+
+    it('should sign a message with ecdsa protocol', async () => {
+      const signature = await connector.signMessage({
+        address: 'mock_address',
+        message: 'message',
+        protocol: 'ecdsa'
+      })
+
+      expect(signature).toBe('mock_signature')
+      expect(wallet.signMessage).toHaveBeenCalledWith('message', 'ecdsa')
+    })
+
+    it('should sign a message with bip322 protocol', async () => {
+      const signature = await connector.signMessage({
+        address: 'mock_address',
+        message: 'message',
+        protocol: 'bip322'
+      })
+
+      expect(signature).toBe('mock_signature')
+      expect(wallet.signMessage).toHaveBeenCalledWith('message', 'bip322-simple')
+    })
+  })
+
+  describe('sendTransfer', () => {
+    it('should send a transfer', async () => {
+      const txid = await connector.sendTransfer({ amount: '1500', recipient: 'mock_to_address' })
+
+      expect(txid).toBe('mock_txhash')
+      expect(wallet.sendBitcoin).toHaveBeenCalledWith('mock_to_address', 0.000015)
+    })
+
+    it('should throw an error if the network is unavailable', async () => {
+      getActiveNetwork.mockReturnValueOnce(undefined)
+
+      await expect(
+        connector.sendTransfer({ amount: '1500', recipient: 'mock_to_address' })
+      ).rejects.toThrow('No active network available')
+    })
+
+    it('should throw an error if no account is available', async () => {
+      wallet.getAccounts.mockResolvedValueOnce([])
+
+      await expect(
+        connector.sendTransfer({ amount: '1500', recipient: 'mock_to_address' })
+      ).rejects.toThrow('No account available')
+    })
+  })
+
+  describe('signPSBT', () => {
+    it('should sign a PSBT without broadcast', async () => {
+      const result = await connector.signPSBT({
+        psbt: Buffer.from('mock_psbt').toString('base64'),
+        signInputs: [],
+        broadcast: false
+      })
+
+      expect(result).toEqual({ psbt: 'bW9ja19wc2J0', txid: undefined })
+      expect(wallet.pushPsbt).not.toHaveBeenCalled()
+    })
+
+    it('should sign a PSBT with broadcast', async () => {
+      getActiveNetwork.mockReturnValueOnce(bitcoinTestnet)
+      const result = await connector.signPSBT({
+        psbt: Buffer.from('mock_psbt').toString('base64'),
+        signInputs: [],
+        broadcast: true
+      })
+
+      expect(result).toEqual({ psbt: 'bW9ja19wc2J0', txid: 'mock_txhash' })
+      expect(wallet.pushPsbt).toHaveBeenCalled()
+    })
+  })
+
+  describe('request', () => {
+    it('should throw an error because request is not supported', async () => {
+      await expect(connector.request({} as any)).rejects.toThrow(MethodNotSupportedError)
+    })
+  })
+
+  describe('events', () => {
+    it('should emit accountChanged event', async () => {
+      const listener = vi.fn(account => {
+        expect(account).toEqual(['mock_address'])
+      })
+      connector.on('accountsChanged', listener)
+      await connector.connect()
+
+      wallet.on.mock.calls[0]![1]({ address: 'mock_address' })
+
+      expect(listener).toHaveBeenCalled()
+    })
+
+    it('should resolve and unbind events', async () => {
+      await connector.disconnect()
+      expect(wallet.removeListener).toHaveBeenCalled()
+    })
+  })
+
+  describe('getWallet', () => {
+    it.each(['binancew3w', 'bitget', 'unisat'] as UnisatConnector.Id[])(
+      'should return undefined if there is no %s wallet',
+      id => {
+        expect(
+          UnisatConnector.getWallet({
+            getActiveNetwork,
+            requestedChains: [],
+            id,
+            name: `${id} wallet`
+          })
+        ).toBeUndefined()
+      }
+    )
+
+    it('should return the Connector if there is a unisat wallet', () => {
+      ;(window as any).unisat = wallet
+      const connector = UnisatConnector.getWallet({
+        getActiveNetwork,
+        id: 'unisat',
+        name: 'Unisat Wallet',
+        requestedChains
+      })
+      expect(connector).toBeInstanceOf(UnisatConnector)
+    })
+
+    it('should return the Connector if there is a unisat wallet', () => {
+      ;(window as any).bitget = { unisat: wallet }
+      const connector = UnisatConnector.getWallet({
+        getActiveNetwork,
+        id: 'unisat',
+        name: 'Unisat Wallet',
+        requestedChains
+      })
+      expect(connector).toBeInstanceOf(UnisatConnector)
+    })
+
+    it('should return the Connector if there is a bitget wallet', () => {
+      ;(window as any).bitkeep = { unisat: wallet }
+      const connector = UnisatConnector.getWallet({
+        getActiveNetwork,
+        id: 'bitget',
+        name: 'Bitget Wallet',
+        requestedChains
+      })
+      expect(connector).toBeInstanceOf(UnisatConnector)
+    })
+
+    it('should return the Connector if there is a binance web3 wallet', () => {
+      ;(window as any).binancew3w = { bitcoin: wallet }
+      const connector = UnisatConnector.getWallet({
+        getActiveNetwork,
+        id: 'binancew3w',
+        name: 'Binance Web3 Wallet',
+        requestedChains
+      })
+      expect(connector).toBeInstanceOf(UnisatConnector)
+    })
+
+    it('should return undefined if window is undefined (server-side)', () => {
+      vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValue(false)
+
+      expect(
+        UnisatConnector.getWallet({
+          getActiveNetwork,
+          requestedChains: [],
+          id: 'unisat',
+          name: 'Unisat Wallet'
+        })
+      ).toBeUndefined()
+    })
+  })
+
+  describe('getPublicKey', () => {
+    it('should return the public key', async () => {
+      const publicKey = await connector.getPublicKey()
+      expect(publicKey).toBe('mock_public_key')
+      expect(wallet.getPublicKey).toHaveBeenCalled()
+    })
+  })
+
+  describe('switchNetwork', () => {
+    it('should switch network', async () => {
+      await connector.switchNetwork(bitcoin.caipNetworkId)
+      expect(wallet.switchChain).toHaveBeenCalledWith('BITCOIN_MAINNET')
+    })
+  })
+})


### PR DESCRIPTION
# Description

Added a new `UnisatConnector` class to support Bitcoin wallet connectivity for Unisat, Bitget, and BinanceW3W wallets (all of these use the same wallet API).

**NOTE:** BinanceW3W injects window value inside binance web3 app browser.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-123 (replace with actual issue ID)
For GH issues: closes #456 (replace with actual issue number)

# Showcase (Optional)

N/A - No UI changes. This is a backend connector implementation.  
Demo recording: [Link to demo recording, if available]

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link