### PR TITLE
fix: social options cannot be toggled on demo

### DIFF
--- a/apps/demo/providers/appkit-context-provider.tsx
+++ b/apps/demo/providers/appkit-context-provider.tsx
@@ -242,7 +242,7 @@ export function ContextProvider({ children }: AppKitProviderProps) {
   }
 
   function updateSocials(enabled: boolean) {
-    if (enabled && !Array.isArray(appKit?.remoteFeatures.socials)) {
+    if (enabled) {
       updateRemoteFeatures({ socials: ConstantsUtil.DEFAULT_SOCIALS })
     } else if (!enabled) {
       updateRemoteFeatures({ socials: false })


### PR DESCRIPTION
# Description

Fixed an issue where social options couldn't be toggled on demo

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3061

# Showcase (Optional)

https://github.com/user-attachments/assets/e3baa767-c3fd-42bf-8cd5-c9a128423ad8

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
