### PR TITLE
fix: networks logics for the ones doesn't have required files

### DIFF
--- a/.changeset/clear-parks-lose.md
+++ b/.changeset/clear-parks-lose.md
@@ -1,0 +1,27 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue on network logics where some networks doesn't have required fields and causing issues

--- a/packages/adapters/bitcoin/tests/exports.test.ts
+++ b/packages/adapters/bitcoin/tests/exports.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 describe('Bitcoin Adapter Exports', () => {
@@ -8,14 +9,14 @@ describe('Bitcoin Adapter Exports', () => {
 
   it('should ensure polyfills are loaded when importing exports', () => {
     const polyfills = {
-      Buffer: window.Buffer,
+      Buffer: Buffer,
       global: window.global,
       process: window.process,
       'process.env': window.process.env
     }
 
-    expect(window.Buffer).toBeDefined()
-    expect(typeof window.Buffer).toBe('function')
+    expect(Buffer).toBeDefined()
+    expect(typeof Buffer).toBe('function')
 
     expect(window.global).toBeDefined()
     expect(window.global).toBe(window)

--- a/packages/appkit-utils/src/CaipNetworkUtil.ts
+++ b/packages/appkit-utils/src/CaipNetworkUtil.ts
@@ -148,14 +148,14 @@ export const CaipNetworksUtil = {
     const chainNamespace = this.getChainNamespace(caipNetwork)
     const caipNetworkId = this.getCaipNetworkId(caipNetwork)
 
-    const networkDefaultRpcUrl = caipNetwork.rpcUrls.default.http?.[0]
+    const networkDefaultRpcUrl = caipNetwork.rpcUrls?.default?.http?.[0]
     const reownRpcUrl = this.getDefaultRpcUrl(caipNetwork, caipNetworkId, projectId)
 
     const chainDefaultRpcUrl =
       caipNetwork?.rpcUrls?.['chainDefault']?.http?.[0] || networkDefaultRpcUrl
     const customRpcUrlsOfNetwork = customRpcUrls?.[caipNetworkId]?.map(i => i.url) || []
 
-    const rpcUrls = [...customRpcUrlsOfNetwork, reownRpcUrl]
+    const rpcUrls = [...customRpcUrlsOfNetwork, ...(reownRpcUrl ? [reownRpcUrl] : [])]
     const rpcUrlsWithoutReown = [...customRpcUrlsOfNetwork]
 
     if (chainDefaultRpcUrl && !rpcUrlsWithoutReown.includes(chainDefaultRpcUrl)) {

--- a/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
+++ b/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
@@ -221,8 +221,8 @@ describe('CaipNetworksUtil', () => {
   })
 
   describe('handle network without rpcUrls', () => {
-    it.only('should handle network without rpcUrls field gracefully', () => {
-      const networkWithoutRpcUrls: AppKitNetwork = {
+    it('should handle network without rpcUrls field gracefully', () => {
+      const networkWithoutRpcUrls = {
         id: 123,
         name: 'No RPC Network',
         nativeCurrency: {
@@ -231,7 +231,7 @@ describe('CaipNetworksUtil', () => {
           decimals: 18
         }
         // Note: rpcUrls field is intentionally omitted
-      }
+      } as AppKitNetwork
 
       const result = CaipNetworksUtil.extendCaipNetwork(networkWithoutRpcUrls, {
         customNetworkImageUrls: undefined,

--- a/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
+++ b/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
@@ -220,6 +220,29 @@ describe('CaipNetworksUtil', () => {
     })
   })
 
+  describe('handle network without rpcUrls', () => {
+    it.only('should handle network without rpcUrls field gracefully', () => {
+      const networkWithoutRpcUrls: AppKitNetwork = {
+        id: 123,
+        name: 'No RPC Network',
+        nativeCurrency: {
+          name: 'NoRPC',
+          symbol: 'NRPC',
+          decimals: 18
+        }
+        // Note: rpcUrls field is intentionally omitted
+      }
+
+      const result = CaipNetworksUtil.extendCaipNetwork(networkWithoutRpcUrls, {
+        customNetworkImageUrls: undefined,
+        projectId: mockProjectId,
+        customRpcUrls: undefined
+      })
+
+      expect(result.rpcUrls.default.http).toEqual([])
+    })
+  })
+
   describe('extendCaipNetworks', () => {
     it('should extend multiple networks correctly', () => {
       const networks = [mainnet, { ...mainnet, id: 2 }]

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.11'
+export const PACKAGE_VERSION = '1.7.12'

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1696,9 +1696,9 @@ export abstract class AppKitBaseClient {
   // -- Public Internal ---------------------------------------------------
   public getCaipNetwork = (chainNamespace?: ChainNamespace, id?: string | number) => {
     if (chainNamespace) {
-      const caipNetworkWithId = ChainController.getNetworkData(
-        chainNamespace
-      )?.requestedCaipNetworks?.find(c => c.id === id)
+      const caipNetworkWithId = ChainController.getCaipNetworks(chainNamespace)?.find(
+        c => c.id === id
+      )
 
       if (caipNetworkWithId) {
         return caipNetworkWithId

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChainNamespace } from '@reown/appkit-common'
 import {
   AlertController,
   ApiController,
+  type ChainAdapter,
   ChainController,
   ConnectionController
 } from '@reown/appkit-controllers'
@@ -227,6 +229,22 @@ describe('AppKitBaseClient.getCaipNetwork', () => {
       async injectModalUi() {}
       async syncIdentity() {}
     })()
+
+    vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+      ...ChainController.state,
+      activeChain: 'eip155',
+      chains: new Map([
+        [
+          'eip155',
+          {
+            networkState: {
+              requestedCaipNetworks: [mainnet],
+              approvedCaipNetworkIds: [mainnet.id]
+            }
+          }
+        ]
+      ]) as Map<ChainNamespace, ChainAdapter>
+    })
   })
 
   it('should call ChainController.getCaipNetworks when chainNamespace is provided', () => {

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -207,3 +207,18 @@ describe('AppKitBaseClient.connectWalletConnect', () => {
     expect(closeSpy).toHaveBeenCalled()
   })
 })
+
+describe('AppKitBaseClient.getCaipNetwork', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should call ChainController.getCaipNetworks when chainNamespace is provided', () => {
+    const getCaipNetworksSpy = vi.spyOn(ChainController, 'getCaipNetworks')
+    const chainNamespace = 'eip155'
+
+    baseClient.getCaipNetwork(chainNamespace)
+
+    expect(getCaipNetworksSpy).toHaveBeenCalledWith(chainNamespace)
+  })
+})

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -216,20 +216,6 @@ describe('AppKitBaseClient.getCaipNetwork', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
 
-    baseClient = new (class extends AppKitBaseClient {
-      constructor() {
-        super({
-          projectId: 'test-project-id',
-          networks: [mainnet],
-          adapters: [],
-          sdkVersion: 'html-wagmi-1'
-        })
-      }
-
-      async injectModalUi() {}
-      async syncIdentity() {}
-    })()
-
     vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
       ...ChainController.state,
       activeChain: 'eip155',
@@ -245,6 +231,20 @@ describe('AppKitBaseClient.getCaipNetwork', () => {
         ]
       ]) as Map<ChainNamespace, ChainAdapter>
     })
+
+    baseClient = new (class extends AppKitBaseClient {
+      constructor() {
+        super({
+          projectId: 'test-project-id',
+          networks: [mainnet],
+          adapters: [],
+          sdkVersion: 'html-wagmi-1'
+        })
+      }
+
+      async injectModalUi() {}
+      async syncIdentity() {}
+    })()
   })
 
   it('should call ChainController.getCaipNetworks when chainNamespace is provided', () => {

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -209,8 +209,24 @@ describe('AppKitBaseClient.connectWalletConnect', () => {
 })
 
 describe('AppKitBaseClient.getCaipNetwork', () => {
+  let baseClient: AppKitBaseClient
+
   beforeEach(() => {
     vi.restoreAllMocks()
+
+    baseClient = new (class extends AppKitBaseClient {
+      constructor() {
+        super({
+          projectId: 'test-project-id',
+          networks: [mainnet],
+          adapters: [],
+          sdkVersion: 'html-wagmi-1'
+        })
+      }
+
+      async injectModalUi() {}
+      async syncIdentity() {}
+    })()
   })
 
   it('should call ChainController.getCaipNetworks when chainNamespace is provided', () => {

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -524,8 +524,9 @@ const controller = {
       approvedCaipNetworkIds,
       requestedCaipNetworks
     )
+    const filteredNetworks = sortedNetworks.filter(network => network?.id)
 
-    return sortedNetworks
+    return filteredNetworks
   },
 
   getAllRequestedCaipNetworks(): CaipNetwork[] {

--- a/packages/controllers/tests/controllers/ChainController.test.ts
+++ b/packages/controllers/tests/controllers/ChainController.test.ts
@@ -275,7 +275,7 @@ describe('ChainController', () => {
       }
     ]
 
-    ChainController.setRequestedCaipNetworks(networksWithMissingId, chainNamespace)
+    ChainController.setRequestedCaipNetworks(networksWithMissingId as CaipNetwork[], chainNamespace)
     const filteredNetworks = ChainController.getRequestedCaipNetworks(chainNamespace)
 
     expect(filteredNetworks).toEqual(requestedCaipNetworks)

--- a/packages/controllers/tests/controllers/ChainController.test.ts
+++ b/packages/controllers/tests/controllers/ChainController.test.ts
@@ -261,6 +261,26 @@ describe('ChainController', () => {
     expect(requestedNetworks).toEqual(requestedCaipNetworks)
   })
 
+  it('should filter out networks without id values in getRequestedCaipNetworks', () => {
+    const chainNamespace = ConstantsUtil.CHAIN.EVM
+    const networksWithMissingId = [
+      ...requestedCaipNetworks,
+      {
+        caipNetworkId: 'eip155:999',
+        name: 'Test Network',
+        chainNamespace: ConstantsUtil.CHAIN.EVM,
+        nativeCurrency: { name: 'Test', symbol: 'TST', decimals: 18 },
+        rpcUrls: { default: { http: ['https://rpc.test.com/v1/'] } },
+        blockExplorers: { default: { name: 'Test Explorer', url: 'https://explorer.test.io' } }
+      }
+    ]
+
+    ChainController.setRequestedCaipNetworks(networksWithMissingId, chainNamespace)
+    const filteredNetworks = ChainController.getRequestedCaipNetworks(chainNamespace)
+
+    expect(filteredNetworks).toEqual(requestedCaipNetworks)
+  })
+
   it('should reset state correctly on resetNetwork()', () => {
     const namespace = 'eip155'
     ChainController.resetNetwork(namespace)


### PR DESCRIPTION
# Description

When using the following approach when initializing the AppKit. AppKit throws error when extending networks. 

```tsx
import * as networkDefinitions from '@reown/appkit/networks'

createAppKit({
 networks: Object.values(networkDefinitions)
})
```

Thrown error:

```sh
Uncaught TypeError: Cannot read properties of undefined (reading 'default')
    at Object.extendCaipNetwork (CaipNetworkUtil.ts:151:54)
    at CaipNetworkUtil.ts:201:24
    at Array.map (<anonymous>)
    at Object.extendCaipNetworks (CaipNetworkUtil.ts:200:25)
    at AppKit.extendCaipNetworks (appkit-base-client.ts:403:47)
    at new AppKitBaseClient (appkit-base-client.ts:139:30)
    at new AppKit (appkit.ts:61:7)
    at createAppKit (react.ts:26:13)
    at useAppKit.ts:22:16
```

This is possibly bc that one of the Viem chains doesn't have rpcUrlsfield and we are calling

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
