### PR TITLE
fix: use wagmi rpc instead of walletconnect rpc when switching network

### DIFF
--- a/.changeset/witty-rings-trade.md
+++ b/.changeset/witty-rings-trade.md
@@ -24,4 +24,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where adding a network using wagmi used the walletconnect rpc instead of wagmi rpc
+Fixed an issue where switching network using wagmi used the walletconnect rpc instead of wagmi rpc

--- a/.changeset/witty-rings-trade.md
+++ b/.changeset/witty-rings-trade.md
@@ -24,4 +24,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where adding a network using wagmi used the WalletConnect rpc instead of wagmi rpc
+Fixed an issue where adding a network using wagmi used the walletconnect rpc instead of wagmi rpc

--- a/.changeset/witty-rings-trade.md
+++ b/.changeset/witty-rings-trade.md
@@ -1,0 +1,27 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where adding a network using wagmi used the WalletConnect RPC instead of wagmi RPC

--- a/.changeset/witty-rings-trade.md
+++ b/.changeset/witty-rings-trade.md
@@ -24,4 +24,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where adding a network using wagmi used the WalletConnect RPC instead of wagmi RPC
+Fixed an issue where adding a network using wagmi used the WalletConnect rpc instead of wagmi rpc

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -811,7 +811,7 @@ export class WagmiAdapter extends AdapterBlueprint {
             ''
         ],
         blockExplorerUrls: [
-          wagmiChain?.blockExplorers?.default?.url ?? caipNetwork.blockExplorers?.[0]?.url ?? ''
+          wagmiChain?.blockExplorers?.default?.url ?? caipNetwork.blockExplorers?.default?.url ?? ''
         ]
       }
     })

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -795,14 +795,24 @@ export class WagmiAdapter extends AdapterBlueprint {
 
   public override async switchNetwork(params: AdapterBlueprint.SwitchNetworkParams) {
     const { caipNetwork } = params
+
+    const wagmiChain = this.wagmiConfig.chains.find(
+      chain => chain.id.toString() === caipNetwork.id.toString()
+    )
+
     await switchChain(this.wagmiConfig, {
       chainId: caipNetwork.id as number,
       addEthereumChainParameter: {
-        chainName: caipNetwork.name,
-        nativeCurrency: caipNetwork.nativeCurrency,
-        rpcUrls: [caipNetwork.rpcUrls?.['chainDefault']?.http?.[0] ?? ''],
-        blockExplorerUrls: [caipNetwork.blockExplorers?.default.url ?? ''],
-        iconUrls: [caipNetwork.assets?.imageUrl ?? '']
+        chainName: wagmiChain?.name ?? caipNetwork.name,
+        nativeCurrency: wagmiChain?.nativeCurrency ?? caipNetwork.nativeCurrency,
+        rpcUrls: [
+          caipNetwork.rpcUrls?.['chainDefault']?.http?.[0] ??
+            wagmiChain?.rpcUrls?.default?.http?.[0] ??
+            ''
+        ],
+        blockExplorerUrls: [
+          wagmiChain?.blockExplorers?.default?.url ?? caipNetwork.blockExplorers?.[0]?.url ?? ''
+        ]
       }
     })
     await super.switchNetwork(params)

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -86,6 +86,7 @@ const mockCaipNetworks = CaipNetworksUtil.extendCaipNetworks(mockNetworks, {
   customNetworkImageUrls: {}
 })
 const mockWagmiConfig = {
+  chains: mockCaipNetworks,
   connectors: [
     {
       id: 'test-connector',
@@ -152,6 +153,7 @@ describe('WagmiAdapter', () => {
       networks: mockNetworks,
       projectId: mockProjectId
     })
+    adapter.wagmiConfig = mockWagmiConfig
     ChainController.initialize([adapter], mockCaipNetworks, {
       connectionControllerClient: vi.fn() as unknown as ConnectionControllerClient,
       networkControllerClient: vi.fn() as unknown as NetworkControllerClient
@@ -853,8 +855,7 @@ describe('WagmiAdapter', () => {
               decimals: mockCaipNetworks[0].nativeCurrency.decimals
             },
             rpcUrls: [mockCaipNetworks[0].rpcUrls?.['chainDefault']?.http?.[0] ?? ''],
-            blockExplorerUrls: [mockCaipNetworks[0].blockExplorers?.default.url ?? ''],
-            iconUrls: [mockCaipNetworks[0].assets?.imageUrl ?? '']
+            blockExplorerUrls: [mockCaipNetworks[0].blockExplorers?.default.url ?? '']
           }
         })
       )


### PR DESCRIPTION
# Description

Fixed an issue where adding a network using wagmi used the walletconnect rpc instead of wagmi rpc

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3026,APKT-3145
For GH issues: closes #...

# Showcase (Optional)

![Screenshot 2025-06-27 at 11 15 38](https://github.com/user-attachments/assets/5aeb4164-53bf-4d0b-8f3f-a93a6c072145)

![Screenshot 2025-06-27 at 11 15 25](https://github.com/user-attachments/assets/fe77b53b-4e18-4d65-97fb-6e72ecce28e9)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
