### PR TITLE
fix: `open` does not throw when attempting to switch network during send flow

### DIFF
--- a/.changeset/khaki-chairs-start.md
+++ b/.changeset/khaki-chairs-start.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where using the `open` function with send arguments and attempting to switch networks did not throw, causing the network state to become inconsistent

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -231,7 +231,7 @@ export abstract class AppKitBaseClient {
         throw new Error(`openSend: caipNetwork with chainId ${args.chainId} not found`)
       }
 
-      await this.switchNetwork(caipNetwork)
+      await this.switchNetwork(caipNetwork, true)
     }
 
     try {
@@ -2159,14 +2159,14 @@ export abstract class AppKitBaseClient {
     return ChainController.state.activeCaipNetwork?.id
   }
 
-  public async switchNetwork(appKitNetwork: AppKitNetwork) {
+  public async switchNetwork(appKitNetwork: AppKitNetwork, throwIfFailedToSwitch = false) {
     const network = this.getCaipNetworks().find(n => n.id === appKitNetwork.id)
     if (!network) {
       AlertController.open(ErrorUtil.ALERT_ERRORS.SWITCH_NETWORK_NOT_FOUND, 'error')
 
       return
     }
-    await ChainController.switchActiveNetwork(network)
+    await ChainController.switchActiveNetwork(network, throwIfFailedToSwitch)
   }
 
   public getWalletProvider() {

--- a/packages/controllers/src/controllers/ChainController.ts
+++ b/packages/controllers/src/controllers/ChainController.ts
@@ -410,7 +410,7 @@ const controller = {
     }
   },
 
-  async switchActiveNetwork(network: CaipNetwork) {
+  async switchActiveNetwork(network: CaipNetwork, throwIfFailedToSwitch = false) {
     const namespace = ChainController.state.activeChain
 
     if (!namespace) {
@@ -434,6 +434,10 @@ const controller = {
           ModalController.close()
         }
       } catch (error) {
+        if (throwIfFailedToSwitch) {
+          throw error
+        }
+
         RouterController.goBack()
       }
 


### PR DESCRIPTION
# Description

Fixed an issue where using the `open` function with send arguments and attempting to switch networks did not throw, causing the network state to become inconsistent

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
