### PR TITLE
chore: pay method rework

### DIFF
--- a/apps/laboratory/src/components/AppKitPay.tsx
+++ b/apps/laboratory/src/components/AppKitPay.tsx
@@ -193,7 +193,7 @@ export function AppKitPay() {
       paymentAsset: paymentDetails.asset
     })
 
-    if (result.status === 'SUCCESS') {
+    if (result.success) {
       toast({ title: 'Payment Succeeded', description: `Tx: ${result.result}`, type: 'success' })
     } else {
       toast({

--- a/apps/laboratory/src/components/AppKitPay.tsx
+++ b/apps/laboratory/src/components/AppKitPay.tsx
@@ -30,19 +30,12 @@ import {
 import { Card } from '@chakra-ui/react'
 
 import type { CaipNetworkId } from '@reown/appkit-common'
-import type {
-  AppKitPayErrorMessage,
-  Exchange,
-  PayResult,
-  PayUrlParams,
-  PaymentAsset
-} from '@reown/appkit-pay'
-import { baseETH, baseSepoliaETH, baseUSDC } from '@reown/appkit-pay'
+import type { Exchange, PayUrlParams, PaymentAsset } from '@reown/appkit-pay'
+import { baseETH, baseSepoliaETH, baseUSDC, pay } from '@reown/appkit-pay'
 import {
   type ExchangeBuyStatus,
   useAvailableExchanges,
   useExchangeBuyStatus,
-  usePay,
   usePayUrlActions
 } from '@reown/appkit-pay/react'
 import { solana, solanaDevnet } from '@reown/appkit/networks'
@@ -101,27 +94,6 @@ interface ActiveStatusCheck {
 export function AppKitPay() {
   const { isOpen, onToggle } = useDisclosure()
   const toast = useChakraToast()
-
-  function handleSuccess(resultData: PayResult) {
-    toast({
-      title: 'Transaction successful',
-      description: resultData,
-      type: 'success'
-    })
-  }
-
-  function handleError(errorData: AppKitPayErrorMessage) {
-    toast({
-      title: 'Transaction failed',
-      description: errorData,
-      type: 'error'
-    })
-  }
-
-  const { open, isPending } = usePay({
-    onSuccess: handleSuccess,
-    onError: handleError
-  })
 
   const {
     data: fetchedExchangesData,
@@ -215,12 +187,21 @@ export function AppKitPay() {
 
       return
     }
-
-    await open({
+    const result = await pay({
       recipient: paymentDetails.recipient,
       amount: paymentDetails.amount,
       paymentAsset: paymentDetails.asset
     })
+
+    if (result.status === 'SUCCESS') {
+      toast({ title: 'Payment Succeeded', description: `Tx: ${result.result}`, type: 'success' })
+    } else {
+      toast({
+        title: 'Payment Failed',
+        description: result.error ?? 'Unknown error',
+        type: 'error'
+      })
+    }
   }
 
   const handleInputChange = useCallback(
@@ -518,8 +499,8 @@ export function AppKitPay() {
         </CardHeader>
         <CardBody>
           <Stack spacing="4">
-            <Button onClick={handleOpenPay} isDisabled={isPending} width="full">
-              {isPending ? <Spinner /> : 'Open Pay Modal'}
+            <Button onClick={handleOpenPay} width="full">
+              Open Pay Modal
             </Button>
 
             <Text fontSize="sm" color="gray.500">

--- a/packages/pay/exports/index.ts
+++ b/packages/pay/exports/index.ts
@@ -8,7 +8,8 @@ export {
   getExchanges,
   getPayResult,
   getPayError,
-  getIsPaymentInProgress
+  getIsPaymentInProgress,
+  pay
 } from '../src/client.js'
 
 // -- Types ----------------------------------------- //

--- a/packages/pay/src/client.ts
+++ b/packages/pay/src/client.ts
@@ -1,8 +1,60 @@
 import { PayController, type PayControllerState } from './controllers/PayController.js'
 import type { GetExchangesParams, PayUrlParams, PaymentOptions } from './types/options.js'
+import type { PaymentResult } from './types/payment.js'
+
+// 5 minutes
+const PAYMENT_TIMEOUT_MS = 300000
 
 export async function openPay(options: PaymentOptions) {
   return PayController.handleOpenPay(options)
+}
+
+export async function pay(options: PaymentOptions, timeoutMs = PAYMENT_TIMEOUT_MS) {
+  await openPay(options)
+
+  return new Promise<PaymentResult>((resolve, reject) => {
+    let cleanup: (() => void) | null = null
+
+    const timeoutId = setTimeout(() => {
+      cleanup?.()
+      reject(new Error('Payment timeout'))
+    }, timeoutMs)
+
+    function checkAndResolve(): void {
+      const currentPayment = PayController.state.currentPayment
+      const error = PayController.state.error
+      const isInProgress = PayController.state.isPaymentInProgress
+
+      if (currentPayment?.status === 'SUCCESS') {
+        cleanup?.()
+        clearTimeout(timeoutId)
+        resolve({
+          status: 'SUCCESS',
+          result: currentPayment.result
+        })
+      } else if (currentPayment?.status === 'FAILED' || (error && !isInProgress)) {
+        cleanup?.()
+        clearTimeout(timeoutId)
+        resolve({
+          status: 'FAILED',
+          error: error || 'Payment failed'
+        })
+      }
+    }
+
+    const unsubscribePayment = subscribeStateKey('currentPayment', checkAndResolve)
+    const unsubscribeError = subscribeStateKey('error', checkAndResolve)
+    const unsubscribeProgress = subscribeStateKey('isPaymentInProgress', checkAndResolve)
+
+    cleanup = (): void => {
+      unsubscribePayment()
+      unsubscribeError()
+      unsubscribeProgress()
+    }
+
+    // Check immediately in case already completed
+    checkAndResolve()
+  })
 }
 
 export function getAvailableExchanges(params?: GetExchangesParams) {

--- a/packages/pay/src/types/payment.ts
+++ b/packages/pay/src/types/payment.ts
@@ -1,7 +1,5 @@
-export type PaymentResultStatus = 'SUCCESS' | 'FAILED'
-
 export type PaymentResult = {
-  status: PaymentResultStatus
+  success: boolean
   result?: string
   error?: string
 }

--- a/packages/pay/src/types/payment.ts
+++ b/packages/pay/src/types/payment.ts
@@ -1,0 +1,7 @@
+export type PaymentResultStatus = 'SUCCESS' | 'FAILED'
+
+export type PaymentResult = {
+  status: PaymentResultStatus
+  result?: string
+  error?: string
+}


### PR DESCRIPTION
# Description

Changed the pay method to handle the success/error subscription internally and export single `pay` method that will resolve once the payment is completed.

Before:
```
  function handleSuccess(resultData: PayResult) {
    toast({
      title: 'Transaction successful',
      description: resultData,
      type: 'success'
    })
  }

  function handleError(errorData: AppKitPayErrorMessage) {
    toast({
      title: 'Transaction failed',
      description: errorData,
      type: 'error'
    })
  }

  const { open, isPending } = usePay({
    onSuccess: handleSuccess,
    onError: handleError
  })
  

 await open({
    recipient: paymentDetails.recipient,
    amount: paymentDetails.amount,
    paymentAsset: paymentDetails.asset
})

```

After:
```
const result = await pay({
  recipient: paymentDetails.recipient,
  amount: paymentDetails.amount,
  paymentAsset: paymentDetails.asset,
});

if (result.success) {
  toast({ title: "Payment Succeeded", type: "success" });
} else {
  toast({ title: "Payment Failed", type: "error" });
}
```

Additionally this handles 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
