### PR TITLE
fix: include correct user address in bitcoin walletconnect signing request

### DIFF
--- a/.changeset/ten-lights-watch.md
+++ b/.changeset/ten-lights-watch.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where bitcoin walletconnect signing requests did not include the correct user address

--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -1,7 +1,7 @@
 import UniversalProvider from '@walletconnect/universal-provider'
 
 import { AccountController, type RequestArguments, WcHelpersUtil } from '@reown/appkit'
-import type { CaipNetwork } from '@reown/appkit-common'
+import { type CaipNetwork, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 import { HelpersUtil } from '@reown/appkit-utils'
 import type { BitcoinConnector } from '@reown/appkit-utils/bitcoin'
 import { WalletConnectConnector } from '@reown/appkit/connectors'
@@ -122,10 +122,10 @@ export class BitcoinWalletConnectConnector
   private getAccount<Required extends boolean>(
     required?: Required
   ): Required extends true ? string : string | undefined {
-    const caipAddress = AccountController.getCaipAddress('bip122')
-    const account = this.provider.session?.namespaces['bip122']?.accounts.find(_account =>
-      HelpersUtil.isLowerCaseMatch(_account, caipAddress)
-    )
+    const caipAddress = AccountController.getCaipAddress(CommonConstantsUtil.CHAIN.BITCOIN)
+    const account = this.provider.session?.namespaces[
+      CommonConstantsUtil.CHAIN.BITCOIN
+    ]?.accounts.find(_account => HelpersUtil.isLowerCaseMatch(_account, caipAddress))
 
     if (!account) {
       if (required) {

--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -1,7 +1,8 @@
 import UniversalProvider from '@walletconnect/universal-provider'
 
-import { type RequestArguments, WcHelpersUtil } from '@reown/appkit'
+import { AccountController, type RequestArguments, WcHelpersUtil } from '@reown/appkit'
 import type { CaipNetwork } from '@reown/appkit-common'
+import { HelpersUtil } from '@reown/appkit-utils'
 import type { BitcoinConnector } from '@reown/appkit-utils/bitcoin'
 import { WalletConnectConnector } from '@reown/appkit/connectors'
 
@@ -121,7 +122,11 @@ export class BitcoinWalletConnectConnector
   private getAccount<Required extends boolean>(
     required?: Required
   ): Required extends true ? string : string | undefined {
-    const account = this.provider.session?.namespaces['bip122']?.accounts[0]
+    const caipAddress = AccountController.getCaipAddress('bip122')
+    const account = this.provider.session?.namespaces['bip122']?.accounts.find(_account =>
+      HelpersUtil.isLowerCaseMatch(_account, caipAddress)
+    )
+
     if (!account) {
       if (required) {
         throw new Error('Account not found')

--- a/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
+++ b/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
@@ -360,5 +360,51 @@ describe('LeatherConnector', () => {
 
       expect((provider as any).getAccount()).toBeUndefined()
     })
+
+    it('should select the correct address when multiple networks have addresses', () => {
+      universalProvider.session = mockUniversalProvider.mockSession({
+        namespaces: {
+          bip122: {
+            accounts: [
+              `${bitcoin.caipNetworkId}:mainnet_address`,
+              `${bitcoinTestnet.caipNetworkId}:testnet_address`
+            ],
+            events: [],
+            methods: []
+          }
+        }
+      })
+
+      vi.spyOn(AccountController, 'getCaipAddress').mockReturnValue(
+        `${bitcoin.caipNetworkId}:mainnet_address`
+      )
+
+      const result = (provider as any).getAccount()
+
+      expect(result).toBe('mainnet_address')
+    })
+
+    it('should select testnet address when testnet is active chain', () => {
+      universalProvider.session = mockUniversalProvider.mockSession({
+        namespaces: {
+          bip122: {
+            accounts: [
+              `${bitcoin.caipNetworkId}:mainnet_address`,
+              `${bitcoinTestnet.caipNetworkId}:testnet_address`
+            ],
+            events: [],
+            methods: []
+          }
+        }
+      })
+
+      vi.spyOn(AccountController, 'getCaipAddress').mockReturnValue(
+        `${bitcoinTestnet.caipNetworkId}:testnet_address`
+      )
+
+      const result = (provider as any).getAccount()
+
+      expect(result).toBe('testnet_address')
+    })
   })
 })

--- a/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
+++ b/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
@@ -1,7 +1,7 @@
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
-import { ChainController } from '@reown/appkit-controllers'
+import { AccountController, ChainController } from '@reown/appkit-controllers'
 import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
 
 import { BitcoinWalletConnectConnector } from '../../src/connectors/BitcoinWalletConnectConnector'
@@ -116,6 +116,9 @@ describe('LeatherConnector', () => {
   describe('sendTransfer', () => {
     beforeEach(() => {
       universalProvider.session = mockUniversalProvider.mockSession()
+      vi.spyOn(AccountController, 'getCaipAddress').mockReturnValue(
+        `${bitcoin.caipNetworkId}:address`
+      )
     })
 
     it('should send the transfer and parse response', async () => {
@@ -186,7 +189,7 @@ describe('LeatherConnector', () => {
 
       await expect(
         provider.sendTransfer({ recipient: 'mock_recipient', amount: 'mock_amount' })
-      ).rejects.toThrow('Address not found')
+      ).rejects.toThrow('Account not found')
     })
   })
 


### PR DESCRIPTION
# Description

Fixed an issue where bitcoin walletconnect signing requests did not include the correct user address

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3637

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
