### PR TITLE
fix: including wallet configuration

### DIFF
--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -85,12 +85,15 @@ export const ApiController = {
   },
 
   _getSdkProperties() {
-    const { projectId, sdkType, sdkVersion } = OptionsController.state
+    const { projectId, sdkType, sdkVersion, includeWalletIds, excludeWalletIds, featuredWalletIds } = OptionsController.state
 
     return {
       projectId,
       st: sdkType || 'appkit',
-      sv: sdkVersion || 'html-wagmi-4.2.2'
+      sv: sdkVersion || 'html-wagmi-4.2.2',
+      ...(includeWalletIds?.length && { includeWalletIds: includeWalletIds.join(',') }),
+      ...(excludeWalletIds?.length && { excludeWalletIds: excludeWalletIds.join(',') }),
+      ...(featuredWalletIds?.length && { featuredWalletIds: featuredWalletIds.join(',') })
     }
   },
 

--- a/packages/controllers/src/controllers/EventsController.ts
+++ b/packages/controllers/src/controllers/EventsController.ts
@@ -41,12 +41,15 @@ export const EventsController = {
   },
 
   getSdkProperties() {
-    const { projectId, sdkType, sdkVersion } = OptionsController.state
+    const { projectId, sdkType, sdkVersion, includeWalletIds, excludeWalletIds, featuredWalletIds } = OptionsController.state
 
     return {
       projectId,
       st: sdkType,
-      sv: sdkVersion || 'html-wagmi-4.2.2'
+      sv: sdkVersion || 'html-wagmi-4.2.2',
+      ...(includeWalletIds?.length && { includeWalletIds: includeWalletIds.join(',') }),
+      ...(excludeWalletIds?.length && { excludeWalletIds: excludeWalletIds.join(',') }),
+      ...(featuredWalletIds?.length && { featuredWalletIds: featuredWalletIds.join(',') })
     }
   },
 


### PR DESCRIPTION
# Description

Fixes the functionality that allows wallet connect with wagmi adapter to specify specific wallet ids using `featuredWalletIds` or `includeWalletIds`

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes [APKT-2997](https://linear.app/reown/issue/APKT-2997/bug-eip6963-and-injected-wallets-show-up-despite-being-disabled-also)
closes #4430 

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
