### PR TITLE
chore: remove high entropy string warning from dangerfile

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -584,10 +584,6 @@ const secretPatterns = [
     description: 'API key with common prefix'
   },
   {
-    pattern: /\b(?=[A-Za-z0-9+/]{32,}=*)(?=.*[0-9+/=])[A-Za-z0-9+/]+=*\b/gu,
-    description: 'High‑entropy string'
-  },
-  {
     pattern: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/giu,
     description: 'UUID'
   },


### PR DESCRIPTION
# Description

Removing high entropy string warning from dangerfile. It doesn't provide any value and it causes clutter so more important warning could be missed because of it.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
