### PR TITLE
fix: default account type after disconnect

### DIFF
--- a/.changeset/upset-pets-wash.md
+++ b/.changeset/upset-pets-wash.md
@@ -1,0 +1,27 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes issue on defaultAccountTypes where after disconnection it takes priority of whatever the last active account type is

--- a/apps/laboratory/tests/email-default-account-types.spec.ts
+++ b/apps/laboratory/tests/email-default-account-types.spec.ts
@@ -64,6 +64,20 @@ emailTest('it should make the default account type as smart account', async () =
   await validator.expectDisconnected()
 })
 
+emailTest('it should connect again and should be sa', async () => {
+  // @ts-expect-error - mailsacApiKey is defined
+  await page.emailFlow({ emailAddress: tempEmail, context, mailsacApiKey })
+  await validator.expectConnected()
+
+  // Verify the active account type is smart account
+  await page.goToProfileWalletsView()
+  await page.clickProfileWalletsMoreButton()
+  await validator.expectChangePreferredAccountToShow(EOA)
+
+  await page.disconnect()
+  await validator.expectDisconnected()
+})
+
 emailTest('it should show make the default account type as EOA', async () => {
   page = new ModalWalletPage(browserPage, 'default-account-types-eoa', 'default')
   await page.load()
@@ -88,6 +102,20 @@ emailTest('it should show make the default account type as EOA', async () => {
   await page.goToProfileWalletsView()
   await page.clickProfileWalletsMoreButton()
   await validator.expectChangePreferredAccountToShow(SMART_ACCOUNT)
+  await page.disconnect()
+  await validator.expectDisconnected()
+})
+
+emailTest('it should connect again and should be eoa', async () => {
+  // @ts-expect-error - mailsacApiKey is defined
+  await page.emailFlow({ emailAddress: tempEmail, context, mailsacApiKey })
+  await validator.expectConnected()
+
+  // Verify the active account type is smart account
+  await page.goToProfileWalletsView()
+  await page.clickProfileWalletsMoreButton()
+  await validator.expectChangePreferredAccountToShow(SMART_ACCOUNT)
+
   await page.disconnect()
   await validator.expectDisconnected()
 })

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.12'
+export const PACKAGE_VERSION = '1.7.13'

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -669,6 +669,7 @@ const controller = {
       throw new Error('Chain is required to set account prop')
     }
 
+    const optionsAccountType = OptionsController.state.defaultAccountTypes[chainToWrite]
     const currentAccountType = ChainController.getAccountProp('preferredAccountType', chainToWrite)
 
     state.activeCaipAddress = undefined
@@ -684,7 +685,7 @@ const controller = {
       addressExplorerUrl: undefined,
       tokenBalance: [],
       connectedWalletInfo: undefined,
-      preferredAccountType: currentAccountType,
+      preferredAccountType: optionsAccountType || currentAccountType,
       socialProvider: undefined,
       socialWindow: undefined,
       farcasterUrl: undefined,

--- a/packages/controllers/tests/controllers/ChainController.test.ts
+++ b/packages/controllers/tests/controllers/ChainController.test.ts
@@ -12,7 +12,8 @@ import {
   AccountController,
   CoreHelperUtil,
   ModalController,
-  type NetworkControllerClient
+  type NetworkControllerClient,
+  OptionsController
 } from '../../exports/index.js'
 import { ChainController } from '../../src/controllers/ChainController.js'
 import { type ConnectionControllerClient } from '../../src/controllers/ConnectionController.js'
@@ -312,6 +313,21 @@ describe('ChainController', () => {
     expect(AccountController.state.status).toEqual('disconnected')
     expect(AccountController.state.socialProvider).toEqual(undefined)
     expect(AccountController.state.socialWindow).toEqual(undefined)
+  })
+
+  it('should reset account and set preferredAccountType from OptionsController.state.defaultAccountTypes if defined', () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValueOnce({
+      ...OptionsController.state,
+      defaultAccountTypes: {
+        eip155: 'eoa'
+      }
+    })
+
+    ChainController.resetAccount(chainNamespace)
+
+    expect(
+      ChainController.state.chains.get(chainNamespace)?.accountState?.preferredAccountType
+    ).toEqual('eoa')
   })
 
   it('Expect modal to close after switching from unsupported network to supported network', async () => {


### PR DESCRIPTION
# Description

When we disconnect the namespace, we are setting `preferredAccountType` of the account status to last used account type, where it should give priority to `defaultAccountTypes` option. 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
