### PR TITLE
fix: redirect to previous screen and show proper error message if connection request was rejected on mobile

### DIFF
--- a/.changeset/little-boats-lead.md
+++ b/.changeset/little-boats-lead.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where rejecting a connection request from a mobile wallet would not redirect back to the previous screen to allow re-initiating the connection

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -25,7 +25,7 @@ import {
 } from '@wagmi/core'
 import { type Chain } from '@wagmi/core/chains'
 import type UniversalProvider from '@walletconnect/universal-provider'
-import { type Address, type Hex, formatUnits, parseUnits } from 'viem'
+import { type Address, type Hex, UserRejectedRequestError, formatUnits, parseUnits } from 'viem'
 
 import { AppKit, type AppKitOptions } from '@reown/appkit'
 import type {
@@ -563,26 +563,34 @@ export class WagmiAdapter extends AdapterBlueprint {
   }
 
   public override async connectWalletConnect(chainId?: number | string) {
-    // Attempt one click auth first, if authenticated, still connect with wagmi to store the session
-    const walletConnectConnector = this.getWalletConnectConnector()
-    await walletConnectConnector.authenticate()
+    try {
+      // Attempt one click auth first, if authenticated, still connect with wagmi to store the session
+      const walletConnectConnector = this.getWalletConnectConnector()
+      await walletConnectConnector.authenticate()
 
-    const wagmiConnector = this.getWagmiConnector('walletConnect')
+      const wagmiConnector = this.getWagmiConnector('walletConnect')
 
-    if (!wagmiConnector) {
-      throw new Error('UniversalAdapter:connectWalletConnect - connector not found')
+      if (!wagmiConnector) {
+        throw new Error('UniversalAdapter:connectWalletConnect - connector not found')
+      }
+
+      const res = await connect(this.wagmiConfig, {
+        connector: wagmiConnector,
+        chainId: chainId ? Number(chainId) : undefined
+      })
+
+      if (res.chainId !== Number(chainId)) {
+        await switchChain(this.wagmiConfig, { chainId: res.chainId })
+      }
+
+      return { clientId: await walletConnectConnector.provider.client.core.crypto.getClientId() }
+    } catch (err) {
+      if (err instanceof UserRejectedRequestError) {
+        throw new Error(err.shortMessage)
+      }
+
+      throw err
     }
-
-    const res = await connect(this.wagmiConfig, {
-      connector: wagmiConnector,
-      chainId: chainId ? Number(chainId) : undefined
-    })
-
-    if (res.chainId !== Number(chainId)) {
-      await switchChain(this.wagmiConfig, { chainId: res.chainId })
-    }
-
-    return { clientId: await walletConnectConnector.provider.client.core.crypto.getClientId() }
   }
 
   public async connect(

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -94,8 +94,12 @@ export interface DisconnectParameters {
   initialDisconnect?: boolean
 }
 
+interface ConnectWalletConnectParameters {
+  cachePromise?: boolean
+}
+
 export interface ConnectionControllerClient {
-  connectWalletConnect?: () => Promise<void>
+  connectWalletConnect?: (params?: ConnectWalletConnectParameters) => Promise<void>
   disconnect: (params?: DisconnectParameters) => Promise<void>
   signMessage: (message: string) => Promise<string>
   sendTransaction: (args: SendTransactionArgs) => Promise<string | null>
@@ -211,8 +215,12 @@ const controller = {
       .some(({ connectorId: _connectorId }) => _connectorId === connectorId)
   },
 
-  async connectWalletConnect() {
-    if (CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos())) {
+  async connectWalletConnect({ cachePromise = true }: ConnectWalletConnectParameters = {}) {
+    const shouldCachePromise =
+      cachePromise &&
+      (CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos()))
+
+    if (shouldCachePromise) {
       if (wcConnectionPromise) {
         await wcConnectionPromise
         wcConnectionPromise = undefined

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -95,7 +95,7 @@ export interface DisconnectParameters {
 }
 
 interface ConnectWalletConnectParameters {
-  cachePromise?: boolean
+  cache?: 'auto' | 'always' | 'never'
 }
 
 export interface ConnectionControllerClient {
@@ -215,12 +215,11 @@ const controller = {
       .some(({ connectorId: _connectorId }) => _connectorId === connectorId)
   },
 
-  async connectWalletConnect({ cachePromise = true }: ConnectWalletConnectParameters = {}) {
-    const shouldCachePromise =
-      cachePromise &&
-      (CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos()))
+  async connectWalletConnect({ cache = 'auto' }: ConnectWalletConnectParameters = {}) {
+    const isInTelegramOrSafariIos =
+      CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos())
 
-    if (shouldCachePromise) {
+    if (cache === 'always' || (cache === 'auto' && isInTelegramOrSafariIos)) {
       if (wcConnectionPromise) {
         await wcConnectionPromise
         wcConnectionPromise = undefined

--- a/packages/controllers/tests/controllers/ConnectionController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectionController.test.ts
@@ -220,14 +220,14 @@ describe('ConnectionController', () => {
     expect(ConnectionController.state.status).toEqual('connected')
   })
 
-  it('should handle connectWalletConnect when cachePromise argument is false', async () => {
+  it('should handle connectWalletConnect when cache argument is "never"', async () => {
     vi.spyOn(CoreHelperUtil, 'isTelegram').mockReturnValue(true)
     vi.spyOn(CoreHelperUtil, 'isSafari').mockReturnValue(true)
     vi.spyOn(CoreHelperUtil, 'isIos').mockReturnValue(true)
 
     const connectWalletConnectSpy = vi.spyOn(client, 'connectWalletConnect')
 
-    await ConnectionController.connectWalletConnect({ cachePromise: false })
+    await ConnectionController.connectWalletConnect({ cache: 'never' })
 
     expect(connectWalletConnectSpy).toHaveBeenCalledTimes(1)
   })

--- a/packages/controllers/tests/controllers/ConnectionController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectionController.test.ts
@@ -220,6 +220,18 @@ describe('ConnectionController', () => {
     expect(ConnectionController.state.status).toEqual('connected')
   })
 
+  it('should handle connectWalletConnect when cachePromise argument is false', async () => {
+    vi.spyOn(CoreHelperUtil, 'isTelegram').mockReturnValue(true)
+    vi.spyOn(CoreHelperUtil, 'isSafari').mockReturnValue(true)
+    vi.spyOn(CoreHelperUtil, 'isIos').mockReturnValue(true)
+
+    const connectWalletConnectSpy = vi.spyOn(client, 'connectWalletConnect')
+
+    await ConnectionController.connectWalletConnect({ cachePromise: false })
+
+    expect(connectWalletConnectSpy).toHaveBeenCalledTimes(1)
+  })
+
   it('should set connections for a namespace', () => {
     const connections = [{ connectorId: 'test-connector', accounts: [{ address: '0x123' }] }]
     ConnectionController.setConnections(connections, chain)

--- a/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
@@ -99,7 +99,7 @@ export class W3mConnectingWcView extends LitElement {
         )
         const isMultiWalletEnabled = this.remoteFeatures?.multiWallet
         const hasConnections = connectionsByNamespace.length > 0
-        await ConnectionController.connectWalletConnect({ cachePromise: false })
+        await ConnectionController.connectWalletConnect({ cache: 'never' })
 
         if (!this.isSiwxEnabled) {
           if (hasConnections && isMultiWalletEnabled) {

--- a/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-wc-view/index.ts
@@ -99,7 +99,7 @@ export class W3mConnectingWcView extends LitElement {
         )
         const isMultiWalletEnabled = this.remoteFeatures?.multiWallet
         const hasConnections = connectionsByNamespace.length > 0
-        await ConnectionController.connectWalletConnect()
+        await ConnectionController.connectWalletConnect({ cachePromise: false })
 
         if (!this.isSiwxEnabled) {
           if (hasConnections && isMultiWalletEnabled) {


### PR DESCRIPTION
# Description

Fixed an issue where rejecting a connection request from a mobile wallet would not redirect back to the previous screen to allow re-initiating the connection

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3181
For GH issues: closes #...

# Showcase (Optional)

https://github.com/user-attachments/assets/bb5e1da7-e58c-4c06-b4ee-50d4ca1263c8

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
