### PR TITLE
fix: snapshot caipNetwork proxy before switching chain

### DIFF
--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -25,6 +25,7 @@ import {
 } from '@wagmi/core'
 import { type Chain } from '@wagmi/core/chains'
 import type UniversalProvider from '@walletconnect/universal-provider'
+import { snapshot } from 'valtio/vanilla'
 import { type Address, type Hex, formatUnits, parseUnits } from 'viem'
 
 import { AppKit, type AppKitOptions } from '@reown/appkit'
@@ -794,7 +795,7 @@ export class WagmiAdapter extends AdapterBlueprint {
   }
 
   public override async switchNetwork(params: AdapterBlueprint.SwitchNetworkParams) {
-    const { caipNetwork } = params
+    const caipNetwork = snapshot(params.caipNetwork)
 
     const wagmiChain = this.wagmiConfig.chains.find(
       chain => chain.id.toString() === caipNetwork.id.toString()

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -16,6 +16,7 @@ import {
 import * as wagmiCore from '@wagmi/core'
 import { mainnet } from '@wagmi/core/chains'
 import type UniversalProvider from '@walletconnect/universal-provider'
+import { proxy } from 'valtio/vanilla'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type AppKitNetwork, ConstantsUtil } from '@reown/appkit-common'
@@ -839,8 +840,10 @@ describe('WagmiAdapter', () => {
 
   describe('WagmiAdapter - switchNetwork', () => {
     it('should switch network successfully', async () => {
+      const mockProxyCaipNetwork = proxy(mockCaipNetworks[0])
+
       await adapter.switchNetwork({
-        caipNetwork: mockCaipNetworks[0]
+        caipNetwork: mockProxyCaipNetwork
       })
 
       expect(switchChain).toHaveBeenCalledWith(
@@ -848,14 +851,14 @@ describe('WagmiAdapter', () => {
         expect.objectContaining({
           chainId: 1,
           addEthereumChainParameter: {
-            chainName: mockCaipNetworks[0].name,
+            chainName: mockProxyCaipNetwork.name,
             nativeCurrency: {
-              name: mockCaipNetworks[0].nativeCurrency.name,
-              symbol: mockCaipNetworks[0].nativeCurrency.symbol,
-              decimals: mockCaipNetworks[0].nativeCurrency.decimals
+              name: mockProxyCaipNetwork.nativeCurrency.name,
+              symbol: mockProxyCaipNetwork.nativeCurrency.symbol,
+              decimals: mockProxyCaipNetwork.nativeCurrency.decimals
             },
-            rpcUrls: [mockCaipNetworks[0].rpcUrls?.['chainDefault']?.http?.[0] ?? ''],
-            blockExplorerUrls: [mockCaipNetworks[0].blockExplorers?.default.url ?? '']
+            rpcUrls: [mockProxyCaipNetwork.rpcUrls?.['chainDefault']?.http?.[0] ?? ''],
+            blockExplorerUrls: [mockProxyCaipNetwork.blockExplorers?.default.url ?? '']
           }
         })
       )
@@ -867,8 +870,10 @@ describe('WagmiAdapter', () => {
         preferredAccountType: 'smartAccount'
       })
 
+      const mockProxyCaipNetwork = proxy(mockCaipNetworks[0])
+
       await adapter.switchNetwork({
-        caipNetwork: mockCaipNetworks[0],
+        caipNetwork: mockProxyCaipNetwork,
         provider: mockAuthProvider,
         providerType: 'AUTH'
       })


### PR DESCRIPTION
# Description

Fixed an issue where switching an EVM network using wagmi threw an error on MetaMask if the network had to be added and the `nativeCurrency` was read from the param's caipNetwork.

The bug was introduced in the AppKit version 1.7.9. The `caipNetwork.nativeCurrency` object passed to wagmi's `switchNetwork` is a proxy, and it seems that MetaMask doesn't like that:

![image](https://github.com/user-attachments/assets/c2f2d826-ab05-4b3a-bb9a-584409b7ec88)

The issue was fixed for most cases as a side-effect of the pull request [#4577](https://github.com/reown-com/appkit/pull/4577) since it prioritizes `wagmiChain?.nativeCurrency` over `caipNetwork.nativeCurrency`, although in a case where the `wagmiNetwork` was undefined the `nativeCurrency` would fallback to `caipNetwork.nativeCurrency` and error.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: Closes #4574

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
