### PR TITLE
refactor: update OKX and Unisat connectors to pass signInputs to wallet provider's `signPsbt` method

### DIFF
--- a/.changeset/wicked-nails-mix.md
+++ b/.changeset/wicked-nails-mix.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+---
+
+Refactors OKX and Unisat connectors to pass signInputs to wallet provider's `signPsbt` method

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,7 @@ updates:
     labels:
       - 'chore: update third party dependencies for AppKit Lab'
     groups:
-      # All @reown/* dependencies in any package.json in the repo
-      'demo-third-parties':
+      'lab-third-parties':
         dependency-type: 'production'
         patterns:
           - '@bitcoinerlab/*'
@@ -56,7 +55,6 @@ updates:
     labels:
       - 'chore: update third party dependencies for AppKit Demo'
     groups:
-      # All @reown/* dependencies in any package.json in the repo
       'demo-third-parties':
         dependency-type: 'production'
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,66 @@ updates:
           - 'viem'
           - '@wagmi/*'
   - package-ecosystem: 'npm'
+    directory: '/apps/laboratory'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'chore: update third party dependencies for AppKit Lab'
+    groups:
+      # All @reown/* dependencies in any package.json in the repo
+      'demo-third-parties':
+        dependency-type: 'production'
+        patterns:
+          - '@bitcoinerlab/*'
+          - '@chakra-ui/*'
+          - '@coinbase/*'
+          - '@safe-global/*'
+          - '@tanstack/*'
+          - '@sentry/*'
+          - '@wallet-standard/*'
+          - 'axios'
+          - 'bitcoinjs-lib'
+          - 'bs58'
+          - 'date-fns'
+          - 'framer-motion'
+          - 'next'
+          - 'next-auth'
+          - 'react-icons'
+          - 'rpc-websockets'
+          - 'webauthn-p256'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
+  - package-ecosystem: 'npm'
     directory: '/apps/demo'
     schedule:
       interval: 'weekly'
     labels:
-      - 'chore: update `@reown/*` dependencies for AppKit Demo'
+      - 'chore: update third party dependencies for AppKit Demo'
     groups:
       # All @reown/* dependencies in any package.json in the repo
-      'reown-appkit':
+      'demo-third-parties':
         dependency-type: 'production'
         patterns:
           - '@reown/*'
+          - '@radix-ui/*'
+          - '@dnd-kit/*'
+          - '@hookform/resolvers'
+          - '@next/third-parties'
+          - '@sentry/*'
+          - '@solana/web3.js'
+          - '@tanstack/react-query'
+          - 'autoprefixer'
+          - 'class-variance-authority'
+          - 'classnames'
+          - 'clsx'
+          - 'next'
+          - 'next-themes'
+          - 'react'
+          - 'react-dom'
+          - 'sonner'
+          - 'tailwind-merge'
+          - 'tailwindcss-animate'
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']

