### PR TITLE
fix: prevent switch network modal when user is disconnected

### DIFF
--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -370,15 +370,18 @@ const controller = {
     })
     StorageUtil.setActiveCaipNetworkId(caipNetwork.caipNetworkId)
 
-    const isSupported = ChainController.checkIfSupportedNetwork(caipNetwork.chainNamespace)
+    // If no address is set, user is not connected, so return true
+    if (state.activeCaipAddress) {
+      const isSupported = ChainController.checkIfSupportedNetwork(caipNetwork.chainNamespace)
 
-    if (
-      !isSupported &&
-      OptionsController.state.enableNetworkSwitch &&
-      !OptionsController.state.allowUnsupportedChain &&
-      !ConnectionController.state.wcBasic
-    ) {
-      ChainController.showUnsupportedChainUI()
+      if (
+        !isSupported &&
+        OptionsController.state.enableNetworkSwitch &&
+        !OptionsController.state.allowUnsupportedChain &&
+        !ConnectionController.state.wcBasic
+      ) {
+        ChainController.showUnsupportedChainUI()
+      }
     }
   },
 


### PR DESCRIPTION
# Description

Fixes an issue where the "Switch Network" modal would incorrectly appear even when the user was **disconnected**. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3032
For GH issues: closes #4476


# Showcase (Optional)

![Fix preview](https://imgur.com/a/KzK2ACB)

# Checklist

- [X] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [X] My changes generate no new warnings
- [X] I have reviewed my own code
- [X] I have filled out all required sections
- [X] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link