### PR TITLE
fix: fund from exhcnage not working at first try

### DIFF
--- a/.changeset/tall-peaches-clap.md
+++ b/.changeset/tall-peaches-clap.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where funding from the exchange had a preset dollar amount causing it to fail on the first attempt

--- a/packages/controllers/src/controllers/ExchangeController.ts
+++ b/packages/controllers/src/controllers/ExchangeController.ts
@@ -24,9 +24,9 @@ import { SnackController } from './SnackController.js'
 
 // -- Constants ----------------------------------------- //
 const DEFAULT_PAGE = 0
-const DEFAULT_STATE: ExchangeControllerState = {
+export const DEFAULT_STATE: ExchangeControllerState = {
   paymentAsset: null,
-  amount: 10,
+  amount: 0,
   tokenAmount: 0,
   priceLoading: false,
   error: null,

--- a/packages/controllers/tests/controllers/ExchangeController.test.ts
+++ b/packages/controllers/tests/controllers/ExchangeController.test.ts
@@ -4,6 +4,7 @@ import { ChainController } from '../../exports'
 import { AccountController } from '../../src/controllers/AccountController'
 import { EventsController } from '../../src/controllers/EventsController'
 import { ExchangeController } from '../../src/controllers/ExchangeController'
+import { DEFAULT_STATE } from '../../src/controllers/ExchangeController'
 import { OptionsController } from '../../src/controllers/OptionsController'
 import { SnackController } from '../../src/controllers/SnackController'
 import { CoreHelperUtil } from '../../src/utils/CoreHelperUtil'
@@ -17,6 +18,10 @@ describe('ExchangeController', () => {
 
   afterEach(() => {
     vi.resetAllMocks()
+  })
+
+  it('should have default state', () => {
+    expect(ExchangeController.state).toEqual(DEFAULT_STATE)
   })
 
   it('getTokenAmount returns computed amount', () => {


### PR DESCRIPTION
# Description

Fixed an issue where funding from the exchange had a preset dollar amount causing it to fail on the first attempt

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

<img width="457" height="485" alt="image" src="https://github.com/user-attachments/assets/5d63caec-ff6e-421f-baa7-32b7eea1ac17" />

<img width="468" height="206" alt="image" src="https://github.com/user-attachments/assets/aacda81b-d0dd-4490-ae0a-cff205ac045d" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
