### PR TITLE
refactor: Blockchain API calls

### DIFF
--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -23,6 +23,8 @@ export type SafeLocalStorageItems = {
   '@appkit/preferred_account_types': string
   '@appkit/connections': string
   '@appkit/disconnected_connector_ids': string
+  '@appkit/history_transactions_cache': string
+  '@appkit/token_price_cache': string
   /*
    * DO NOT CHANGE: @walletconnect/universal-provider requires us to set this specific key
    *  This value is a stringified version of { href: stiring; name: string }
@@ -52,7 +54,9 @@ export const SafeLocalStorageKeys = {
   IDENTITY_CACHE: '@appkit/identity_cache',
   PREFERRED_ACCOUNT_TYPES: '@appkit/preferred_account_types',
   CONNECTIONS: '@appkit/connections',
-  DISCONNECTED_CONNECTOR_IDS: '@appkit/disconnected_connector_ids'
+  DISCONNECTED_CONNECTOR_IDS: '@appkit/disconnected_connector_ids',
+  HISTORY_TRANSACTIONS_CACHE: '@appkit/history_transactions_cache',
+  TOKEN_PRICE_CACHE: '@appkit/token_price_cache'
 } as const satisfies Record<string, keyof SafeLocalStorageItems>
 
 export type SafeLocalStorageKey = keyof SafeLocalStorageItems | NamespacedConnectorKey

--- a/packages/controllers/src/controllers/BlockchainApiController.ts
+++ b/packages/controllers/src/controllers/BlockchainApiController.ts
@@ -242,7 +242,15 @@ export const BlockchainApiController = {
       return { data: [], next: undefined }
     }
 
-    return BlockchainApiController.get<BlockchainApiTransactionsResponse>({
+    const transactionsCache = StorageUtil.getTransactionsCacheForAddress({
+      address: account,
+      chainId
+    })
+    if (transactionsCache) {
+      return transactionsCache as BlockchainApiTransactionsResponse
+    }
+
+    const result = await BlockchainApiController.get<BlockchainApiTransactionsResponse>({
       path: `/v1/account/${account}/history`,
       params: {
         cursor,
@@ -252,6 +260,15 @@ export const BlockchainApiController = {
       signal,
       cache
     })
+
+    StorageUtil.updateTransactionsCache({
+      address: account,
+      chainId,
+      timestamp: Date.now(),
+      transactions: result
+    })
+
+    return result
   },
 
   async fetchSwapQuote({ amount, userAddress, from, to, gasPrice }: BlockchainApiSwapQuoteRequest) {
@@ -301,7 +318,12 @@ export const BlockchainApiController = {
       return { fungibles: [] }
     }
 
-    return state.api.post<BlockchainApiTokenPriceResponse>({
+    const tokenPriceCache = StorageUtil.getTokenPriceCacheForAddresses(addresses)
+    if (tokenPriceCache) {
+      return tokenPriceCache as BlockchainApiTokenPriceResponse
+    }
+
+    const result = await state.api.post<BlockchainApiTokenPriceResponse>({
       path: '/v1/fungible/price',
       body: {
         currency: 'usd',
@@ -312,6 +334,14 @@ export const BlockchainApiController = {
         'Content-Type': 'application/json'
       }
     })
+
+    StorageUtil.updateTokenPriceCache({
+      addresses,
+      timestamp: Date.now(),
+      tokenPrice: result
+    })
+
+    return result
   },
 
   async fetchSwapAllowance({ tokenAddress, userAddress }: BlockchainApiSwapAllowanceRequest) {

--- a/packages/controllers/src/controllers/SwapController.ts
+++ b/packages/controllers/src/controllers/SwapController.ts
@@ -363,7 +363,7 @@ const controller = {
     if (networkToken) {
       state.networkTokenSymbol = networkToken.symbol
       SwapController.setSourceToken(networkToken)
-      SwapController.setSourceTokenAmount('1')
+      SwapController.setSourceTokenAmount('0')
     }
   },
 

--- a/packages/controllers/src/utils/StorageUtil.ts
+++ b/packages/controllers/src/utils/StorageUtil.ts
@@ -13,6 +13,8 @@ import type {
   BlockchainApiBalanceResponse,
   BlockchainApiIdentityResponse,
   BlockchainApiLookupEnsName,
+  BlockchainApiTokenPriceResponse,
+  BlockchainApiTransactionsResponse,
   ConnectionStatus,
   PreferredAccountTypes,
   SocialProvider,
@@ -33,7 +35,9 @@ export const StorageUtil = {
     portfolio: 30000,
     nativeBalance: 30000,
     ens: 300000,
-    identity: 300000
+    identity: 300000,
+    transactionsHistory: 15000,
+    tokenPrice: 15000
   },
   isCacheExpired(timestamp: number, cacheExpiry: number) {
     return Date.now() - timestamp > cacheExpiry
@@ -567,6 +571,7 @@ export const StorageUtil = {
       SafeLocalStorage.removeItem(SafeLocalStorageKeys.NATIVE_BALANCE_CACHE)
       SafeLocalStorage.removeItem(SafeLocalStorageKeys.ENS_CACHE)
       SafeLocalStorage.removeItem(SafeLocalStorageKeys.IDENTITY_CACHE)
+      SafeLocalStorage.removeItem(SafeLocalStorageKeys.HISTORY_TRANSACTIONS_CACHE)
     } catch {
       console.info('Unable to clear address cache')
     }
@@ -765,5 +770,135 @@ export const StorageUtil = {
     }
 
     return false
+  },
+  getTransactionsCache() {
+    try {
+      const result = SafeLocalStorage.getItem(SafeLocalStorageKeys.HISTORY_TRANSACTIONS_CACHE)
+
+      return result ? JSON.parse(result) : {}
+    } catch {
+      console.info('Unable to get transactions cache')
+    }
+
+    return {}
+  },
+
+  getTransactionsCacheForAddress({ address, chainId = '' }: { address: string; chainId?: string }) {
+    try {
+      const cache = StorageUtil.getTransactionsCache()
+      const transactionsCache = cache[address]?.[chainId]
+
+      // We want to discard cache if it's older than the cache expiry
+      if (
+        transactionsCache &&
+        !this.isCacheExpired(transactionsCache.timestamp, this.cacheExpiry.transactionsHistory)
+      ) {
+        return transactionsCache.transactions
+      }
+      StorageUtil.removeTransactionsCache(address)
+    } catch {
+      console.info('Unable to get transactions cache')
+    }
+
+    return undefined
+  },
+  updateTransactionsCache({
+    address,
+    chainId = '',
+    timestamp,
+    transactions
+  }: {
+    address: string
+    chainId?: string
+    timestamp: number
+    transactions: BlockchainApiTransactionsResponse
+  }) {
+    try {
+      const cache = StorageUtil.getTransactionsCache()
+      cache[address] = {
+        ...cache[address],
+        [chainId]: {
+          timestamp,
+          transactions
+        }
+      }
+      SafeLocalStorage.setItem(
+        SafeLocalStorageKeys.HISTORY_TRANSACTIONS_CACHE,
+        JSON.stringify(cache)
+      )
+    } catch {
+      console.info('Unable to update transactions cache', {
+        address,
+        chainId,
+        timestamp,
+        transactions
+      })
+    }
+  },
+  removeTransactionsCache(address: string) {
+    try {
+      const cache = StorageUtil.getTransactionsCache()
+      SafeLocalStorage.setItem(
+        SafeLocalStorageKeys.HISTORY_TRANSACTIONS_CACHE,
+        JSON.stringify({ ...cache, [address]: undefined })
+      )
+    } catch {
+      console.info('Unable to remove transactions cache', address)
+    }
+  },
+  getTokenPriceCache() {
+    try {
+      const result = SafeLocalStorage.getItem(SafeLocalStorageKeys.TOKEN_PRICE_CACHE)
+
+      return result ? JSON.parse(result) : {}
+    } catch {
+      console.info('Unable to get token price cache')
+    }
+
+    return {}
+  },
+  getTokenPriceCacheForAddresses(addresses: string[]) {
+    try {
+      const cache = StorageUtil.getTokenPriceCache()
+      const tokenPriceCache = cache[addresses.join(',')]
+      if (
+        tokenPriceCache &&
+        !this.isCacheExpired(tokenPriceCache.timestamp, this.cacheExpiry.tokenPrice)
+      ) {
+        return tokenPriceCache.tokenPrice
+      }
+      StorageUtil.removeTokenPriceCache(addresses)
+    } catch {
+      console.info('Unable to get token price cache for addresses', addresses)
+    }
+
+    return undefined
+  },
+  updateTokenPriceCache(params: {
+    addresses: string[]
+    timestamp: number
+    tokenPrice: BlockchainApiTokenPriceResponse
+  }) {
+    try {
+      const cache = StorageUtil.getTokenPriceCache()
+      cache[params.addresses.join(',')] = {
+        timestamp: params.timestamp,
+        tokenPrice: params.tokenPrice
+      }
+      SafeLocalStorage.setItem(SafeLocalStorageKeys.TOKEN_PRICE_CACHE, JSON.stringify(cache))
+    } catch {
+      console.info('Unable to update token price cache', params)
+    }
+  },
+  removeTokenPriceCache(addresses: string[]) {
+    try {
+      const cache = StorageUtil.getTokenPriceCache()
+      SafeLocalStorage.setItem(
+        SafeLocalStorageKeys.TOKEN_PRICE_CACHE,
+        JSON.stringify({ ...cache, [addresses.join(',')]: undefined })
+      )
+    } catch {
+      console.info('Unable to remove token price cache', addresses)
+    }
   }
 }

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-select-token-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-select-token-view/index.ts
@@ -6,7 +6,8 @@ import {
   ChainController,
   CoreHelperUtil,
   RouterController,
-  SendController
+  SendController,
+  SwapController
 } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
@@ -39,6 +40,8 @@ export class W3mSendSelectTokenView extends LitElement {
   // -- Lifecycle ----------------------------------------- //
   public constructor() {
     super()
+    this.fetchNetworkPrice()
+    this.fetchBalances()
     this.unsubscribe.push(
       ...[
         SendController.subscribe(val => {
@@ -62,6 +65,15 @@ export class W3mSendSelectTokenView extends LitElement {
   }
 
   // -- Private ------------------------------------------- //
+
+  private async fetchBalances() {
+    await SendController.fetchTokenBalance()
+    SendController.fetchNetworkBalance()
+  }
+
+  private async fetchNetworkPrice() {
+    await SwapController.getNetworkTokenPrice()
+  }
 
   private templateSearchInput() {
     return html`

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -46,8 +46,12 @@ export class W3mWalletSendView extends LitElement {
 
   public constructor() {
     super()
-    this.fetchNetworkPrice()
-    this.fetchBalances()
+    // Only load balances and network price if a token is set, else they will be loaded in the select token view
+    if (this.token) {
+      this.fetchBalances()
+      this.fetchNetworkPrice()
+    }
+
     this.unsubscribe.push(
       ...[
         SendController.subscribe(val => {

--- a/packages/ui/src/composites/wui-token-list-item/index.ts
+++ b/packages/ui/src/composites/wui-token-list-item/index.ts
@@ -85,7 +85,7 @@ export class WuiTokenListItem extends LitElement {
             <wui-text variant="small-400" color="fg-200" lineClamp="1">${this.symbol}</wui-text>
             ${this.amount
               ? html`<wui-text variant="small-400" color="fg-200">
-                  ${UiHelperUtil.formatNumberToLocalString(this.amount, 4)}
+                  ${UiHelperUtil.formatNumberToLocalString(this.amount, 3)}
                 </wui-text>`
               : null}
           </wui-flex>


### PR DESCRIPTION
# Description
Refactored the `Send`, `Swap` and `Activity` screens to improve the efficiency of http calls. Also implemented local caching to some of the blockchain api calls

### `Send` page
Fetches tokens/price info only if a `token` is already selected, else they are fetched in token select screen

### `Activity` page
Added temporary local cache to transactions history so users can still refresh the history but not hit the backend everytime the page is opened

### `Swap`
- Default native token amount set to `0` instead of `1`
- Starts network price interval only when both tokens are selected
- Added visibility listener so the network price calls are disabled while the page is in background 
 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
https://linear.app/reown/issue/APKT-3169/activity-page-http-calls-improvement-proposal
https://linear.app/reown/issue/APKT-3168/send-page-http-calls-improvement-proposal
https://linear.app/reown/issue/APKT-3166/swap-page-http-calls-reduction-proposal

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
