### PR TITLE
fix: showing wrong preferred account type in `ProfileWallets` view

### DIFF
--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -16,7 +16,7 @@
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run connection.test --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true",
+    "test": "vitest run --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true",
     "postinstall": "node scripts/appkit-version-check.js"
   },
   "exports": {

--- a/packages/appkit/package.json
+++ b/packages/appkit/package.json
@@ -16,7 +16,7 @@
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "test": "vitest run --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true",
+    "test": "vitest run connection.test --coverage.enabled=true -- coverage.reporter=json --coverage.reporter=json-summary --coverage.reportOnFailure=true",
     "postinstall": "node scripts/appkit-version-check.js"
   },
   "exports": {

--- a/packages/appkit/src/client/appkit.ts
+++ b/packages/appkit/src/client/appkit.ts
@@ -155,9 +155,9 @@ export class AppKit extends AppKitBaseClient {
 
       this.setLoading(false, namespace)
     })
-    provider.onSocialConnected(({ userName }) => {
+    provider.onSocialConnected(user => {
       this.setUser(
-        { ...(AccountController.state.user || {}), username: userName },
+        { ...(AccountController.state.user || {}), ...user },
         ChainController.state.activeChain
       )
     })

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@reown/appkit-controllers'
 import { ConstantsUtil as UtilConstantsUtil } from '@reown/appkit-utils'
 import { ProviderUtil } from '@reown/appkit-utils'
+import type { W3mFrameProvider } from '@reown/appkit-wallet'
 
 import { AppKit } from '../../src/client/appkit.js'
 import { mockEvmAdapter, mockSolanaAdapter } from '../mocks/Adapter.js'
@@ -28,6 +29,24 @@ const MOCKED_CONNECTORS = [
     id: 'evm-connector'
   } as unknown as Connector
 ]
+
+const mockFrameProvider = {
+  getUsername: () => 'mock-username',
+  getEmail: () => 'mock-email',
+  getLoginEmailUsed: () => true,
+  onRpcRequest: vi.fn(),
+  onRpcSuccess: vi.fn(),
+  onRpcError: vi.fn(),
+  onNotConnected: vi.fn(),
+  onConnect: vi.fn(),
+  onSocialConnected: vi.fn(),
+  onGetSmartAccountEnabledNetworks: vi.fn(),
+  onSetPreferredAccount: vi.fn(),
+  isConnected: () => true,
+  syncDappData: vi.fn(),
+  syncTheme: vi.fn(),
+  getSmartAccountEnabledNetworks: vi.fn()
+} as unknown as W3mFrameProvider
 
 describe('syncExistingConnection', () => {
   beforeEach(() => {
@@ -150,23 +169,7 @@ describe('syncConnectedWalletInfo', () => {
       UtilConstantsUtil.CONNECTOR_TYPE_AUTH as ConnectorType
     )
 
-    appKit['authProvider'] = {
-      getUsername: () => 'mock-username',
-      getEmail: () => 'mock-email',
-      getLoginEmailUsed: () => true,
-      onRpcRequest: vi.fn(),
-      onRpcSuccess: vi.fn(),
-      onRpcError: vi.fn(),
-      onNotConnected: vi.fn(),
-      onConnect: vi.fn(),
-      onSocialConnected: vi.fn(),
-      onGetSmartAccountEnabledNetworks: vi.fn(),
-      onSetPreferredAccount: vi.fn(),
-      isConnected: () => true,
-      syncDappData: vi.fn(),
-      syncTheme: vi.fn(),
-      getSmartAccountEnabledNetworks: vi.fn()
-    } as any
+    appKit['authProvider'] = mockFrameProvider
 
     appKit['syncConnectedWalletInfo']('eip155')
 
@@ -186,22 +189,10 @@ describe('syncConnectedWalletInfo', () => {
     )
 
     appKit['authProvider'] = {
-      getUsername: () => 'mock-username',
+      ...mockFrameProvider,
       getEmail: () => null,
-      getLoginEmailUsed: () => true,
-      onRpcRequest: vi.fn(),
-      onRpcSuccess: vi.fn(),
-      onRpcError: vi.fn(),
-      onNotConnected: vi.fn(),
-      onConnect: vi.fn(),
-      onSocialConnected: vi.fn(),
-      onGetSmartAccountEnabledNetworks: vi.fn(),
-      onSetPreferredAccount: vi.fn(),
-      isConnected: () => true,
-      syncDappData: vi.fn(),
-      syncTheme: vi.fn(),
-      getSmartAccountEnabledNetworks: vi.fn()
-    } as any
+      getUsername: () => 'mock-username'
+    } as unknown as W3mFrameProvider
 
     vi.spyOn(StorageUtil, 'getConnectedSocialProvider').mockReturnValueOnce('mock-social')
 
@@ -452,6 +443,30 @@ describe('syncConnectedWalletInfo', () => {
           chain: 'eip155'
         })
       ).rejects.toThrow('Connection declined')
+    })
+  })
+
+  describe('setupAuthConnectorListeners', () => {
+    it('should call onSocialConnected with the user', () => {
+      const userMock = {
+        address: '0x123',
+        chainId: '1',
+        provider: {} as any,
+        id: 'test-connector',
+        type: 'INJECTED'
+      }
+
+      const cbSpy = vi.fn()
+
+      vi.spyOn(mockFrameProvider, 'onSocialConnected').mockImplementation(() => {
+        cbSpy(userMock)
+      })
+
+      const appKit = new AppKit(mockOptions)
+
+      appKit['setupAuthConnectorListeners'](mockFrameProvider)
+
+      expect(cbSpy).toHaveBeenCalledWith(userMock)
     })
   })
 })

--- a/packages/appkit/tests/client/connection.test.ts
+++ b/packages/appkit/tests/client/connection.test.ts
@@ -190,8 +190,7 @@ describe('syncConnectedWalletInfo', () => {
 
     appKit['authProvider'] = {
       ...mockFrameProvider,
-      getEmail: () => null,
-      getUsername: () => 'mock-username'
+      getEmail: () => null
     } as unknown as W3mFrameProvider
 
     vi.spyOn(StorageUtil, 'getConnectedSocialProvider').mockReturnValueOnce('mock-social')
@@ -449,11 +448,10 @@ describe('syncConnectedWalletInfo', () => {
   describe('setupAuthConnectorListeners', () => {
     it('should call onSocialConnected with the user', () => {
       const userMock = {
-        address: '0x123',
-        chainId: '1',
-        provider: {} as any,
-        id: 'test-connector',
-        type: 'INJECTED'
+        email: 'test@test.com',
+        username: 'test',
+        smartAccountDeployed: true,
+        accounts: ['0x123']
       }
 
       const cbSpy = vi.fn()


### PR DESCRIPTION
# Description

Fixed an issue where we showed the wrong preferred account type on profile wallets screen

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
