### PR TITLE
chore: automate AppKit CDN update in AppKit Unity 

### DIFF
--- a/.github/workflows/devin_unity_cdn_update.yml
+++ b/.github/workflows/devin_unity_cdn_update.yml
@@ -1,0 +1,113 @@
+name: Trigger Devin for Docs Update
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read # Required to read github.event.head_commit.message
+
+jobs:
+  trigger-devin-docs-analysis:
+    # This job runs only if the head commit message on the push to main contains 'chore: version packages'
+    if: |
+      contains(github.event.head_commit.message, 'chore: version packages')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack Notification for Docs Analysis
+        env:
+          DEVIN_SLACK_WEBHOOK_URL: ${{ secrets.DEVIN_SLACK_WEBHOOK_URL }}
+          DEVIN_SLACK_USER_ID: U08M9DKD4MC
+          PROMPT_TEXT: |
+            ## Context
+            A commit titled **"chore: version packages"** (SHA: ${{ github.sha }}) just landed on **${{ github.repository }}**'s `main` branch.  
+            This commit bumps the published AppKit packages and updates one or more `CHANGELOG.md` files.
+
+            ## Task - Update Unity binding
+            1. Detect the new AppKit version introduced by this commit.
+            2. In repo **reown-com/reown-dotnet**:
+               • Create a branch off `develop`.  
+               • Edit `src/Reown.AppKit.Unity/Plugins/AppKit.jslib`, replacing the import line  
+                 ```js
+                 import("https://cdn.jsdelivr.net/npm/@reown/appkit-cdn@OLD_VER/dist/appkit.js").then(async (AppKit) => {
+                 ```  
+                 with  
+                 ```js
+                 import("https://cdn.jsdelivr.net/npm/@reown/appkit-cdn@<NEW_VER>/dist/appkit.js").then(async (AppKit) => {
+                 ```
+               • If the import line already uses the latest version, **do not create a PR** and instead respond **"No Unity AppKit update needed."**  
+               • Otherwise, commit and open a PR.
+
+            ## PR requirements
+            * **Title:** `chore: bump appkit-cdn to <NEW_VER>`
+            * **Body must include:**  
+              - A bullet list of features / fixes from the AppKit web changelog for `<NEW_VER>` (copy from the same CHANGELOG).  
+              - A link to the triggering commit: `${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}`  
+
+            ## Reminders
+            • Treat duplicated CHANGELOG entries as one source of truth.  
+            • Fail fast and report clear errors if anything blocks you (permissions, missing file, etc.).  
+            • Keep messages concise—no boilerplate.
+        run: |
+          # Exit on error
+          set -e
+
+          # Check if the Slack webhook URL is provided and not empty
+          if [ -z "${DEVIN_SLACK_WEBHOOK_URL}" ]; then
+            echo "Error: DEVIN_SLACK_WEBHOOK_URL is not set or is empty."
+            echo "Please ensure this secret is configured in the repository settings (Secrets and variables > Actions)."
+            exit 1
+          fi
+
+          # PROMPT_TEXT is set in the 'env' block and should be fully expanded by GitHub Actions.
+          # Construct the final message text for Slack.
+          MESSAGE_TEXT="<@${DEVIN_SLACK_USER_ID}> ${PROMPT_TEXT}"
+
+          # Create the JSON payload for Slack.
+          # jq 's --arg option handles escaping special characters in MESSAGE_TEXT for valid JSON.
+          echo "Attempting to create JSON payload..."
+          JSON_PAYLOAD=$(jq -n --arg text "$MESSAGE_TEXT" '{text: $text}')
+          JQ_EXIT_CODE=$?
+
+          if [ $JQ_EXIT_CODE -ne 0 ]; then
+            echo "Error: jq command failed to create JSON payload (Exit Code: $JQ_EXIT_CODE)."
+            # Log a snippet of the message text to aid debugging, avoiding overly long logs.
+            echo "Original Message Text (first 200 characters):"
+            echo "${MESSAGE_TEXT:0:200}..."
+            exit 1
+          fi
+
+          echo "Sending Slack notification for Docs Analysis."
+          # Echo context information using direct GitHub context expressions for clarity and consistency.
+          echo "AppKit Repo: ${{ github.repository }}"
+          echo "Commit SHA: ${{ github.sha }}"
+          echo "Commit URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+
+          # Send the notification to Slack using curl.
+          # -s: silent mode (no progress meter).
+          # -X POST: specifies the HTTP POST method.
+          # -H "Content-Type: application/json": sets the content type header.
+          # -d "$JSON_PAYLOAD": provides the JSON data for the request body.
+          RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "$JSON_PAYLOAD" \
+            "${DEVIN_SLACK_WEBHOOK_URL}")
+          CURL_EXIT_CODE=$?
+
+          if [ $CURL_EXIT_CODE -ne 0 ]; then
+            echo "Error: curl command failed to send Slack notification (Exit Code: $CURL_EXIT_CODE)."
+            # RESPONSE might be empty or contain an error message from curl itself (e.g., if URL is malformed or network issue).
+            echo "Curl response (if any): $RESPONSE"
+            exit 1
+          fi
+
+          # Check the content of the response from the Slack API.
+          # A successful Slack webhook POST request typically returns the string "ok".
+          if [ "$RESPONSE" = "ok" ]; then
+            echo "Slack notification sent successfully."
+          else
+            echo "Error sending Slack notification: Slack API did not return 'ok'."
+            echo "Response from Slack: $RESPONSE"
+            exit 1
+          fi


### PR DESCRIPTION
# Description

Whenever a commit titled “chore: version packages” is made to `main`, this workflow sends a Slack message to Devin, instructing him to update the Unity plugin’s `appkit-cdn` version in the `reown-dotnet` repo. If the version is already up-to-date, he should reply with “No Unity AppKit update needed.” If necessary, a corresponding PR will be opened in `reown-dotnet` repo.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
