### PR TITLE
refactor: remove redundant project id not configured error triggers

### DIFF
--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.7.19'
+export const PACKAGE_VERSION = '1.7.20'

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -243,7 +243,7 @@ export abstract class AppKitBaseClient {
           break
         }
         default:
-          return
+          break
       }
     }
   }

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -206,9 +206,7 @@ export abstract class AppKitBaseClient {
     try {
       const allowedOrigins = await ApiController.fetchAllowedOrigins()
 
-      if (!allowedOrigins || !CoreHelperUtil.isClient()) {
-        AlertController.open(ErrorUtil.ALERT_ERRORS.PROJECT_ID_NOT_CONFIGURED, 'error')
-
+      if (!CoreHelperUtil.isClient()) {
         return
       }
 
@@ -224,8 +222,6 @@ export abstract class AppKitBaseClient {
       }
     } catch (error) {
       if (!(error instanceof Error)) {
-        AlertController.open(ErrorUtil.ALERT_ERRORS.PROJECT_ID_NOT_CONFIGURED, 'error')
-
         return
       }
 
@@ -247,7 +243,7 @@ export abstract class AppKitBaseClient {
           break
         }
         default:
-          AlertController.open(ErrorUtil.ALERT_ERRORS.PROJECT_ID_NOT_CONFIGURED, 'error')
+          return
       }
     }
   }

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -32,11 +32,7 @@ describe('AppKitBaseClient.checkAllowedOrigins', () => {
     })
 
     Object.defineProperty(globalThis, 'window', {
-      value: {
-        location: {
-          origin: 'http://localhost:3000'
-        }
-      },
+      value: { location: { origin: 'https://appkit-lab.reown.com' } },
       writable: true
     })
   })

--- a/packages/appkit/tests/client/appkit-base-client.test.ts
+++ b/packages/appkit/tests/client/appkit-base-client.test.ts
@@ -125,7 +125,7 @@ describe('AppKitBaseClient.checkAllowedOrigins', () => {
     expect(alertSpy).not.toHaveBeenCalled()
   })
 
-  it.only('should show ORIGIN_NOT_ALLOWED alert when origin is not allowed', async () => {
+  it('should show ORIGIN_NOT_ALLOWED alert when origin is not allowed', async () => {
     vi.spyOn(ApiController, 'fetchAllowedOrigins').mockResolvedValueOnce(['https://example.com'])
     vi.spyOn(WcHelpersUtil, 'isOriginAllowed').mockReturnValueOnce(false as any)
     vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValueOnce(true)


### PR DESCRIPTION
# Description

In AppKit base client we have `checkAlloweOrigins` method where we call redundant `ErrorUtil.ALERT_ERRORS.PROJECT_ID_NOT_CONFIGURED` alerts:

- `!allowedOrigins || !CoreHelperUtil.isClient()` clause: The `!allowedOrigins` here is deadly code where it never goes falsy as we handle the errors on `fetchAllowedOrigins` method. If the error is not known, we return empty array, where it's not falsy. Only isClient() check left, and if the code runs on server side, we should not proceed running the function.
- As we handle errors on the `fetchAllowedOrigins` and return empty array for other types of errors, calling `ErrorUtil.ALERT_ERRORS.PROJECT_ID_NOT_CONFIGURED` on switch case's `default` is dead code.
 
## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