--- a/packages/adapters/bitcoin/src/connectors/LeatherConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/LeatherConnector.ts
@@ -69,12 +69,15 @@ export class LeatherConnector extends SatsConnectConnector {
 
   public override async signPSBT({
     psbt,
-    broadcast = false
+    broadcast = false,
+    signInputs
   }: BitcoinConnector.SignPSBTParams): Promise<BitcoinConnector.SignPSBTResponse> {
     const params: LeatherConnector.SignPSBTParams = {
       hex: Buffer.from(psbt, 'base64').toString('hex'),
       network: this.getNetwork(),
-      broadcast
+      broadcast,
+      signAtIndex: signInputs.map(input => input.index),
+      allowedSighash: signInputs.flatMap(input => input.sighashTypes)
     }
 
     // @ts-expect-error - expected LeatherWallet params don't match sats-connect

--- a/packages/adapters/bitcoin/src/connectors/LeatherConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/LeatherConnector.ts
@@ -72,12 +72,13 @@ export class LeatherConnector extends SatsConnectConnector {
     broadcast = false,
     signInputs
   }: BitcoinConnector.SignPSBTParams): Promise<BitcoinConnector.SignPSBTResponse> {
+    const signInputObj = signInputs?.[0]
     const params: LeatherConnector.SignPSBTParams = {
       hex: Buffer.from(psbt, 'base64').toString('hex'),
       network: this.getNetwork(),
       broadcast,
-      signAtIndex: signInputs.map(input => input.index),
-      allowedSighash: signInputs.flatMap(input => input.sighashTypes)
+      signAtIndex: signInputObj?.index,
+      allowedSighash: signInputObj?.sighashTypes
     }
 
     // @ts-expect-error - expected LeatherWallet params don't match sats-connect

--- a/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
@@ -15,6 +15,11 @@ const OKX_NETWORK_KEYS = {
   [bitcoinTestnet.caipNetworkId]: 'bitcoinTestnet'
 } as const
 
+type OKXSignPSBTOptions = {
+  toSignInputs: Omit<BitcoinConnector.SignPSBTParams['signInputs'][number], 'useTweakedSigner'>[]
+  autoFinalized?: boolean
+}
+
 export class OKXConnector extends ProviderEventEmitter implements BitcoinConnector {
   public readonly id = 'OKX'
   public readonly name = 'OKX Wallet'
@@ -113,14 +118,16 @@ export class OKXConnector extends ProviderEventEmitter implements BitcoinConnect
   ): Promise<BitcoinConnector.SignPSBTResponse> {
     const psbtHex = Buffer.from(params.psbt, 'base64').toString('hex')
 
-    let options
+    let options: OKXSignPSBTOptions | undefined = undefined
     if (params.signInputs?.length > 0) {
       options = {
         autoFinalized: false,
         toSignInputs: params.signInputs.map(input => ({
           index: input.index,
           address: input.address,
-          sighashTypes: input.sighashTypes
+          sighashTypes: input.sighashTypes,
+          publicKey: input.publicKey,
+          disableTweakSigner: input.disableTweakSigner
         }))
       }
     }

--- a/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/OKXConnector.ts
@@ -15,11 +15,6 @@ const OKX_NETWORK_KEYS = {
   [bitcoinTestnet.caipNetworkId]: 'bitcoinTestnet'
 } as const
 
-type OKXSignPSBTOptions = {
-  toSignInputs: Omit<BitcoinConnector.SignPSBTParams['signInputs'][number], 'useTweakedSigner'>[]
-  autoFinalized?: boolean
-}
-
 export class OKXConnector extends ProviderEventEmitter implements BitcoinConnector {
   public readonly id = 'OKX'
   public readonly name = 'OKX Wallet'
@@ -118,7 +113,7 @@ export class OKXConnector extends ProviderEventEmitter implements BitcoinConnect
   ): Promise<BitcoinConnector.SignPSBTResponse> {
     const psbtHex = Buffer.from(params.psbt, 'base64').toString('hex')
 
-    let options: OKXSignPSBTOptions | undefined = undefined
+    let options: OKXConnector.SignPSBTParams | undefined = undefined
     if (params.signInputs?.length > 0) {
       options = {
         autoFinalized: false,
@@ -269,4 +264,9 @@ export namespace OKXConnector {
   }
 
   export type GetWalletParams = Omit<ConstructorParams, 'wallet' | 'imageUrl'>
+
+  export type SignPSBTParams = {
+    toSignInputs: Omit<BitcoinConnector.SignPSBTParams['signInputs'][number], 'useTweakedSigner'>[]
+    autoFinalized?: boolean
+  }
 }

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
@@ -9,6 +9,11 @@ import { ProviderEventEmitter } from '../../utils/ProviderEventEmitter.js'
 import { UnitsUtil } from '../../utils/UnitsUtil.js'
 import type { UnisatConnector as UnisatConnectorTypes } from './types.js'
 
+type UnisatSignPSBTOptions = {
+  toSignInputs: BitcoinConnector.SignPSBTParams['signInputs']
+  autoFinalized?: boolean
+}
+
 export class UnisatConnector extends ProviderEventEmitter implements BitcoinConnector {
   public id: UnisatConnectorTypes.Id
   public name
@@ -115,14 +120,17 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
   ): Promise<BitcoinConnector.SignPSBTResponse> {
     const psbtHex = Buffer.from(params.psbt, 'base64').toString('hex')
 
-    let options
+    let options: UnisatSignPSBTOptions | undefined = undefined
     if (params.signInputs?.length > 0) {
       options = {
         autoFinalized: false,
         toSignInputs: params.signInputs.map(input => ({
           index: input.index,
           address: input.address,
-          sighashTypes: input.sighashTypes
+          sighashTypes: input.sighashTypes,
+          publicKey: input.publicKey,
+          disableTweakSigner: input.disableTweakSigner,
+          useTweakedSigner: input.useTweakedSigner
         }))
       }
     }

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
@@ -9,11 +9,6 @@ import { ProviderEventEmitter } from '../../utils/ProviderEventEmitter.js'
 import { UnitsUtil } from '../../utils/UnitsUtil.js'
 import type { UnisatConnector as UnisatConnectorTypes } from './types.js'
 
-type UnisatSignPSBTOptions = {
-  toSignInputs: BitcoinConnector.SignPSBTParams['signInputs']
-  autoFinalized?: boolean
-}
-
 export class UnisatConnector extends ProviderEventEmitter implements BitcoinConnector {
   public id: UnisatConnectorTypes.Id
   public name
@@ -120,7 +115,7 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
   ): Promise<BitcoinConnector.SignPSBTResponse> {
     const psbtHex = Buffer.from(params.psbt, 'base64').toString('hex')
 
-    let options: UnisatSignPSBTOptions | undefined = undefined
+    let options: UnisatConnectorTypes.SignPSBTParams | undefined = undefined
     if (params.signInputs?.length > 0) {
       options = {
         autoFinalized: false,

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector/types.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector/types.ts
@@ -1,4 +1,5 @@
 import type { CaipNetwork } from '@reown/appkit-common'
+import type { BitcoinConnector } from '@reown/appkit-utils/bitcoin'
 
 export namespace UnisatConnector {
   export type Chain = 'BITCOIN_MAINNET' | 'BITCOIN_TESTNET' | 'FRACTAL_BITCOIN_MAINNET'
@@ -71,4 +72,9 @@ export namespace UnisatConnector {
   }
 
   export type GetWalletParams = Omit<ConstructorParams, 'wallet'>
+
+  export type SignPSBTParams = {
+    toSignInputs: BitcoinConnector.SignPSBTParams['signInputs']
+    autoFinalized?: boolean
+  }
 }

--- a/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
@@ -184,6 +184,62 @@ describe('UnisatConnector', () => {
       expect(result).toEqual({ psbt: 'bW9ja19wc2J0', txid: 'mock_txhash' })
       expect(wallet.pushPsbt).toHaveBeenCalled()
     })
+
+    it('should sign a PSBT with partial signing without broadcast', async () => {
+      const signInputs = [
+        {
+          index: 0,
+          address: 'mock_address',
+          publicKey: 'mock_pubkey',
+          sighashTypes: [1, 3],
+          disableTweakSigner: true,
+          useTweakedSigner: false
+        }
+      ]
+      const psbtBase64 = Buffer.from('mock_psbt').toString('base64')
+      const result = await connector.signPSBT({
+        psbt: psbtBase64,
+        signInputs,
+        broadcast: false
+      })
+      expect(result).toEqual({ psbt: 'bW9ja19wc2J0', txid: undefined })
+      expect(wallet.signPsbt).toHaveBeenCalledWith(
+        Buffer.from(psbtBase64, 'base64').toString('hex'),
+        {
+          autoFinalized: false,
+          toSignInputs: [
+            {
+              index: 0,
+              address: 'mock_address',
+              publicKey: 'mock_pubkey',
+              sighashTypes: [1, 3],
+              disableTweakSigner: true,
+              useTweakedSigner: false
+            }
+          ]
+        }
+      )
+      expect(wallet.pushPsbt).not.toHaveBeenCalled()
+    })
+    it('should throw error when trying to broadcast with partial signing', async () => {
+      const signInputs = [
+        {
+          index: 0,
+          address: 'mock_address',
+          publicKey: 'mock_pubkey',
+          sighashTypes: [1, 3],
+          disableTweakSigner: true,
+          useTweakedSigner: false
+        }
+      ]
+      await expect(
+        connector.signPSBT({
+          psbt: Buffer.from('mock_psbt').toString('base64'),
+          signInputs,
+          broadcast: true
+        })
+      ).rejects.toThrow('Broadcast not supported for partial signing')
+    })
   })
 
   describe('request', () => {

--- a/packages/appkit-utils/src/bitcoin/BitcoinTypesUtil.ts
+++ b/packages/appkit-utils/src/bitcoin/BitcoinTypesUtil.ts
@@ -73,6 +73,8 @@ export namespace BitcoinConnector {
    * Parameters for signing a PSBT. The names or types of these parameters may vary across different providers. Refer to the links below for more information:
    * @link https://docs.unisat.io/dev/open-api-documentation/unisat-wallet#signpsbt
    * @link https://web3.okx.com/build/dev-docs/sdks/chains/bitcoin/provider#signpsbt
+   * @link https://developer.onekey.so/connect-to-software/webapp-connect-onekey/btc/api-reference/signpsbt
+   * @link https://leather.gitbook.io/developers/bitcoin-methods/signpsbt
    */
   export type SignPSBTParams = {
     /**

--- a/packages/appkit-utils/src/bitcoin/BitcoinTypesUtil.ts
+++ b/packages/appkit-utils/src/bitcoin/BitcoinTypesUtil.ts
@@ -69,6 +69,11 @@ export namespace BitcoinConnector {
     recipient: string
   }
 
+  /**
+   * Parameters for signing a PSBT. The names or types of these parameters may vary across different providers. Refer to the links below for more information:
+   * @link https://docs.unisat.io/dev/open-api-documentation/unisat-wallet#signpsbt
+   * @link https://web3.okx.com/build/dev-docs/sdks/chains/bitcoin/provider#signpsbt
+   */
   export type SignPSBTParams = {
     /**
      * The PSBT to be signed, string base64 encoded
@@ -87,6 +92,21 @@ export namespace BitcoinConnector {
        * Specifies which part(s) of the transaction the signature commits to
        */
       sighashTypes: number[]
+      /**
+       * (Optional) The public key corresponding to the private key to use for signing.
+       * At least specify either an address or a public key.
+       */
+      publicKey?: string
+      /**
+       * (Optional) When signing and unlocking Taproot addresses, the tweakSigner is used by default for signature generation.
+       * Enabling this allows for signing with the original private key.
+       */
+      disableTweakSigner?: boolean
+      /**
+       * (Optional) By setting useTweakedSigner, you can forcibly decide whether or not to use tweakedSigner.
+       * It has a higher priority than disableTweakSigner.
+       */
+      useTweakedSigner?: boolean
     }[]
 
     /**

--- a/packages/appkit-utils/tsconfig.json
+++ b/packages/appkit-utils/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist/esm",
-    "declarationDir": "./dist/types"
+    "declarationDir": "./dist/types",
+    "removeComments": false
   },
   "extends": "../../tsconfig.json",
   "include": ["exports", "src", "package.json", "tests"]


### PR DESCRIPTION
# Description

Refactors OKX and Unisat connectors to pass signInputs to wallet provider's `signPsbt` method

### Resources

- https://docs.unisat.io/dev/open-api-documentation/unisat-wallet#signpsbt
- https://web3.okx.com/build/dev-docs/sdks/chains/bitcoin/provider#signpsbt

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
