### PR TITLE
fix: reviewer assignment in devin_docs_update workflow

### DIFF
--- a/.github/workflows/devin_docs_update.yml
+++ b/.github/workflows/devin_docs_update.yml
@@ -34,7 +34,7 @@ jobs:
                 * Include the necessary documentation updates reflecting the changes from the appkit changelog.
                 * Contain a clear description of why the updates are needed, referencing the specific changes from the appkit repository.
                 * Include a link back to the original "chore: version packages" commit in the ${{ github.repository }} repository (Commit: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
-                * Tag the following Github teams in the pull request: @reown-com/appkit-web-team, @reown-com/devrel-team
+                * Assign the following Github teams as reviewers in the pull request: @reown-com/appkit-web-team, @reown-com/devrel-team
             * If no documentation updates are needed, clearly state this conclusion. You do not need to open a pull request in this case. Simply report that no updates are necessary based on your analysis of the changelog.
             * You will need to operate within the following repositories: ${{ github.repository }} (for reading the changelog of the commit) and reown-com/reown-docs (for potentially creating a PR with documentation updates).
         run: |


### PR DESCRIPTION

# Description

* Updated the documentation workflow to specify assigning GitHub teams as reviewers instead of tagging them in pull requests.
* Devin was simply tagging the teams in the PR description instead of assigning reviewers


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
