### PR TITLE
fix: use getCaipNetworks method on Bitcoin adapter to find active caip network

### DIFF
--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -51,9 +51,7 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
       throw new Error('connectionControllerClient:connectExternal - connector is undefined')
     }
 
-    const chain =
-      this.getCaipNetworks(this.namespace).find(c => c.id === params.chainId) ||
-      this.getCaipNetworks(this.namespace)[0]
+    const chain = connector.chains.find(c => c.id === params.chainId) || connector.chains[0]
 
     if (!chain) {
       throw new Error('The connector does not support any of the requested chains')

--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -51,7 +51,9 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
       throw new Error('connectionControllerClient:connectExternal - connector is undefined')
     }
 
-    const chain = connector.chains.find(c => c.id === params.chainId) || connector.chains[0]
+    const chain =
+      this.getCaipNetworks(this.namespace).find(c => c.id === params.chainId) ||
+      this.getCaipNetworks(this.namespace)[0]
 
     if (!chain) {
       throw new Error('The connector does not support any of the requested chains')

--- a/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/UnisatConnector/index.ts
@@ -40,10 +40,6 @@ export class UnisatConnector extends ProviderEventEmitter implements BitcoinConn
   }
 
   public get chains() {
-    if (this.id === 'unisat') {
-      return this.requestedChains.filter(chain => chain.caipNetworkId === bitcoin.caipNetworkId)
-    }
-
     return this.requestedChains.filter(
       chain => chain.chainNamespace === ConstantsUtil.CHAIN.BITCOIN
     )

--- a/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/UnisatConnector.test.ts
@@ -61,8 +61,8 @@ describe('UnisatConnector', () => {
     expect(connector.imageUrl).toBe('mock_image_url')
   })
 
-  it('should return only mainnet chain', () => {
-    expect(connector.chains).toEqual([bitcoin])
+  it('should return bitcoin chains', () => {
+    expect(connector.chains).toEqual([bitcoin, bitcoinTestnet])
   })
 
   describe('connect', () => {


### PR DESCRIPTION
# Description

After connecting and switching network on Bitcoin, refreshing page switches AppKit back to Bitcoin Mainnet

### Reproducing steps

- Go to https://appkit-lab.reown.com/library/bitcoin/
- Connect with Unisat Wallet
- Switch to Bitcoin Signet
- Refresh page
- See that AppKit switches back to Bitcoin back

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
