### PR TITLE
fix: Do not show error message if payWithExchange is not enabled

### DIFF
--- a/.changeset/khaki-experts-yell.md
+++ b/.changeset/khaki-experts-yell.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fixes issue where an error snack would be shown on non-enabled pay with exchange projects

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -158,13 +158,10 @@ export const ExchangeController = {
 
   // -- Getters ----------------------------------------- //
   async fetchExchanges() {
-    const isPayWithExchangeSupported = ExchangeController.isPayWithExchangeSupported()
-    if (!isPayWithExchangeSupported) {
-      return
-    }
-
     try {
-      if (!state.paymentAsset) {
+      const isPayWithExchangeSupported = ExchangeController.isPayWithExchangeSupported()
+
+      if (!state.paymentAsset || !isPayWithExchangeSupported) {
         state.exchanges = []
         state.isLoading = false
 

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -141,12 +141,15 @@ export const ExchangeController = {
   // -- Getters ----------------------------------------- //
   async fetchExchanges() {
     const isPayWithExchangeEnabled =
-      OptionsController.state.remoteFeatures?.payWithExchange &&
+      OptionsController.state.remoteFeatures?.payWithExchange ||
+      OptionsController.state.remoteFeatures?.payments ||
+      OptionsController.state.features?.pay
+    const isPayWithExchangeSupported =
       ChainController.state.activeCaipNetwork &&
       ConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
         ChainController.state.activeCaipNetwork.chainNamespace
       )
-    if (!isPayWithExchangeEnabled) {
+    if (!(isPayWithExchangeEnabled && isPayWithExchangeSupported)) {
       return
     }
 

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -138,18 +138,28 @@ export const ExchangeController = {
     state.paymentAsset = asset
   },
 
-  // -- Getters ----------------------------------------- //
-  async fetchExchanges() {
-    const isPayWithExchangeEnabled =
+  isPayWithExchangeEnabled() {
+    return (
       OptionsController.state.remoteFeatures?.payWithExchange ||
       OptionsController.state.remoteFeatures?.payments ||
       OptionsController.state.features?.pay
-    const isPayWithExchangeSupported =
+    )
+  },
+
+  isPayWithExchangeSupported() {
+    return (
+      ExchangeController.isPayWithExchangeEnabled() &&
       ChainController.state.activeCaipNetwork &&
       ConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
         ChainController.state.activeCaipNetwork.chainNamespace
       )
-    if (!(isPayWithExchangeEnabled && isPayWithExchangeSupported)) {
+    )
+  },
+
+  // -- Getters ----------------------------------------- //
+  async fetchExchanges() {
+    const isPayWithExchangeSupported = ExchangeController.isPayWithExchangeSupported()
+    if (!isPayWithExchangeSupported) {
       return
     }
 

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -17,6 +17,7 @@ import type { CurrentPayment, Exchange, PayUrlParams, PaymentAsset } from '../ut
 import { AccountController } from './AccountController.js'
 import { BlockchainApiController } from './BlockchainApiController.js'
 import { EventsController } from './EventsController.js'
+import { OptionsController } from './OptionsController.js'
 import { SnackController } from './SnackController.js'
 
 // -- Constants ----------------------------------------- //
@@ -154,7 +155,10 @@ export const ExchangeController = {
       // Putting this here in order to maintain backawrds compatibility with the UI when we introduce more exchanges
       state.exchanges = response.exchanges.slice(0, 2)
     } catch (error) {
-      SnackController.showError('Unable to get exchanges')
+      const isEnabled = OptionsController.state.remoteFeatures?.payWithExchange
+      if (isEnabled) {
+        SnackController.showError('Unable to get exchanges')
+      }
       throw new Error('Unable to get exchanges')
     } finally {
       state.isLoading = false

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -138,6 +138,11 @@ export const ExchangeController = {
 
   // -- Getters ----------------------------------------- //
   async fetchExchanges() {
+    const isEnabled = OptionsController.state.remoteFeatures?.payWithExchange
+    if (!isEnabled) {
+      return
+    }
+
     try {
       if (!state.paymentAsset) {
         state.exchanges = []
@@ -155,10 +160,7 @@ export const ExchangeController = {
       // Putting this here in order to maintain backawrds compatibility with the UI when we introduce more exchanges
       state.exchanges = response.exchanges.slice(0, 2)
     } catch (error) {
-      const isEnabled = OptionsController.state.remoteFeatures?.payWithExchange
-      if (isEnabled) {
-        SnackController.showError('Unable to get exchanges')
-      }
+      SnackController.showError('Unable to get exchanges')
       throw new Error('Unable to get exchanges')
     } finally {
       state.isLoading = false

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -4,6 +4,7 @@ import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import { type CaipNetworkId } from '@reown/appkit-common'
 
 import { getActiveNetworkTokenAddress } from '../utils/ChainControllerUtil.js'
+import { ConstantsUtil } from '../utils/ConstantsUtil.js'
 import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import {
   type GetBuyStatusResult,
@@ -16,6 +17,7 @@ import {
 import type { CurrentPayment, Exchange, PayUrlParams, PaymentAsset } from '../utils/ExchangeUtil.js'
 import { AccountController } from './AccountController.js'
 import { BlockchainApiController } from './BlockchainApiController.js'
+import { ChainController } from './ChainController.js'
 import { EventsController } from './EventsController.js'
 import { OptionsController } from './OptionsController.js'
 import { SnackController } from './SnackController.js'
@@ -138,8 +140,13 @@ export const ExchangeController = {
 
   // -- Getters ----------------------------------------- //
   async fetchExchanges() {
-    const isEnabled = OptionsController.state.remoteFeatures?.payWithExchange
-    if (!isEnabled) {
+    const isPayWithExchangeEnabled =
+      OptionsController.state.remoteFeatures?.payWithExchange &&
+      ChainController.state.activeCaipNetwork &&
+      ConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
+        ChainController.state.activeCaipNetwork.chainNamespace
+      )
+    if (!isPayWithExchangeEnabled) {
       return
     }
 

--- a/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
@@ -47,12 +47,15 @@ export class W3mFundWalletView extends LitElement {
 
   public override async firstUpdated() {
     const isPayWithExchangeEnabled =
-      this.remoteFeatures?.payWithExchange &&
-      this.activeCaipNetwork &&
+      OptionsController.state.remoteFeatures?.payWithExchange ||
+      OptionsController.state.remoteFeatures?.payments ||
+      OptionsController.state.features?.pay
+    const isPayWithExchangeSupported =
+      ChainController.state.activeCaipNetwork &&
       CoreConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
-        this.activeCaipNetwork.chainNamespace
+        ChainController.state.activeCaipNetwork.chainNamespace
       )
-    if (isPayWithExchangeEnabled) {
+    if (isPayWithExchangeEnabled && isPayWithExchangeSupported) {
       await this.setDefaultPaymentAsset()
       await ExchangeController.fetchExchanges()
     }

--- a/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
@@ -46,16 +46,8 @@ export class W3mFundWalletView extends LitElement {
   }
 
   public override async firstUpdated() {
-    const isPayWithExchangeEnabled =
-      OptionsController.state.remoteFeatures?.payWithExchange ||
-      OptionsController.state.remoteFeatures?.payments ||
-      OptionsController.state.features?.pay
-    const isPayWithExchangeSupported =
-      ChainController.state.activeCaipNetwork &&
-      CoreConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
-        ChainController.state.activeCaipNetwork.chainNamespace
-      )
-    if (isPayWithExchangeEnabled && isPayWithExchangeSupported) {
+    const isPayWithExchangeSupported = ExchangeController.isPayWithExchangeSupported()
+    if (isPayWithExchangeSupported) {
       await this.setDefaultPaymentAsset()
       await ExchangeController.fetchExchanges()
     }
@@ -115,13 +107,8 @@ export class W3mFundWalletView extends LitElement {
       return null
     }
 
-    const isPayWithExchangeEnabled =
-      this.remoteFeatures?.payWithExchange &&
-      CoreConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
-        this.activeCaipNetwork.chainNamespace
-      )
-
-    if (!isPayWithExchangeEnabled) {
+    const isPayWithExchangeSupported = ExchangeController.isPayWithExchangeSupported()
+    if (!isPayWithExchangeSupported) {
       return null
     }
 

--- a/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-fund-wallet-view/index.ts
@@ -46,8 +46,16 @@ export class W3mFundWalletView extends LitElement {
   }
 
   public override async firstUpdated() {
-    await this.setDefaultPaymentAsset()
-    await ExchangeController.fetchExchanges()
+    const isPayWithExchangeEnabled =
+      this.remoteFeatures?.payWithExchange &&
+      this.activeCaipNetwork &&
+      CoreConstantsUtil.PAY_WITH_EXCHANGE_SUPPORTED_CHAIN_NAMESPACES.includes(
+        this.activeCaipNetwork.chainNamespace
+      )
+    if (isPayWithExchangeEnabled) {
+      await this.setDefaultPaymentAsset()
+      await ExchangeController.fetchExchanges()
+    }
   }
 
   // -- Render -------------------------------------------- //


### PR DESCRIPTION
# Description

- Fixes issue where error would appear if payWithExchange is not enabled.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
