### PR TITLE
fix: add better error message when reown authentication is not enabled

### DIFF
--- a/.changeset/polite-pianos-run.md
+++ b/.changeset/polite-pianos-run.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-siwx': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Add better error message when reown authentication is not enabled

--- a/packages/siwx/src/ui/w3m-data-capture-view/index.ts
+++ b/packages/siwx/src/ui/w3m-data-capture-view/index.ts
@@ -38,7 +38,7 @@ export class W3mDataCaptureView extends LitElement {
 
   public override connectedCallback() {
     if (!this.siwx || !(this.siwx instanceof ReownAuthentication)) {
-      SnackController.showError('ReownAuthentication is not initialized.')
+      SnackController.showError('ReownAuthentication is not initialized. Please contact support.')
     }
 
     super.connectedCallback()
@@ -230,6 +230,12 @@ export class W3mDataCaptureView extends LitElement {
   }
 
   private async onSubmit() {
+    if (!(this.siwx instanceof ReownAuthentication)) {
+      SnackController.showError('ReownAuthentication is not initialized. Please contact support.')
+
+      return
+    }
+
     const account = ChainController.getActiveCaipAddress()
 
     if (!account) {

--- a/packages/siwx/tests/ui/w3m-data-capture-view.test.ts
+++ b/packages/siwx/tests/ui/w3m-data-capture-view.test.ts
@@ -124,7 +124,7 @@ describe('W3mDataCaptureView', () => {
       await createView()
 
       expect(SnackController.showError).toHaveBeenCalledWith(
-        'ReownAuthentication is not initialized.'
+        'ReownAuthentication is not initialized. Please contact support.'
       )
     })
 
@@ -209,6 +209,31 @@ describe('W3mDataCaptureView', () => {
   })
 
   describe('Form Submission', () => {
+    it('should show error and abort when siwx is not an instance of ReownAuthentication on submit', async () => {
+      // Prepare view with invalid siwx
+      OptionsController.state.siwx = {} as any
+
+      const view = await createView()
+
+      // Set a valid email and attempt submit
+      const emailInput = HelpersUtil.querySelector(view, 'wui-email-input')
+      emailInput?.dispatchEvent(new CustomEvent('inputChange', { detail: 'test@example.com' }))
+      await view.updateComplete
+
+      // Spy on requestEmailOtp on prototype to detect accidental calls
+      const spy = vi.spyOn(ReownAuthentication.prototype as any, 'requestEmailOtp')
+
+      const submitButton = HelpersUtil.querySelector(view, 'wui-button[type="submit"]')
+      submitButton?.click()
+
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(SnackController.showError).toHaveBeenCalledWith(
+        'ReownAuthentication is not initialized. Please contact support.'
+      )
+      expect(spy).not.toHaveBeenCalled()
+      spy.mockRestore()
+    })
     it('should handle successful OTP request with UUID', async () => {
       mockSiwx.requestEmailOtp = vi.fn().mockResolvedValue({ uuid: 'test-uuid' })
 


### PR DESCRIPTION
# Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes DAS-752

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ x I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
