### PR TITLE
fix: allow sending spl solana tokens in send flow

### DIFF
--- a/.changeset/seven-rabbits-behave.md
+++ b/.changeset/seven-rabbits-behave.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-common': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where users could not send SPL solana tokens through the send flow

--- a/packages/common/src/utils/ConstantsUtil.ts
+++ b/packages/common/src/utils/ConstantsUtil.ts
@@ -65,6 +65,9 @@ export const ConstantsUtil = {
     // Arbitrum
     '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9'
   ],
+  SOLANA_SPL_TOKEN_ADDRESSES: {
+    SOL: 'So11111111111111111111111111111111111111112'
+  },
   HTTP_STATUS_CODES: {
     SERVER_ERROR: 500,
     TOO_MANY_REQUESTS: 429,

--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -322,8 +322,19 @@ const controller = {
       }
     })
 
+    let tokenMint: string | undefined = undefined
+
+    if (
+      SendController.state.token &&
+      CoreHelperUtil.isCaipAddress(SendController.state.token.address)
+    ) {
+      const [, , tokenMintSPLAdress] = SendController.state.token.address.split(':')
+      tokenMint = tokenMintSPLAdress
+    }
+
     await ConnectionController.sendTransaction({
       chainNamespace: 'solana',
+      tokenMint,
       to: SendController.state.receiverAddress,
       value: SendController.state.sendTokenAmount
     })

--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -328,8 +328,8 @@ const controller = {
       SendController.state.token &&
       CoreHelperUtil.isCaipAddress(SendController.state.token.address)
     ) {
-      const [, , tokenMintSPLAdress] = SendController.state.token.address.split(':')
-      tokenMint = tokenMintSPLAdress
+      const [, , tokenMintSPLAddress] = SendController.state.token.address.split(':')
+      tokenMint = tokenMintSPLAddress
     }
 
     await ConnectionController.sendTransaction({


### PR DESCRIPTION
# Description

Fixed an issue where users could not send SPL solana tokens through the send flow

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3625

# Showcase (Optional)

<img width="794" height="671" alt="Screenshot 2025-08-19 at 15 50 12" src="https://github.com/user-attachments/assets/f5caa149-62a6-4232-84c0-ab88ac81ec38" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
