### PR TITLE
refactor: update error boundary to handle wk error messages properly

### DIFF
--- a/.changeset/ready-ducks-send.md
+++ b/.changeset/ready-ducks-send.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Updates error boundary to handle WalletKit error messages on toast properly

--- a/packages/controllers/src/utils/withErrorBoundary.ts
+++ b/packages/controllers/src/utils/withErrorBoundary.ts
@@ -68,7 +68,7 @@ function errorHandler(err: any, defaultCategory: TelemetryErrorCategory) {
     } else if (typeof err === 'string') {
       errMessage = err
     } else if (typeof err === 'object' && err !== null) {
-      errMessage = err.message || JSON.stringify(err)
+      errMessage = err?.message || JSON.stringify(err)
     } else {
       errMessage = String(err)
     }

--- a/packages/controllers/src/utils/withErrorBoundary.ts
+++ b/packages/controllers/src/utils/withErrorBoundary.ts
@@ -68,7 +68,7 @@ function errorHandler(err: any, defaultCategory: TelemetryErrorCategory) {
     } else if (typeof err === 'string') {
       errMessage = err
     } else if (typeof err === 'object' && err !== null) {
-      errMessage = JSON.stringify(err)
+      errMessage = err.message || JSON.stringify(err)
     } else {
       errMessage = String(err)
     }

--- a/packages/controllers/tests/utils/withErrorBoundary.test.ts
+++ b/packages/controllers/tests/utils/withErrorBoundary.test.ts
@@ -206,7 +206,7 @@ describe('withErrorBoundary', () => {
       } catch (err: unknown) {
         expect(err).toBeInstanceOf(AppKitError)
         const appKitError = err as AppKitError
-        expect(appKitError.message).toBe(JSON.stringify(errorObject))
+        expect(appKitError.message).toBe('Server error')
         expect(appKitError.category).toBe('SECURE_SITE_ERROR')
         expect(appKitError.originalError).toBe(errorObject)
       }
@@ -321,6 +321,34 @@ describe('withErrorBoundary', () => {
         const appKitError = err as AppKitError
         // The object should be serialized successfully since Date and undefined are serializable
         expect(appKitError.message).toContain('Complex error')
+        expect(appKitError.category).toBe('SECURE_SITE_ERROR')
+        expect(appKitError.originalError).toBe(complexObject)
+      }
+      expect(sendErrorSpy).toHaveBeenCalledWith(expect.any(AppKitError), 'SECURE_SITE_ERROR')
+    })
+
+    it('should handle objects if message doesnt exist', async () => {
+      const complexObject = {
+        timestamp: new Date(),
+        function: () => 'test',
+        symbol: Symbol('test'),
+        undefined: undefined
+      }
+
+      const mockController = {
+        async errorMethod() {
+          throw complexObject
+        }
+      }
+
+      const wrappedController = withErrorBoundary(mockController, 'SECURE_SITE_ERROR')
+
+      try {
+        await wrappedController.errorMethod()
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(AppKitError)
+        const appKitError = err as AppKitError
+        // The object should be serialized successfully since Date and undefined are serializable
         expect(appKitError.message).toContain('timestamp')
         expect(appKitError.category).toBe('SECURE_SITE_ERROR')
         expect(appKitError.originalError).toBe(complexObject)


### PR DESCRIPTION
# Description

When any error thrown on WalletKit, AppKit handle those with `withErrorBoundary` and stringifying objects. But the WK errors already returned as object and includes `message` property which will be enough for us to show proper messages. 

In this PR it updates the error boundary to look for the error.message first use it if exist. 

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
