### PR TITLE
chore: make close button not available on SIWXSignMessag screen

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-header/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-header/index.ts
@@ -170,29 +170,35 @@ export class W3mHeader extends LitElement {
 
   private rightHeaderTemplate() {
     const isSmartSessionsEnabled = OptionsController?.state?.features?.smartSessions
-
-    if (RouterController.state.view !== 'Account' || !isSmartSessionsEnabled) {
-      return this.closeButtonTemplate()
+    if (RouterController.state.view === 'Account' && isSmartSessionsEnabled) {
+      return html`<wui-flex>
+        ${this.smartSessionButtonTemplate()} ${this.closeButtonTemplate()}
+      </wui-flex> `
     }
 
-    return html`<wui-flex>
-      <wui-icon-link
-        icon="clock"
-        @click=${() => RouterController.push('SmartSessionList')}
-        data-testid="w3m-header-smart-sessions"
-      ></wui-icon-link>
-      ${this.closeButtonTemplate()}
-    </wui-flex> `
+    return this.closeButtonTemplate()
+  }
+
+  private smartSessionButtonTemplate() {
+    return html`<wui-icon-link
+      icon="clock"
+      @click=${() => RouterController.push('SmartSessionList')}
+      data-testid="w3m-header-smart-sessions"
+    ></wui-icon-link>`
   }
 
   private closeButtonTemplate() {
-    return html`
-      <wui-icon-link
-        icon="close"
-        @click=${this.onClose.bind(this)}
-        data-testid="w3m-header-close"
-      ></wui-icon-link>
-    `
+    if (RouterController.state.view !== 'SIWXSignMessage') {
+      return html`
+        <wui-icon-link
+          icon="close"
+          @click=${this.onClose.bind(this)}
+          data-testid="w3m-header-close"
+        ></wui-icon-link>
+      `
+    }
+
+    return null
   }
 
   private titleTemplate() {

--- a/packages/scaffold-ui/test/partials/w3m-header.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-header.test.ts
@@ -158,6 +158,16 @@ describe('W3mHeader', () => {
 
       expect(shakeSpy).toHaveBeenCalled()
     })
+
+    it('should not show close button in SIWXSignMessage view', async () => {
+      RouterController.state.view = 'SIWXSignMessage'
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const closeButton = HelpersUtil.getByTestId(element, 'w3m-header-close')
+      expect(closeButton).toBeFalsy()
+    })
   })
 
   describe('Smart Sessions', () => {


### PR DESCRIPTION
# Description

- Remove close button from the screen as closing is not a valid action

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
