### PR TITLE
fix: multi-wallet tabs shrinking on iOS

### DIFF
--- a/packages/scaffold-ui/src/views/w3m-profile-wallets-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-profile-wallets-view/index.ts
@@ -177,7 +177,7 @@ export class W3mProfileWalletsView extends LitElement {
         const tabCount = availableTabs.length
 
         if (tabCount > 1) {
-          const containerWidth = this.getBoundingClientRect().width
+          const containerWidth = this.getBoundingClientRect()?.width
           const totalInnerTabsPadding = TABS_INNER_PADDING * 2
           const totalTabsPadding = TABS_PADDING * 2
           const availableWidth = containerWidth - totalTabsPadding - totalInnerTabsPadding


### PR DESCRIPTION
# Description

Fixed an issue where profile wallets tab would shrink on mobile devices

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3095

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
