### PR TITLE
chore: add back button on connecting a disconnected WC wallet in multi-wallet

### DIFF
--- a/.changeset/swift-gifts-see.md
+++ b/.changeset/swift-gifts-see.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fixes issue where back button was not displayed on connecting a disconnected WC wallet in multi-wallet

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -533,7 +533,13 @@ const controller = {
         connector,
         closeModalOnConnect,
         onOpen(isMobile) {
-          ModalController.open({ view: isMobile ? 'AllWallets' : 'ConnectingWalletConnect' })
+          console.log('>> onOpen', isMobile, ModalController.state.open)
+          const view = isMobile ? 'AllWallets' : 'ConnectingWalletConnect'
+          if (ModalController.state.open) {
+            RouterController.push(view)
+          } else {
+            ModalController.open({ view })
+          }
         },
         onConnect() {
           RouterController.replace('ProfileWallets')


### PR DESCRIPTION
# Description

- When reconnecting a previously disconnected WC wallet, the back button was not visible on the QR Code view
- Add back button on connecting a disconnected WC wallet in multi-wallet

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes APKT-3389

# Showcase 

https://github.com/user-attachments/assets/708397f0-bbe6-4c5b-954c-e8673516a7df



# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
