### PR TITLE
fix: secure site screens breaking in demo

### DIFF
--- a/apps/laboratory/src/components/Bitcoin/BitcoinSignPSBTTest.tsx
+++ b/apps/laboratory/src/components/Bitcoin/BitcoinSignPSBTTest.tsx
@@ -54,6 +54,8 @@ export function BitcoinSignPSBTTest() {
         utxos
       })
 
+ 
+
       params.broadcast = broadcast
 
       const signature = await walletProvider.signPSBT(params)

--- a/apps/laboratory/src/components/Bitcoin/BitcoinSignPSBTTest.tsx
+++ b/apps/laboratory/src/components/Bitcoin/BitcoinSignPSBTTest.tsx
@@ -54,8 +54,6 @@ export function BitcoinSignPSBTTest() {
         utxos
       })
 
- 
-
       params.broadcast = broadcast
 
       const signature = await walletProvider.signPSBT(params)

--- a/packages/scaffold-ui/src/views/w3m-approve-transaction-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-approve-transaction-view/index.ts
@@ -61,7 +61,7 @@ export class W3mApproveTransactionView extends LitElement {
 
     this.iframe.style.display = 'block'
     const container = this?.renderRoot?.querySelector('div') as HTMLDivElement
-    this.bodyObserver = new ResizeObserver(async entries => {
+    this.bodyObserver = new ResizeObserver(entries => {
       const contentBoxSize = entries?.[0]?.contentBoxSize
       const width = contentBoxSize?.[0]?.inlineSize
 
@@ -69,22 +69,7 @@ export class W3mApproveTransactionView extends LitElement {
 
       container.style.height = `${PAGE_HEIGHT}px`
       if (OptionsController.state.enableEmbedded) {
-        /*
-         * Wait for the resize to complete to avoid getting wrong rect sizes
-         * as its not updated yet when the animation is pending
-         */
-        await new Promise(resolve => {
-          setTimeout(resolve, 300)
-        })
-
-        const rect = this.getBoundingClientRect()
-
-        container.style.width = '100%'
-
-        this.iframe.style.left = `${rect.left}px`
-        this.iframe.style.top = `${rect.top}px`
-        this.iframe.style.width = `${rect.width}px`
-        this.iframe.style.height = `${rect.height}px`
+        this.updateFrameSizeForEmbeddedMode()
       } else if (width && width <= 430) {
         // Update container size to prevent the iframe from being cut off
         this.iframe.style.width = '100%'
@@ -133,6 +118,27 @@ export class W3mApproveTransactionView extends LitElement {
         w3mThemeVariables: getW3mThemeVariables(themeVariables, themeMode)
       })
     }
+  }
+
+  private async updateFrameSizeForEmbeddedMode() {
+    const container = this?.renderRoot?.querySelector('div') as HTMLDivElement
+
+    /*
+     * Wait for the resize to complete to avoid getting wrong rect sizes
+     * as it is not updated yet when the animation is pending
+     */
+    await new Promise(resolve => {
+      setTimeout(resolve, 300)
+    })
+
+    const rect = this.getBoundingClientRect()
+
+    container.style.width = '100%'
+
+    this.iframe.style.left = `${rect.left}px`
+    this.iframe.style.top = `${rect.top}px`
+    this.iframe.style.width = `${rect.width}px`
+    this.iframe.style.height = `${rect.height}px`
   }
 }
 

--- a/packages/scaffold-ui/src/views/w3m-approve-transaction-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-approve-transaction-view/index.ts
@@ -2,7 +2,12 @@ import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 
 import { getW3mThemeVariables } from '@reown/appkit-common'
-import { ConnectorController, ModalController, ThemeController } from '@reown/appkit-controllers'
+import {
+  ConnectorController,
+  ModalController,
+  OptionsController,
+  ThemeController
+} from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 
 import styles from './styles.js'
@@ -10,6 +15,9 @@ import styles from './styles.js'
 // -- Variables ------------------------------------------- //
 const PAGE_HEIGHT = 600
 const PAGE_WIDTH = 360
+const PAGE_WIDTH_EMBEDDED = 400
+const FIXED_LEFT_OFFSET = 22
+const FIXED_TOP_OFFSET = 287
 const HEADER_HEIGHT = 64
 
 @customElement('w3m-approve-transaction-view')
@@ -70,6 +78,11 @@ export class W3mApproveTransactionView extends LitElement {
         this.iframe.style.left = '0px'
         this.iframe.style.bottom = '0px'
         this.iframe.style.top = 'unset'
+      } else if (OptionsController.state.enableEmbedded) {
+        this.iframe.style.width = `${PAGE_WIDTH_EMBEDDED}px`
+        this.iframe.style.left = `calc(50% - ${FIXED_LEFT_OFFSET}px)`
+        this.iframe.style.top = `calc(50% - ${FIXED_TOP_OFFSET}px)`
+        this.iframe.style.bottom = 'unset'
       } else {
         this.iframe.style.width = `${PAGE_WIDTH}px`
         this.iframe.style.left = `calc(50% - ${PAGE_WIDTH / 2}px)`

--- a/packages/scaffold-ui/test/views/w3m-approve-transaction-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-approve-transaction-view.test.ts
@@ -1,0 +1,273 @@
+import { fixture } from '@open-wc/testing'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { html } from 'lit'
+
+import { type ThemeType, type ThemeVariables, getW3mThemeVariables } from '@reown/appkit-common'
+import {
+  type AuthConnector,
+  ConnectorController,
+  ModalController,
+  OptionsController,
+  ThemeController
+} from '@reown/appkit-controllers'
+
+import { W3mApproveTransactionView } from '../../src/views/w3m-approve-transaction-view/index'
+
+// --- Types ---------------------------------------------------- //
+interface MockResizeObserver extends ResizeObserver {
+  triggerCallback(entries: Partial<ResizeObserverEntry>[]): void
+}
+
+// --- Constants ---------------------------------------------------- //
+const FRAME_CONTAINER = '[data-ready]'
+const IFRAME_ID = 'w3m-iframe'
+
+const MOCK_AUTH_CONNECTOR = {
+  provider: {
+    syncTheme: vi.fn().mockResolvedValue(undefined)
+  }
+} as unknown as AuthConnector
+
+const MOCK_THEME_SNAPSHOT = {
+  themeMode: 'dark',
+  themeVariables: {
+    '--w3m-accent-color': '#3396ff',
+    '--w3m-background-color': '#000000'
+  }
+} as unknown as ReturnType<typeof ThemeController.getSnapshot>
+
+const MOCK_RECT = {
+  left: 100,
+  top: 200,
+  width: 400,
+  height: 600
+} as DOMRect
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    private callback: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
+
+    constructor(callback: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void) {
+      this.callback = callback
+    }
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+
+    triggerCallback(entries: Partial<ResizeObserverEntry>[]) {
+      const mockEntries = entries.map(entry => ({
+        contentBoxSize: entry.contentBoxSize || [],
+        borderBoxSize: entry.borderBoxSize || [],
+        contentRect: entry.contentRect || {
+          width: 0,
+          height: 0,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0
+        },
+        devicePixelContentBoxSize: entry.devicePixelContentBoxSize || [],
+        target: entry.target || document.body
+      })) as ResizeObserverEntry[]
+      this.callback(mockEntries, this)
+    }
+  }
+})
+
+beforeAll(() => {
+  const mockIframe = document.createElement('iframe')
+  mockIframe.id = IFRAME_ID
+  mockIframe.style.display = 'none'
+  document.body.appendChild(mockIframe)
+})
+
+describe('W3mApproveTransactionView - Basic Rendering', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      enableEmbedded: false
+    })
+
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(MOCK_AUTH_CONNECTOR)
+    vi.spyOn(ThemeController, 'getSnapshot').mockReturnValue(MOCK_THEME_SNAPSHOT)
+    vi.spyOn(ModalController, 'subscribeKey').mockReturnValue(() => {})
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should render basic structure with frame container', async () => {
+    const element = await fixture<W3mApproveTransactionView>(
+      html`<w3m-approve-transaction-view></w3m-approve-transaction-view>`
+    )
+    await element.updateComplete
+
+    const frameContainer = element.shadowRoot?.querySelector(FRAME_CONTAINER)
+
+    expect(frameContainer).not.toBeNull()
+    expect(frameContainer?.getAttribute('data-ready')).toBe('false')
+    expect(frameContainer?.id).toBe('w3m-frame-container')
+  })
+
+  it('should initialize with ready state as false', async () => {
+    const element = await fixture<W3mApproveTransactionView>(
+      html`<w3m-approve-transaction-view></w3m-approve-transaction-view>`
+    )
+    await element.updateComplete
+
+    expect(element.ready).toBe(false)
+  })
+
+  it('should subscribe to modal controller events on construction', async () => {
+    const element = await fixture<W3mApproveTransactionView>(
+      html`<w3m-approve-transaction-view></w3m-approve-transaction-view>`
+    )
+
+    await element.updateComplete
+
+    expect(ModalController.subscribeKey).toHaveBeenCalledWith('open', expect.any(Function))
+    expect(ModalController.subscribeKey).toHaveBeenCalledWith('shake', expect.any(Function))
+  })
+
+  it('should sync theme on first update', async () => {
+    const element = await fixture<W3mApproveTransactionView>(
+      html`<w3m-approve-transaction-view></w3m-approve-transaction-view>`
+    )
+
+    await element.updateComplete
+
+    expect(ConnectorController.getAuthConnector).toHaveBeenCalled()
+    expect(ThemeController.getSnapshot).toHaveBeenCalled()
+    expect(MOCK_AUTH_CONNECTOR.provider.syncTheme).toHaveBeenCalledWith({
+      themeVariables: MOCK_THEME_SNAPSHOT.themeVariables,
+      w3mThemeVariables: getW3mThemeVariables(
+        MOCK_THEME_SNAPSHOT.themeVariables as ThemeVariables,
+        MOCK_THEME_SNAPSHOT.themeMode as ThemeType
+      )
+    })
+  })
+})
+
+describe('W3mApproveTransactionView - Iframe Positioning Logic', () => {
+  let element: W3mApproveTransactionView
+  let mockIframe: HTMLIFrameElement
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    mockIframe = document.getElementById(IFRAME_ID) as HTMLIFrameElement
+
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      enableEmbedded: false
+    })
+
+    vi.spyOn(ConnectorController, 'getAuthConnector').mockReturnValue(MOCK_AUTH_CONNECTOR)
+    vi.spyOn(ThemeController, 'getSnapshot').mockReturnValue(MOCK_THEME_SNAPSHOT)
+    vi.spyOn(ModalController, 'subscribeKey').mockReturnValue(() => {})
+
+    element = await fixture<W3mApproveTransactionView>(
+      html`<w3m-approve-transaction-view></w3m-approve-transaction-view>`
+    )
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(MOCK_RECT)
+  })
+
+  it('should position iframe correctly for desktop view', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true })
+
+    await element.updateComplete
+
+    const resizeObserver = element['bodyObserver'] as MockResizeObserver
+
+    if (resizeObserver) {
+      const mockEntries = [
+        {
+          contentBoxSize: [{ inlineSize: 1200, blockSize: 800 }]
+        }
+      ]
+      await resizeObserver.triggerCallback(mockEntries)
+    }
+
+    expect(mockIframe.style.display).toBe('block')
+    expect(mockIframe.style.width).toBe('360px')
+    expect(mockIframe.style.left).toBe('calc(50% - 180px)')
+    expect(mockIframe.style.top).toBe('calc(50% - 268px)')
+    expect(mockIframe.style.bottom).toBe('unset')
+  })
+
+  it('should position iframe correctly for mobile view', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 400, writable: true })
+
+    await element.updateComplete
+
+    const resizeObserver = element['bodyObserver'] as MockResizeObserver
+    if (resizeObserver) {
+      const mockEntries = [
+        {
+          contentBoxSize: [{ inlineSize: 400, blockSize: 600 }]
+        }
+      ]
+      await resizeObserver.triggerCallback(mockEntries)
+    }
+
+    expect(mockIframe.style.display).toBe('block')
+    expect(mockIframe.style.width).toBe('100%')
+    expect(mockIframe.style.left).toBe('0px')
+    expect(mockIframe.style.bottom).toBe('0px')
+    expect(mockIframe.style.top).toBe('unset')
+  })
+
+  it('should position iframe correctly for embedded mode', async () => {
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      enableEmbedded: true
+    })
+
+    vi.spyOn(global, 'setTimeout').mockImplementation((callback: any) => {
+      callback()
+
+      return setTimeout(() => {}, 1)
+    })
+
+    await element.updateComplete
+
+    const resizeObserver = element['bodyObserver'] as MockResizeObserver
+    if (resizeObserver) {
+      const mockEntries = [
+        {
+          contentBoxSize: [{ inlineSize: 800, blockSize: 600 }]
+        }
+      ]
+      await resizeObserver.triggerCallback(mockEntries)
+    }
+
+    expect(mockIframe.style.display).toBe('block')
+    expect(mockIframe.style.left).toBe('100px')
+    expect(mockIframe.style.top).toBe('200px')
+    expect(mockIframe.style.width).toBe('400px')
+    expect(mockIframe.style.height).toBe('600px')
+  })
+
+  it('should set ready state to true after positioning', async () => {
+    await element.updateComplete
+
+    const resizeObserver = element['bodyObserver'] as MockResizeObserver
+
+    if (resizeObserver) {
+      const mockEntries = [
+        {
+          contentBoxSize: [{ inlineSize: 1200, blockSize: 800 }]
+        }
+      ]
+      await resizeObserver.triggerCallback(mockEntries)
+    }
+
+    expect(element.ready).toBe(true)
+  })
+})


### PR DESCRIPTION
# Description

Fixed an issue where secure site screens are breaking in demo

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3435

# Showcase (Optional)

<img width="467" height="709" alt="demo-auth-signing" src="https://github.com/user-attachments/assets/d9bd2930-a670-445a-b6f3-326c5bbb5a4e" />


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
