### PR TITLE
fix: `UpdateEmailWallet` view not opening when using `useAppKitUpdateEmail` hook

### DIFF
--- a/.changeset/eighty-states-wonder.md
+++ b/.changeset/eighty-states-wonder.md
@@ -1,0 +1,28 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the update email view would not open when using the `useAppKitUpdateEmail` hook

--- a/packages/controllers/src/utils/ConnectorControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectorControllerUtil.ts
@@ -331,9 +331,12 @@ export const ConnectorControllerUtil = {
 
     const initialEmail = authConnector.provider.getEmail() ?? ''
 
-    RouterController.push('UpdateEmailWallet', {
-      email: initialEmail,
-      redirectView: undefined
+    await ModalController.open({
+      view: 'UpdateEmailWallet',
+      data: {
+        email: initialEmail,
+        redirectView: undefined
+      }
     })
 
     return new Promise((resolve, reject) => {

--- a/packages/controllers/tests/utils/ConnectorControllerUtil.test.ts
+++ b/packages/controllers/tests/utils/ConnectorControllerUtil.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { type ChainNamespace } from '@reown/appkit-common'
+import { type ChainNamespace, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 
+import { type AuthConnector, StorageUtil } from '../../exports/index.js'
 import { ConnectorController } from '../../src/controllers/ConnectorController.js'
+import { ModalController } from '../../src/controllers/ModalController.js'
 import { ConnectorControllerUtil } from '../../src/utils/ConnectorControllerUtil.js'
 
 describe('checkNamespaceConnectorId', () => {
@@ -22,5 +24,34 @@ describe('checkNamespaceConnectorId', () => {
 
     const result = ConnectorControllerUtil.checkNamespaceConnectorId(namespace, connectorId)
     expect(result).toBe(false)
+  })
+})
+
+describe('updateEmail', () => {
+  it('should open "UpdateEmailWallet" view', async () => {
+    const email = 'test@test.com'
+
+    const openSpy = vi.spyOn(ModalController, 'open')
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue({
+      id: CommonConstantsUtil.CONNECTOR_ID.AUTH,
+      provider: {
+        getEmail: () => email
+      }
+    } as unknown as AuthConnector)
+    vi.spyOn(StorageUtil, 'getConnectedConnectorId').mockReturnValue(
+      CommonConstantsUtil.CONNECTOR_ID.AUTH
+    )
+
+    ConnectorControllerUtil.updateEmail()
+
+    await vi.waitFor(() =>
+      expect(openSpy).toHaveBeenCalledWith({
+        view: 'UpdateEmailWallet',
+        data: {
+          email: email,
+          redirectView: undefined
+        }
+      })
+    )
   })
 })


### PR DESCRIPTION
# Description

Fixed an issue where `UpdateEmailWallet` view would not open when using the `useAppKitUpdateEmail` hook

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3346

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
