### PR TITLE
fix: cloud auth siwx get sessions

### DIFF
--- a/.changeset/young-otters-mix.md
+++ b/.changeset/young-otters-mix.md
@@ -1,0 +1,26 @@
+---
+'@reown/appkit-siwx': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Cloud Auth SIWX skip get sessions if token is not set

--- a/packages/siwx/src/configs/CloudAuthSIWX.ts
+++ b/packages/siwx/src/configs/CloudAuthSIWX.ts
@@ -73,6 +73,10 @@ export class CloudAuthSIWX implements SIWXConfig {
 
   async getSessions(chainId: CaipNetworkId, address: string): Promise<SIWXSession[]> {
     try {
+      if (!this.getStorageToken(this.localAuthStorageKey)) {
+        return []
+      }
+
       const siweSession = await this.request('me', undefined, 'authJwt')
 
       const isSameAddress = siweSession?.address.toLowerCase() === address.toLowerCase()

--- a/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
+++ b/packages/siwx/tests/configs/CloudAuthSIWX.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type CaipNetwork, NetworkUtil } from '@reown/appkit-common'
 import {
@@ -285,7 +285,11 @@ Issued At: 2024-12-05T16:02:32.905Z`)
 
   describe('getSessions', () => {
     beforeEach(() => {
-      vi.spyOn(localStorage, 'getItem').mockReturnValueOnce('mock_token')
+      vi.spyOn(localStorage, 'getItem').mockReturnValue('mock_token')
+    })
+
+    afterEach(() => {
+      vi.spyOn(localStorage, 'getItem').mockRestore()
     })
 
     it('gets sessions', async () => {
@@ -375,6 +379,14 @@ Issued At: 2024-12-05T16:02:32.905Z`)
 
       fetchSpy.mockRejectedValueOnce(new Error())
       await expect(siwx.getSessions(`${namespace}:${id}`, address)).resolves.toEqual([])
+    })
+
+    it('should not request session if no auth token is set', async () => {
+      vi.spyOn(localStorage, 'getItem').mockReturnValueOnce(null)
+      const fetchSpy = vi.spyOn(global, 'fetch')
+
+      await expect(siwx.getSessions(`${namespace}:${id}`, address)).resolves.toEqual([])
+      expect(fetchSpy).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
# Description

Cloud Auth SIWX skip get sessions if token is not set.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
