### PR TITLE
chore(e2e-tests): upload playwright report with date in path

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -447,7 +447,10 @@ jobs:
           S3_BUCKET="reown.appkit.e2e.reports"
           S3_PREFIX="appkit/playwright-results"
           FILE_NAME="merged-test-results.json"
-          S3_KEY="${S3_PREFIX}/${{ env.BUILD_CONTEXT }}/${{ github.run_id }}-$(date +%s)-${FILE_NAME}"
+          year=$(date +%Y)
+          month=$(date +%m)
+          day=$(date +%d)
+          S3_KEY="${S3_PREFIX}/year=${year}/month=${month}/day=${day}/${{ env.BUILD_CONTEXT }}/${{ github.run_id }}-$(date +%s)-${FILE_NAME}"
 
           echo "Uploading ${{ github.workspace }}/apps/laboratory/merged-test-results.json to s3://${S3_BUCKET}/${S3_KEY}"
           aws s3 cp ${{ github.workspace }}/apps/laboratory/merged-test-results.json s3://${S3_BUCKET}/${S3_KEY}


### PR DESCRIPTION
# Description

Currently https://playwright-insights.vercel.app/ takes a long time to load as it uses S3 as a database and there's lots of reports to churn through.

While S3 is probably not the best database a short-term improvement is to add the date such that https://playwright-insights.vercel.app/ can filter by date range.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
