### PR TITLE
fix: auth connector to reconnect only on last active network

### DIFF
--- a/.changeset/cold-plants-drive.md
+++ b/.changeset/cold-plants-drive.md
@@ -1,0 +1,25 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes an issue on auth provider where it doesn't respect the last connected network and default to first available network of EVM adapter on page load

--- a/apps/laboratory/tests/multichain/multichain-ethers-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-ethers-solana-email.spec.ts
@@ -54,6 +54,14 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await validator.expectSwitchedNetwork(chainName)
     await page.closeModal()
 
+    // -- Refresh and verify connection persists ----------------------------------
+    await page.page.reload()
+    await validator.expectConnected()
+    await page.openModal()
+    await page.openNetworks()
+    await validator.expectSwitchedNetwork(chainName)
+    await page.closeModal()
+
     // -- Sign ------------------------------------------------------------------
     await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet

--- a/apps/laboratory/tests/multichain/multichain-ethers5-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-ethers5-solana-email.spec.ts
@@ -53,6 +53,14 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await validator.expectSwitchedNetwork(chainName)
     await page.closeModal()
 
+    // -- Refresh and verify connection persists ----------------------------------
+    await page.page.reload()
+    await validator.expectConnected()
+    await page.openModal()
+    await page.openNetworks()
+    await validator.expectSwitchedNetwork(chainName)
+    await page.closeModal()
+
     // -- Sign ------------------------------------------------------------------
     await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet

--- a/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
@@ -54,6 +54,14 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await validator.expectSwitchedNetwork(chainName)
     await page.closeModal()
 
