### PR TITLE
chore: fix missing `address` in WC success event

### DIFF
--- a/.changeset/fifty-coats-camp.md
+++ b/.changeset/fifty-coats-camp.md
@@ -1,0 +1,29 @@
+---
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where WalletConnect connections didn't include the `address` value when sending the `CONNECT_SUCCESS` event

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1550,8 +1550,10 @@ export abstract class AppKitBaseClient {
           onDisplayUri: uri => {
             ConnectionController.setUri(uri)
           },
-          onConnect: () => {
-            ConnectionController.finalizeWcConnection()
+          onConnect: accounts => {
+            const { address } = CoreHelperUtil.getAccount(accounts[0])
+
+            ConnectionController.finalizeWcConnection(address)
           },
           onDisconnect: () => {
             if (ChainController.state.noAdapters) {

--- a/packages/appkit/tests/client/walletconnect-events.test.ts
+++ b/packages/appkit/tests/client/walletconnect-events.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { ChainController, ConnectionController } from '@reown/appkit-controllers'
+import { ChainController, ConnectionController, CoreHelperUtil } from '@reown/appkit-controllers'
 
 import { AppKit } from '../../src/client/appkit.js'
 import { mainnet, sepolia } from '../mocks/Networks.js'
@@ -92,6 +92,10 @@ describe('WalletConnect Events', () => {
 
   describe('connect', () => {
     it('should call finalizeWcConnection once connected', async () => {
+      vi.spyOn(CoreHelperUtil, 'getAccount').mockReturnValueOnce({
+        address: '0x123',
+        chainId: '1'
+      })
       const finalizeWcConnectionSpy = vi
         .spyOn(ConnectionController, 'finalizeWcConnection')
         .mockReturnValueOnce()
@@ -114,7 +118,7 @@ describe('WalletConnect Events', () => {
 
       connectCallback()
 
-      expect(finalizeWcConnectionSpy).toHaveBeenCalledOnce()
+      expect(finalizeWcConnectionSpy).toHaveBeenCalledWith('0x123')
     })
   })
 })

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -363,7 +363,7 @@ const controller = {
     wcConnectionPromise = undefined
   },
 
-  finalizeWcConnection() {
+  finalizeWcConnection(address?: string) {
     const { wcLinking, recentWallet } = ConnectionController.state
 
     if (wcLinking) {
@@ -377,6 +377,7 @@ const controller = {
     EventsController.sendEvent({
       type: 'track',
       event: 'CONNECT_SUCCESS',
+      address,
       properties: {
         method: wcLinking ? 'mobile' : 'qrcode',
         name: RouterController.state.data?.wallet?.name || 'Unknown',

--- a/packages/controllers/src/controllers/EventsController.ts
+++ b/packages/controllers/src/controllers/EventsController.ts
@@ -51,7 +51,8 @@ export const EventsController = {
 
   async _sendAnalyticsEvent(payload: EventsControllerState) {
     try {
-      const address = AccountController.state.address
+      const address =
+        'address' in payload.data ? payload.data.address : AccountController.state.address
       if (excluded.includes(payload.data.event) || typeof window === 'undefined') {
         return
       }

--- a/packages/controllers/src/controllers/EventsController.ts
+++ b/packages/controllers/src/controllers/EventsController.ts
@@ -51,8 +51,12 @@ export const EventsController = {
 
   async _sendAnalyticsEvent(payload: EventsControllerState) {
     try {
-      const address =
-        'address' in payload.data ? payload.data.address : AccountController.state.address
+      let address = AccountController.state.address
+
+      if ('address' in payload.data && payload.data.address) {
+        address = payload.data.address
+      }
+
       if (excluded.includes(payload.data.event) || typeof window === 'undefined') {
         return
       }


### PR DESCRIPTION
# Description

Fixed an issue where WalletConnect connections didn't include the `address` value when sending the `CONNECT_SUCCESS` event

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3440

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
