### PR TITLE
fix: siwe spam

### DIFF
--- a/.changeset/new-teeth-fail.md
+++ b/.changeset/new-teeth-fail.md
@@ -1,0 +1,7 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+---
+
+Fixes issue where getSession would be called for every network in config.

--- a/packages/controllers/src/utils/SIWXUtil.ts
+++ b/packages/controllers/src/utils/SIWXUtil.ts
@@ -197,16 +197,25 @@ export const SIWXUtil = {
 
     return sessions
   },
-  async getSessions() {
+  async getSessions(args?: { address?: string; caipNetworkId?: CaipNetworkId }) {
     const siwx = OptionsController.state.siwx
-    const address = CoreHelperUtil.getPlainAddress(ChainController.getActiveCaipAddress())
-    const network = ChainController.getActiveCaipNetwork()
+    let address = args?.address
+    if (!address) {
+      const activeCaipAddress = ChainController.getActiveCaipAddress()
+      address = CoreHelperUtil.getPlainAddress(activeCaipAddress)
+    }
+
+    let network = args?.caipNetworkId
+    if (!network) {
+      const activeCaipNetwork = ChainController.getActiveCaipNetwork()
+      network = activeCaipNetwork?.caipNetworkId
+    }
 
     if (!(siwx && address && network)) {
       return []
     }
 
-    return siwx.getSessions(network.caipNetworkId, address)
+    return siwx.getSessions(network, address)
   },
   async isSIWXCloseDisabled() {
     const siwx = this.getSIWX()

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -226,8 +226,8 @@ export class W3mModalBase extends LitElement {
   private async onNewAddress(caipAddress?: CaipAddress) {
     const isSwitchingNamespace = ChainController.state.isSwitchingNamespace
     const isPrevDisconnected = !CoreHelperUtil.getPlainAddress(this.caipAddress)
-    const isNextConnected = CoreHelperUtil.getPlainAddress(caipAddress)
-    const sessions = await SIWXUtil.getAllSessions()
+    const newAddress = CoreHelperUtil.getPlainAddress(caipAddress)
+    const sessions = await SIWXUtil.getSessions({ address: newAddress })
     const isNextAuthenticated =
       caipAddress && SIWXUtil.getSIWX()
         ? sessions.some(
@@ -237,11 +237,11 @@ export class W3mModalBase extends LitElement {
         : true
 
     // When users decline SIWE signature, we should close the modal
-    const isDisconnectedInSameNamespace = !isNextConnected && !isSwitchingNamespace
+    const isDisconnectedInSameNamespace = !newAddress && !isSwitchingNamespace
 
     // If user is switching to another namespace and connected in that namespace, we should go back
     const isSwitchingNamespaceAndConnected =
-      isSwitchingNamespace && isNextConnected && isNextAuthenticated
+      isSwitchingNamespace && newAddress && isNextAuthenticated
 
     // If user is in profile wallets view, we should not go back or close the modal
     const isInProfileWalletsView = RouterController.state.view === 'ProfileWallets'
@@ -251,7 +251,7 @@ export class W3mModalBase extends LitElement {
         ModalController.close()
       } else if (isSwitchingNamespaceAndConnected && !this.enableEmbedded) {
         RouterController.goBack()
-      } else if (this.enableEmbedded && isPrevDisconnected && isNextConnected) {
+      } else if (this.enableEmbedded && isPrevDisconnected && newAddress) {
         ModalController.close()
       }
     }

--- a/packages/siwe/src/mapToSIWX.ts
+++ b/packages/siwe/src/mapToSIWX.ts
@@ -130,9 +130,11 @@ export function mapToSIWX(siwe: AppKitSIWEClient): SIWXConfig {
       }
 
       if (await siwe.methods.verifyMessage(session)) {
+        const address = session.data.accountAddress
+        const network = NetworkUtil.parseEvmChainId(session.data.chainId)
         siwe.methods.onSignIn?.({
-          address: session.data.accountAddress,
-          chainId: NetworkUtil.parseEvmChainId(session.data.chainId) as number
+          address,
+          chainId: network as number
         })
 
         return Promise.resolve()


### PR DESCRIPTION
# Description

- Fixes issue where `getSession` would be called for every caip network in config every time adress/network changed

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes APKT-3297

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
