### PR TITLE
fix: sats connect connectors not appearing in connect modal after page load

### DIFF
--- a/.changeset/whole-moose-double.md
+++ b/.changeset/whole-moose-double.md
@@ -1,0 +1,27 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where Sats Connect connectors (e.g Leather and Xverse) didn't appear in the connect modal after page load

--- a/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
+++ b/apps/laboratory/tests/multichain/multichain-wagmi-solana-email.spec.ts
@@ -56,6 +56,7 @@ test('it should switch networks (including different namespaces) and sign', asyn
     await page.closeModal()
 
     // -- Refresh and verify connection persists ----------------------------------
+    await page.page.waitForTimeout(500)
     await page.page.reload()
     await validator.expectConnected()
     await page.openModal()

--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -148,7 +148,7 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
     }
   }
 
-  override syncConnectors(_options?: AppKitOptions, appKit?: AppKit) {
+  override async syncConnectors(_options?: AppKitOptions, appKit?: AppKit) {
     function getActiveNetwork() {
       return appKit?.getCaipNetwork(ConstantsUtil.CHAIN.BITCOIN)
     }
@@ -158,11 +158,13 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
       requestedChains: this.networks
     })
 
+    const satsConnectConnectors = await SatsConnectConnector.getWallets({
+      requestedChains: this.networks,
+      getActiveNetwork
+    })
+
     this.addConnector(
-      ...SatsConnectConnector.getWallets({
-        requestedChains: this.networks,
-        getActiveNetwork
-      }).map(connector => {
+      ...satsConnectConnectors.map(connector => {
         switch (connector.wallet.id) {
           case LeatherConnector.ProviderId:
             return new LeatherConnector({

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -128,7 +128,7 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
     })) as BitcoinConnector.AccountAddress[]
   }
 
-  private static hasSatsConnectProviders() {
+  private static hasProviders() {
     if (!CoreHelperUtil.isClient()) {
       return false
     }
@@ -152,7 +152,7 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
      * We'll retry every 200ms, up to a maximum of 3 attempts.
      */
     await HelpersUtil.withRetry({
-      conditionFn: () => SatsConnectConnector.hasSatsConnectProviders(),
+      conditionFn: () => SatsConnectConnector.hasProviders(),
       intervalMs: 200,
       maxRetries: 3
     })

--- a/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/SatsConnectConnector.ts
@@ -17,7 +17,7 @@ import {
 import type { CaipNetwork } from '@reown/appkit-common'
 import { CoreHelperUtil } from '@reown/appkit-controllers'
 import type { RequestArguments } from '@reown/appkit-controllers'
-import { PresetsUtil } from '@reown/appkit-utils'
+import { HelpersUtil, PresetsUtil } from '@reown/appkit-utils'
 import type { BitcoinConnector } from '@reown/appkit-utils/bitcoin'
 
 import { mapSatsConnectAddressPurpose } from '../utils/BitcoinConnector.js'
@@ -128,13 +128,34 @@ export class SatsConnectConnector extends ProviderEventEmitter implements Bitcoi
     })) as BitcoinConnector.AccountAddress[]
   }
 
-  public static getWallets({
+  private static hasSatsConnectProviders() {
+    if (!CoreHelperUtil.isClient()) {
+      return false
+    }
+
+    const providers = getProviders()
+
+    return providers.length > 0
+  }
+
+  public static async getWallets({
     requestedChains,
     getActiveNetwork
   }: SatsConnectConnector.GetWalletsParams) {
     if (!CoreHelperUtil.isClient()) {
       return []
     }
+
+    /*
+     * Use a retry strategy because some Bitcoin wallets (e.g. Leather)
+     * may delay exposing their provider after page load.
+     * We'll retry every 200ms, up to a maximum of 3 attempts.
+     */
+    await HelpersUtil.withRetry({
+      conditionFn: () => SatsConnectConnector.hasSatsConnectProviders(),
+      intervalMs: 200,
+      maxRetries: 3
+    })
 
     const providers = getProviders()
 

--- a/packages/adapters/bitcoin/tests/BitcoinAdapter.test.ts
+++ b/packages/adapters/bitcoin/tests/BitcoinAdapter.test.ts
@@ -238,45 +238,45 @@ describe('BitcoinAdapter', () => {
   })
 
   describe('syncConnectors', () => {
-    it('should get wallets from all the available connectors', () => {
+    it('should get wallets from all the available connectors', async () => {
       const walletStandardConnectorSpy = vi.spyOn(WalletStandardConnector, 'watchWallets')
       const satsConnectConnectorSpy = vi.spyOn(SatsConnectConnector, 'getWallets')
       const okxConnectorSpy = vi.spyOn(OKXConnector, 'getWallet')
 
-      adapter.syncConnectors(undefined, undefined)
+      await adapter.syncConnectors(undefined, undefined)
 
       expect(walletStandardConnectorSpy).toHaveBeenCalled()
       expect(satsConnectConnectorSpy).toHaveBeenCalled()
       expect(okxConnectorSpy).toHaveBeenCalled()
     })
 
-    it('should add connectors from SatsConnectConnector', () => {
+    it('should add connectors from SatsConnectConnector', async () => {
       mockSatsConnectProvider()
-      adapter.syncConnectors(undefined, undefined)
+      await adapter.syncConnectors(undefined, undefined)
 
       expect(adapter.connectors).toHaveLength(1)
       expect(adapter.connectors[0]).toBeInstanceOf(SatsConnectConnector)
     })
 
-    it('should map LeatherConnector', () => {
+    it('should map LeatherConnector', async () => {
       mockSatsConnectProvider({ id: LeatherConnector.ProviderId, name: 'Leather' })
-      adapter.syncConnectors(undefined, undefined)
+      await adapter.syncConnectors(undefined, undefined)
 
       expect(adapter.connectors[1]).toBeInstanceOf(LeatherConnector)
     })
 
-    it('should add OKXConnector', () => {
+    it('should add OKXConnector', async () => {
       ;(window as any).okxwallet = { bitcoin: { connect: vi.fn() } }
 
-      adapter.syncConnectors(undefined, undefined)
+      await adapter.syncConnectors(undefined, undefined)
 
       expect(adapter.connectors[0]).toBeInstanceOf(OKXConnector)
     })
 
-    it('should pass correct getActiveNetwork to SatsConnectConnector', () => {
+    it('should pass correct getActiveNetwork to SatsConnectConnector', async () => {
       const mocks = mockSatsConnectProvider({ id: LeatherConnector.ProviderId, name: 'Leather' })
       const getRequestedCaipNetworksSpy = vi.spyOn(ChainController, 'getRequestedCaipNetworks')
-      adapter.syncConnectors(undefined, { getCaipNetwork: mockGetActiveNetworks } as any)
+      await adapter.syncConnectors(undefined, { getCaipNetwork: mockGetActiveNetworks } as any)
 
       vi.spyOn(mocks.wallet, 'request').mockResolvedValueOnce(
         mockSatsConnectProvider.mockRequestResolve({ hex: 'mock_hex', txid: 'mock_txid' })
@@ -592,7 +592,7 @@ describe('BitcoinAdapter', () => {
       const getCaipNetwork = vi.fn(() => bitcoin)
 
       mocks = mockSatsConnectProvider()
-      adapter.syncConnectors(undefined, { getCaipNetwork } as any)
+      await adapter.syncConnectors(undefined, { getCaipNetwork } as any)
 
       vi.spyOn(mocks.wallet, 'request').mockResolvedValue(
         mockSatsConnectProvider.mockRequestResolve({

--- a/packages/appkit-utils/src/HelpersUtil.ts
+++ b/packages/appkit-utils/src/HelpersUtil.ts
@@ -33,5 +33,47 @@ export const HelpersUtil = {
         ConnectorController.getConnectorId(chain) === CommonConstantsUtil.CONNECTOR_ID.AUTH &&
         chain === activeChain
     )
+  },
+
+  /**
+   * Runs a condition function again and again until it returns true or the max number of tries is reached.
+   *
+   * @param conditionFn - A function (can be async) that returns true when the condition is met.
+   * @param intervalMs - Time to wait between tries, in milliseconds.
+   * @param maxRetries - Maximum number of times to try before stopping.
+   * @returns A Promise that resolves to true if the condition becomes true in time, or false if it doesn't.
+   */
+  withRetry({
+    conditionFn,
+    intervalMs,
+    maxRetries
+  }: {
+    conditionFn: () => boolean | Promise<boolean>
+    intervalMs: number
+    maxRetries: number
+  }): Promise<boolean> {
+    let attempts = 0
+
+    return new Promise(resolve => {
+      async function tryCheck() {
+        attempts += 1
+
+        const result = await conditionFn()
+
+        if (result) {
+          return resolve(true)
+        }
+
+        if (attempts >= maxRetries) {
+          return resolve(false)
+        }
+
+        setTimeout(tryCheck, intervalMs)
+
+        return null
+      }
+
+      tryCheck()
+    })
   }
 }

--- a/packages/appkit-utils/tests/HelperUtil.test.ts
+++ b/packages/appkit-utils/tests/HelperUtil.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HelpersUtil } from '../src/HelpersUtil.js'
+
+describe('HelpersUtil', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  describe('withRetry', () => {
+    it('should retry condition function until success or max retries reached', async () => {
+      let attempts = 0
+      const conditionFn = vi.fn(() => {
+        attempts++
+        return attempts >= 3
+      })
+
+      const promise = HelpersUtil.withRetry({
+        conditionFn,
+        intervalMs: 100,
+        maxRetries: 5
+      })
+
+      await vi.advanceTimersByTimeAsync(100)
+      await vi.advanceTimersByTimeAsync(100)
+
+      const result = await promise
+
+      expect(result).toBe(true)
+      expect(conditionFn).toHaveBeenCalledTimes(3)
+    })
+
+    it('should return false when max retries exceeded', async () => {
+      const conditionFn = vi.fn(() => false)
+
+      const promise = HelpersUtil.withRetry({
+        conditionFn,
+        intervalMs: 50,
+        maxRetries: 3
+      })
+
+      await vi.advanceTimersByTimeAsync(50)
+      await vi.advanceTimersByTimeAsync(50)
+      await vi.advanceTimersByTimeAsync(50)
+
+      const result = await promise
+
+      expect(result).toBe(false)
+      expect(conditionFn).toHaveBeenCalledTimes(3)
+    })
+
+    it('should handle async condition functions', async () => {
+      let attempts = 0
+
+      const conditionFn = vi.fn(async () => {
+        attempts++
+        return attempts >= 2
+      })
+
+      const promise = HelpersUtil.withRetry({
+        conditionFn,
+        intervalMs: 100,
+        maxRetries: 3
+      })
+
+      await vi.advanceTimersByTimeAsync(100)
+
+      const result = await promise
+
+      expect(result).toBe(true)
+      expect(conditionFn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should succeed immediately when condition is true on first try', async () => {
+      const conditionFn = vi.fn(() => true)
+
+      const promise = HelpersUtil.withRetry({
+        conditionFn,
+        intervalMs: 100,
+        maxRetries: 5
+      })
+
+      const result = await promise
+
+      expect(result).toBe(true)
+      expect(conditionFn).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
# Description

Fixed an issue where Sats Connect connectors (e.g Leather and Xverse) didn't appear in the connect modal after page load

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3071

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
