### PR TITLE
fix: disconnecting namespace where it's not on WC connection's available namespaces

### DIFF
--- a/.changeset/sixty-clowns-cough.md
+++ b/.changeset/sixty-clowns-cough.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue on multichain where we are disconnecting namespaces if they are not in the WC connection's available namespaces

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1007,6 +1007,7 @@ export abstract class AppKitBaseClient {
       const adapter = this.getAdapter(chainNamespace as ChainNamespace)
       const namespaceAccounts =
         this.universalProvider?.session?.namespaces?.[chainNamespace]?.accounts || []
+      const namespaces = Object.keys(this.universalProvider?.session?.namespaces || {})
 
       // We try and find the address for this network in the session object.
       const activeChainId = ChainController.state.activeCaipNetwork?.id
@@ -1053,7 +1054,7 @@ export abstract class AppKitBaseClient {
           chainId,
           chainNamespace
         })
-      } else {
+      } else if (namespaces.includes(chainNamespace)) {
         this.setStatus('disconnected', chainNamespace)
       }
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1003,11 +1003,11 @@ export abstract class AppKitBaseClient {
   }
 
   protected async syncWalletConnectAccount() {
+    const sessionNamespaces = Object.keys(this.universalProvider?.session?.namespaces || {})
     const syncTasks = this.chainNamespaces.map(async chainNamespace => {
       const adapter = this.getAdapter(chainNamespace as ChainNamespace)
       const namespaceAccounts =
         this.universalProvider?.session?.namespaces?.[chainNamespace]?.accounts || []
-      const namespaces = Object.keys(this.universalProvider?.session?.namespaces || {})
 
       // We try and find the address for this network in the session object.
       const activeChainId = ChainController.state.activeCaipNetwork?.id
@@ -1054,7 +1054,7 @@ export abstract class AppKitBaseClient {
           chainId,
           chainNamespace
         })
-      } else if (namespaces.includes(chainNamespace)) {
+      } else if (sessionNamespaces.includes(chainNamespace)) {
         this.setStatus('disconnected', chainNamespace)
       }
 


### PR DESCRIPTION
# Description

There is a case where we are calling `syncWalletConnectAccount` which is iterating all AppKit adapters and checking them in the existing WC connection, if the adapter's namespace is not in the connection's available namespaces, we are disconnecting that adapter. 

But there is a case where WC can be used for some adapters, while some others use different connector types. I.e:

- Go to https://appkit-lab.reown.com/library/multichain-all/
- Connect with Trust iOS app with WC 
  - It'll connect EVM and Solana only since Bitcoin is not supported on Trust yet)
- Connect Bitcoin with an extension wallet (i.e XVerse)
- Refresh page
- It should reconnect all adapters to whatever they've connected with. Currently, we are disconnecting Bitcoin adapter bc it's not supported on current WC connection, which is mistake.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
