### PR TITLE
chore: use --frozen-lockfile on pnpm install in workflow files

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -52,7 +52,7 @@ jobs:
           cache: 'pnpm'
 
       - name: install
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       # Cache Turborepo's build outputs (.turbo directory).
       # This speeds up the 'pnpm build' step significantly if inputs haven't changed.
@@ -148,7 +148,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: check
         run: pnpm ${{ matrix.style-command }}
@@ -195,7 +195,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: build sample apps
         run: pnpm build:sample-apps
@@ -241,7 +241,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Test
         run: pnpm test:ci

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -52,7 +52,7 @@ jobs:
           cache: 'pnpm'
 
       - name: install
-        run: pnpm install
+        run: pnpm ci
 
       # Cache Turborepo's build outputs (.turbo directory).
       # This speeds up the 'pnpm build' step significantly if inputs haven't changed.
@@ -148,7 +148,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm install
+        run: pnpm ci
 
       - name: check
         run: pnpm ${{ matrix.style-command }}
@@ -195,7 +195,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm install
+        run: pnpm ci
 
       - name: build sample apps
         run: pnpm build:sample-apps
@@ -241,7 +241,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm install
+        run: pnpm ci
 
       - name: Test
         run: pnpm test:ci

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
         shell: bash
 
       - name: Publish prerelease
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
-          pnpm install
+          pnpm ci
           pnpm changeset:pre ${{ github.event.inputs.canaryName }}
           pnpm changeset:version
           pnpm changeset:pre:exit

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
         shell: bash
 
       - name: Publish prerelease
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
-          pnpm ci
+          pnpm install --frozen-lockfile
           pnpm changeset:pre ${{ github.event.inputs.canaryName }}
           pnpm changeset:version
           pnpm changeset:pre:exit

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -31,14 +31,14 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
         shell: bash
 
       - name: Publish prerelease (canary)
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           git reset --hard origin/main
-          pnpm install
+          pnpm ci
           pnpm changeset:pre ${{ github.sha }}
           pnpm changeset:version
           pnpm changeset:pre:exit

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -31,14 +31,14 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
         shell: bash
 
       - name: Publish prerelease (canary)
         run: |
           npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
           git reset --hard origin/main
-          pnpm ci
+          pnpm install --frozen-lockfile
           pnpm changeset:pre ${{ github.sha }}
           pnpm changeset:version
           pnpm changeset:pre:exit

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
-      - run: pnpm install
+      - run: pnpm ci
 
       - name: Version or publish
         id: changesets

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
-      - run: pnpm ci
+      - run: pnpm install --frozen-lockfile
 
       - name: Version or publish
         id: changesets

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
-      - run: pnpm install
+      - run: pnpm ci
 
       - name: Compute next version
         id: next

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 22.x
           cache: pnpm
 
-      - run: pnpm ci
+      - run: pnpm install --frozen-lockfile
 
       - name: Compute next version
         id: next

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -105,7 +105,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm ci
 
       - name: Cache Turborepo cache
         uses: actions/cache@v4
@@ -197,7 +197,7 @@ jobs:
       # - name: Tune GitHub-hosted runner network
       #   uses: smorimoto/tune-github-hosted-runner-network@v1
 
-      - name: checkout # Checkout is still needed for pnpm install and playwright config
+      - name: checkout # Checkout is still needed for pnpm ci and playwright config
         uses: actions/checkout@v4
         with:
           repository: reown-com/appkit
@@ -272,7 +272,7 @@ jobs:
         run: chmod +x node_modules/*/bin/* || true # Allow failure if no binaries found
 
       - name: Install dependencies # Install again to link binaries, etc.
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       # The cache is scoped to the key, version, and branch.
       # Version includes the path e.g. /tmp/playwright_cache
@@ -417,7 +417,7 @@ jobs:
           path: node_modules # Specify path to download into
 
       - name: Install dependencies # Install again to link binaries, etc.
-        run: pnpm install --frozen-lockfile
+        run: pnpm ci
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true' # <-- Re-enable condition

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -105,7 +105,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Turborepo cache
         uses: actions/cache@v4
@@ -197,7 +197,7 @@ jobs:
       # - name: Tune GitHub-hosted runner network
       #   uses: smorimoto/tune-github-hosted-runner-network@v1
 
-      - name: checkout # Checkout is still needed for pnpm ci and playwright config
+      - name: checkout # Checkout is still needed for pnpm install --frozen-lockfile and playwright config
         uses: actions/checkout@v4
         with:
           repository: reown-com/appkit
@@ -272,7 +272,7 @@ jobs:
         run: chmod +x node_modules/*/bin/* || true # Allow failure if no binaries found
 
       - name: Install dependencies # Install again to link binaries, etc.
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       # The cache is scoped to the key, version, and branch.
       # Version includes the path e.g. /tmp/playwright_cache
@@ -417,7 +417,7 @@ jobs:
           path: node_modules # Specify path to download into
 
       - name: Install dependencies # Install again to link binaries, etc.
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true' # <-- Re-enable condition

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm ci
+        run: pnpm install --frozen-lockfile
 
       - name: run vitest shard
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: chmod +x node_modules/*/bin/*
 
       - name: install
-        run: pnpm install
+        run: pnpm ci
 
       - name: run vitest shard
         run: |


### PR DESCRIPTION
# Description

- Replaces `pnpm install` with `pnpm install --frozen-lockfile` on workflow files to ensure lockfile is respected during workflow runs.
- Ensures installed packages in workflows use known/stable/safe versions.


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
Closes ISAI-41