+    // -- Refresh and verify connection persists ----------------------------------
+    await page.page.reload()
+    await validator.expectConnected()
+    await page.openModal()
+    await page.openNetworks()
+    await validator.expectSwitchedNetwork(chainName)
+    await page.closeModal()
+
     // -- Sign ------------------------------------------------------------------
     await page.sign(getNamespaceByNetworkName(chainName))
     // For Solana, the chain name on the wallet page is Solana Mainnet

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -355,7 +355,7 @@ export class EthersAdapter extends AdapterBlueprint {
 
     let requestChainId: string | undefined = undefined
 
-    if (type === 'AUTH') {
+    if (type === ConstantsUtil.CONNECTOR_TYPE_AUTH) {
       const { address } = await (selectedProvider as unknown as W3mFrameProvider).connect({
         chainId,
         socialUri,

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -130,16 +130,6 @@ export function authConnector(parameters: AuthParameters) {
     async connect(
       options: { chainId?: number; isReconnecting?: boolean; socialUri?: string } = {}
     ) {
-      const activeChain = ChainController.state.activeChain
-      const isActiveChainEvm = activeChain === CommonConstantsUtil.CHAIN.EVM
-      const isAnyAuthConnected = ConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.some(
-        chain => ConnectorController.getConnectorId(chain) === CommonConstantsUtil.CONNECTOR_ID.AUTH
-      )
-
-      if (isAnyAuthConnected && !isActiveChainEvm) {
-        throw new Error('Auth connector is already connected')
-      }
-
       if (connectSocialPromise) {
         return connectSocialPromise
       }
@@ -200,6 +190,16 @@ export function authConnector(parameters: AuthParameters) {
     },
 
     async isAuthorized() {
+      const activeChain = ChainController.state.activeChain
+      const isActiveChainEvm = activeChain === CommonConstantsUtil.CHAIN.EVM
+      const isAnyAuthConnected = ConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.some(
+        chain => ConnectorController.getConnectorId(chain) === CommonConstantsUtil.CONNECTOR_ID.AUTH
+      )
+
+      if (isAnyAuthConnected && !isActiveChainEvm) {
+        return false
+      }
+
       const provider = await this.getProvider()
 
       return Promise.resolve(provider.getLoginEmailUsed())

--- a/packages/adapters/wagmi/src/connectors/AuthConnector.ts
+++ b/packages/adapters/wagmi/src/connectors/AuthConnector.ts
@@ -4,10 +4,16 @@ import type { Address } from 'viem'
 
 import {
   ConstantsUtil as CommonConstantsUtil,
+  ConstantsUtil,
   type EmbeddedWalletTimeoutReason
 } from '@reown/appkit-common'
 import { NetworkUtil } from '@reown/appkit-common'
-import { AccountController, AlertController, ChainController } from '@reown/appkit-controllers'
+import {
+  AccountController,
+  AlertController,
+  ChainController,
+  ConnectorController
+} from '@reown/appkit-controllers'
 import { ErrorUtil } from '@reown/appkit-utils'
 import { W3mFrameProvider } from '@reown/appkit-wallet'
 import { W3mFrameProviderSingleton } from '@reown/appkit/auth-provider'
@@ -124,6 +130,16 @@ export function authConnector(parameters: AuthParameters) {
     async connect(
       options: { chainId?: number; isReconnecting?: boolean; socialUri?: string } = {}
     ) {
+      const activeChain = ChainController.state.activeChain
+      const isActiveChainEvm = activeChain === CommonConstantsUtil.CHAIN.EVM
+      const isAnyAuthConnected = ConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.some(
+        chain => ConnectorController.getConnectorId(chain) === CommonConstantsUtil.CONNECTOR_ID.AUTH
+      )
+
+      if (isAnyAuthConnected && !isActiveChainEvm) {
+        throw new Error('Auth connector is already connected')
+      }
+
       if (connectSocialPromise) {
         return connectSocialPromise
       }

--- a/packages/appkit-utils/src/HelpersUtil.ts
+++ b/packages/appkit-utils/src/HelpersUtil.ts
@@ -1,5 +1,5 @@
-import type { CaipNetworkId } from '@reown/appkit-common'
-import type { Tokens } from '@reown/appkit-controllers'
+import { type CaipNetworkId, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
+import { ChainController, ConnectorController, type Tokens } from '@reown/appkit-controllers'
 
 import { ConstantsUtil } from './ConstantsUtil.js'
 
@@ -19,5 +19,19 @@ export const HelpersUtil = {
 
   isLowerCaseMatch(str1?: string, str2?: string) {
     return str1?.toLowerCase() === str2?.toLowerCase()
+  },
+
+  /**
+   * Iterates the Auth connector supported chains and returns the namespace that is last connected to the active chain.
+   * @returns ChainNamespace | undefined
+   */
+  getActiveNamespaceConnectedToAuth() {
+    const activeChain = ChainController.state.activeChain
+
+    return CommonConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.find(
+      chain =>
+        ConnectorController.getConnectorId(chain) === CommonConstantsUtil.CONNECTOR_ID.AUTH &&
+        chain === activeChain
+    )
   }
 }

--- a/packages/appkit-utils/tests/HelpersUtil.test.ts
+++ b/packages/appkit-utils/tests/HelpersUtil.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 import type { Tokens } from '@reown/appkit-controllers'
+import { ChainController, ConnectorController } from '@reown/appkit-controllers'
 
 import { ConstantsUtil } from '../src/ConstantsUtil.js'
 import { HelpersUtil } from '../src/HelpersUtil.js'
@@ -28,6 +30,61 @@ describe('HelpersUtil', () => {
     it('should handle empty tokens object', () => {
       const result = HelpersUtil.getCaipTokens({})
       expect(result).toEqual({})
+    })
+  })
+
+  describe('isLowerCaseMatch', () => {
+    it('should return true for matching strings regardless of case', () => {
+      expect(HelpersUtil.isLowerCaseMatch('Hello', 'hello')).toBe(true)
+      expect(HelpersUtil.isLowerCaseMatch('WORLD', 'world')).toBe(true)
+      expect(HelpersUtil.isLowerCaseMatch('Test123', 'test123')).toBe(true)
+    })
+
+    it('should return false for non-matching strings', () => {
+      expect(HelpersUtil.isLowerCaseMatch('Hello', 'World')).toBe(false)
+      expect(HelpersUtil.isLowerCaseMatch('Test', 'Test123')).toBe(false)
+    })
+
+    it('should handle undefined inputs', () => {
+      expect(HelpersUtil.isLowerCaseMatch(undefined, 'test')).toBe(false)
+      expect(HelpersUtil.isLowerCaseMatch('test', undefined)).toBe(false)
+      expect(HelpersUtil.isLowerCaseMatch(undefined, undefined)).toBe(true)
+    })
+  })
+
+  describe('getActiveNamespaceConnectedToAuth', () => {
+    beforeEach(() => {})
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return the active chain when it matches auth connector', () => {
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        activeChain: 'solana'
+      } as any)
+      vi.spyOn(ConnectorController, 'getConnectorId').mockImplementation(chain => {
+        if (chain === 'eip155' || chain === 'solana') {
+          return CommonConstantsUtil.CONNECTOR_ID.AUTH
+        }
+        return undefined
+      })
+      const result = HelpersUtil.getActiveNamespaceConnectedToAuth()
+      expect(result).toBe('solana')
+    })
+
+    it('should return undefined when active chain does not match auth connector', () => {
+      vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('other-connector')
+      const result = HelpersUtil.getActiveNamespaceConnectedToAuth()
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined when active chain is not in supported chains', () => {
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        activeChain: 'unsupported-chain'
+      } as any)
+      const result = HelpersUtil.getActiveNamespaceConnectedToAuth()
+      expect(result).toBeUndefined()
     })
   })
 })

--- a/packages/appkit-utils/tests/HelpersUtil.test.ts
+++ b/packages/appkit-utils/tests/HelpersUtil.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 import type { Tokens } from '@reown/appkit-controllers'

--- a/packages/appkit-utils/tests/HelpersUtil.test.ts
+++ b/packages/appkit-utils/tests/HelpersUtil.test.ts
@@ -53,9 +53,7 @@ describe('HelpersUtil', () => {
   })
 
   describe('getActiveNamespaceConnectedToAuth', () => {
-    beforeEach(() => {})
-
-    afterEach(() => {
+    beforeEach(() => {
       vi.restoreAllMocks()
     })
 

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -328,17 +328,18 @@ export class AppKit extends AppKitBaseClient {
     }
 
     const isEmailEnabled = this.remoteFeatures?.email
-
     const isSocialsEnabled =
       Array.isArray(this.remoteFeatures?.socials) && this.remoteFeatures.socials.length > 0
-
     const isAuthEnabled = isEmailEnabled || isSocialsEnabled
+
+    const activeNamespaceConnectedToAuth = HelpersUtil.getActiveNamespaceConnectedToAuth()
+    const namespaceToConnect = activeNamespaceConnectedToAuth || chainNamespace
 
     if (!this.authProvider && this.options?.projectId && isAuthEnabled) {
       this.authProvider = W3mFrameProviderSingleton.getInstance({
         projectId: this.options.projectId,
         enableLogger: this.options.enableAuthLogger,
-        chainId: this.getCaipNetwork(chainNamespace)?.caipNetworkId,
+        chainId: this.getCaipNetwork(namespaceToConnect)?.caipNetworkId,
         abortController: ErrorUtil.EmbeddedWalletAbortController,
         onTimeout: (reason: EmbeddedWalletTimeoutReason) => {
           if (reason === 'iframe_load_failed') {

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -198,6 +198,7 @@ export class AppKit extends AppKitBaseClient {
 
   private async syncAuthConnector(provider: W3mFrameProvider, chainNamespace: ChainNamespace) {
     const isAuthSupported = ConstantsUtil.AUTH_CONNECTOR_SUPPORTED_CHAINS.includes(chainNamespace)
+    const shouldSync = chainNamespace === ChainController.state.activeChain
 
     if (!isAuthSupported) {
       return
@@ -215,7 +216,6 @@ export class AppKit extends AppKitBaseClient {
     const username = provider.getUsername()
 
     this.setUser({ ...(AccountController.state?.user || {}), username, email }, chainNamespace)
-
     this.setupAuthConnectorListeners(provider)
 
     const { isConnected } = await provider.isConnected()
@@ -239,7 +239,7 @@ export class AppKit extends AppKitBaseClient {
 
     await provider.getSmartAccountEnabledNetworks()
 
-    if (chainNamespace && isAuthSupported) {
+    if (chainNamespace && isAuthSupported && shouldSync) {
       if (isConnected && this.connectionControllerClient?.connectExternal) {
         await this.connectionControllerClient?.connectExternal({
           id: ConstantsUtil.CONNECTOR_ID.AUTH,
@@ -355,7 +355,11 @@ export class AppKit extends AppKitBaseClient {
           this.authProvider?.rejectRpcRequests()
         }
       })
+    }
 
+    const shouldSync = chainNamespace === ChainController.state.activeChain
+
+    if (this.authProvider && shouldSync) {
       this.syncAuthConnector(this.authProvider, chainNamespace)
       this.checkExistingTelegramSocialConnection(chainNamespace)
     }


### PR DESCRIPTION
# Description

We have an issue on Auth connector when using AppKit with multiple adapters with Wagmi where Wagmi is auto connecting it's AuthConnector no matter what is the last active network on the dapp. 

If last active network on Solana, and refreshing page, Wagmi is calling `reconnect` and this causing Auth provider to switch to Mainnet from Solana unexpectedly.

This PR fixes the auto connection when syncing adapter connections.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
