### PR TITLE
fix: multichain state synchronization and solana send flow issues

### DIFF
--- a/.changeset/ripe-falcons-fix.md
+++ b/.changeset/ripe-falcons-fix.md
@@ -26,4 +26,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where using `<w3m-button>` with multichain didn't reflect the latest state changes and fixed send flow issues on Solana when using multichain
+Fixed an issue where using `<w3m-button>` with multichain didn't reflect the latest state changes and fixed send flow issues on solana when using multichain

--- a/.changeset/ripe-falcons-fix.md
+++ b/.changeset/ripe-falcons-fix.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where using `<w3m-button>` with multichain didn't reflect the latest state changes and fixed send flow issues on Solana when using multichain

--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -180,9 +180,11 @@ const controller = {
 
   async fetchTokenBalance(onError?: (error: unknown) => void): Promise<Balance[]> {
     state.loading = true
+    const namespace = ChainController.state.activeChain
     const chainId = ChainController.state.activeCaipNetwork?.caipNetworkId
     const chain = ChainController.state.activeCaipNetwork?.chainNamespace
-    const caipAddress = ChainController.state.activeCaipAddress
+    const caipAddress =
+      AccountController.getCaipAddress(namespace) ?? ChainController.state.activeCaipAddress
     const address = caipAddress ? CoreHelperUtil.getPlainAddress(caipAddress) : undefined
     if (
       state.lastRetry &&

--- a/packages/controllers/src/controllers/SwapController.ts
+++ b/packages/controllers/src/controllers/SwapController.ts
@@ -188,7 +188,9 @@ const controller = {
   },
 
   getParams() {
-    const caipAddress = ChainController.state.activeCaipAddress
+    const namespace = ChainController.state.activeChain
+    const caipAddress =
+      AccountController.getCaipAddress(namespace) ?? ChainController.state.activeCaipAddress
     const address = CoreHelperUtil.getPlainAddress(caipAddress)
     const networkAddress = getActiveNetworkTokenAddress()
     const connectorId = ConnectorController.getConnectorId(ChainController.state.activeChain)

--- a/packages/controllers/tests/controllers/SwapController.test.ts
+++ b/packages/controllers/tests/controllers/SwapController.test.ts
@@ -169,4 +169,64 @@ describe('SwapController', () => {
       onSuccess: onEmbeddedWalletApprovalSuccessSpy
     })
   })
+
+  describe('getParams()', () => {
+    it('should use AccountController.getCaipAddress before falling back to activeCaipAddress', () => {
+      const mockNamespace = ConstantsUtil.CHAIN.EVM
+      const mockCaipAddressFromAccount = 'eip155:1:0xAccountController'
+      const mockActiveCaipAddress = 'eip155:1:0xChainController'
+
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        ...ChainController.state,
+        activeChain: mockNamespace,
+        activeCaipAddress: mockActiveCaipAddress,
+        activeCaipNetwork: caipNetwork
+      })
+
+      const getCaipAddressSpy = vi
+        .spyOn(AccountController, 'getCaipAddress')
+        .mockReturnValue(mockCaipAddressFromAccount)
+
+      const params = SwapController.getParams()
+
+      expect(getCaipAddressSpy).toHaveBeenCalledWith(mockNamespace)
+      expect(params.fromCaipAddress).toBe(mockCaipAddressFromAccount)
+    })
+
+    it('should fallback to activeCaipAddress when AccountController.getCaipAddress returns undefined', () => {
+      const mockNamespace = ConstantsUtil.CHAIN.EVM
+      const mockActiveCaipAddress = 'eip155:1:0xFallback'
+
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        ...ChainController.state,
+        activeChain: mockNamespace,
+        activeCaipAddress: mockActiveCaipAddress,
+        activeCaipNetwork: caipNetwork
+      })
+
+      const getCaipAddressSpy = vi
+        .spyOn(AccountController, 'getCaipAddress')
+        .mockReturnValue(undefined)
+
+      const params = SwapController.getParams()
+
+      expect(getCaipAddressSpy).toHaveBeenCalledWith(mockNamespace)
+      expect(params.fromCaipAddress).toBe(mockActiveCaipAddress)
+    })
+
+    it('should throw error when no address is available from either source', () => {
+      const mockNamespace = ConstantsUtil.CHAIN.EVM
+
+      vi.spyOn(ChainController, 'state', 'get').mockReturnValue({
+        ...ChainController.state,
+        activeChain: mockNamespace,
+        activeCaipAddress: undefined,
+        activeCaipNetwork: caipNetwork
+      })
+
+      vi.spyOn(AccountController, 'getCaipAddress').mockReturnValue(undefined)
+
+      expect(() => SwapController.getParams()).toThrow('No address found to swap the tokens from.')
+    })
+  })
 })

--- a/packages/scaffold-ui/src/modal/w3m-button/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-button/index.ts
@@ -36,14 +36,11 @@ class W3mButtonBase extends LitElement {
   @state() private caipAddress: CaipAddress | undefined
 
   // -- Lifecycle ----------------------------------------- //
-  public override connectedCallback() {
-    super.connectedCallback()
+  public override firstUpdated() {
     this.caipAddress = this.namespace
       ? ChainController.state.chains.get(this.namespace)?.accountState?.caipAddress
       : ChainController.state.activeCaipAddress
-  }
 
-  public override firstUpdated() {
     if (this.namespace) {
       this.unsubscribe.push(
         ChainController.subscribeChainProp(


### PR DESCRIPTION
# Description

Fixed an issue where using `<w3m-button>` with multichain didn't reflect the latest state changes and fixed send flow issues on solana when using multichain

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3359

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [x] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
