### PR TITLE
feat: UP and AK config in UniversalConnector

### DIFF
--- a/.changeset/early-spies-wish.md
+++ b/.changeset/early-spies-wish.md
@@ -1,0 +1,6 @@
+---
+'@reown/appkit-universal-connector': patch
+'@reown/appkit': patch
+---
+
+Adds `modalConfig` and `providerConfig` to UniversalConnector

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.8.2'
+export const PACKAGE_VERSION = '1.8.3'

--- a/packages/universal-connector/src/UniversalConnector.ts
+++ b/packages/universal-connector/src/UniversalConnector.ts
@@ -47,6 +47,7 @@ export class UniversalConnector {
 
   public static async init(config: Config) {
     const provider = await UniversalProvider.init({
+      ...config.providerConfig,
       projectId: config.projectId,
       metadata: config.metadata
     })

--- a/packages/universal-connector/src/UniversalConnector.ts
+++ b/packages/universal-connector/src/UniversalConnector.ts
@@ -2,7 +2,8 @@ import type { SessionTypes } from '@walletconnect/types'
 import {
   type NamespaceConfig,
   type RequestArguments,
-  UniversalProvider
+  UniversalProvider,
+  type UniversalProviderOpts
 } from '@walletconnect/universal-provider'
 
 import type { CreateAppKit } from '@reown/appkit'
@@ -18,6 +19,11 @@ export type Config = {
   projectId: string
   metadata: Metadata
   networks: ExtendedNamespaces[]
+  modalConfig?: Omit<
+    CreateAppKit,
+    'networks' | 'projectId' | 'metadata' | 'universalProvider' | 'manualWCControl'
+  >
+  providerConfig?: Omit<UniversalProviderOpts, 'projectId' | 'metadata'>
 }
 
 export class UniversalConnector {
@@ -46,6 +52,7 @@ export class UniversalConnector {
     })
 
     const appKitConfig: CreateAppKit = {
+      ...config.modalConfig,
       networks: config.networks.flatMap(network => network.chains) as [
         CaipNetwork,
         ...CaipNetwork[]

--- a/packages/universal-connector/tests/UniversalConnector.test.ts
+++ b/packages/universal-connector/tests/UniversalConnector.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as AppKitCore from '@reown/appkit/core'
 
-import { UniversalConnector } from '../src/UniversalConnector'
+import { type Config, UniversalConnector } from '../src/UniversalConnector'
 
 // Create lightweight in-file mocks to avoid cross-package type issues
 const provider = {
@@ -37,8 +37,14 @@ const baseConfig = {
       methods: ['eth_sendTransaction'],
       events: []
     }
-  ]
-} as any // Cast to any to avoid importing internal types
+  ],
+  modalConfig: {
+    themeMode: 'light'
+  },
+  providerConfig: {
+    logger: 'debug'
+  }
+} as Config
 
 describe('UniversalConnector', () => {
   beforeEach(() => {
@@ -57,10 +63,13 @@ describe('UniversalConnector', () => {
       // Assert
       expect(UniversalProvider.init).toHaveBeenCalledWith({
         projectId: baseConfig.projectId,
-        metadata: baseConfig.metadata
+        metadata: baseConfig.metadata,
+        ...baseConfig.providerConfig
       })
 
-      expect(AppKitCore.createAppKit).toHaveBeenCalled()
+      expect(AppKitCore.createAppKit).toHaveBeenCalledWith(
+        expect.objectContaining(baseConfig.modalConfig)
+      )
       expect(connector).toBeInstanceOf(UniversalConnector)
       expect(connector.provider).toBe(provider)
     })


### PR DESCRIPTION
# Description

- Adds `modalConfig` to forward custom AppKit configs in UC
- Adds `providerConfig` to forward custom UP configs in UC

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [c] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
