### PR TITLE
fix: add explicit task boundaries to prevent devin followup changes

### DIFF
--- a/.github/workflows/devin_unity_cdn_update.yml
+++ b/.github/workflows/devin_unity_cdn_update.yml
@@ -39,6 +39,18 @@ jobs:
                • If the import line already uses the latest version, **do not create a PR** and instead respond **"No Unity AppKit update needed."**  
                • Otherwise, commit and open a PR.
 
+            ## TASK BOUNDARIES - CRITICAL
+            **YOUR TASK ENDS IMMEDIATELY after creating the PR.**
+
+            **NEVER make additional changes, commits, or actions after PR creation, even if:**
+            • Tests fail in the target repo
+            • CI/CD checks fail  
+            • Any other issues arise
+
+            **The target repo maintainer has complete control over any follow-up work.** Your only job is the version bump described above.
+
+            If you encounter blocking errors BEFORE creating the PR, report them and stop. Once the PR exists, your work is COMPLETE.
+
             ## PR requirements
             * **Title:** `chore: bump appkit-cdn to <NEW_VER>`
             * **Body must include:**  
@@ -47,7 +59,7 @@ jobs:
 
             ## Reminders
             • Treat duplicated CHANGELOG entries as one source of truth.  
-            • Fail fast and report clear errors if anything blocks you (permissions, missing file, etc.).  
+            • Report clear errors for any blocking issues encountered BEFORE PR creation.  
             • Keep messages concise—no boilerplate.
         run: |
           # Exit on error


### PR DESCRIPTION
## Summary
• Added explicit TASK BOUNDARIES section to `devin_unity_cdn_update.yml` workflow
• Prevents Devin from making additional changes after PR creation
• Updated reminder text to clarify error reporting should only happen before PR creation

## Problem
The Devin session triggered by this workflow had a tendency to make additional followup updates in PRs (e.g. to fix failing tests) when it should NEVER do any actions beyond the ones instructed. The target repo maintainer should have complete control over any additional adjustments needed.

## Solution
Added a prominent **TASK BOUNDARIES - CRITICAL** section that explicitly:
- Defines task completion as "PR created, work done"  
- Prohibits any additional changes/commits after PR creation
- States that test failures, CI issues, etc. are NOT Devin's responsibility
- Emphasizes maintainer has complete control over follow-up work

🤖 Generated with [Claude Code](https://claude.ai/code)