### PR TITLE
chore: add signature cta bot

### DIFF
--- a/.github/workflows/cta.yml
+++ b/.github/workflows/cta.yml
@@ -1,0 +1,21 @@
+name: 'CTA Assistant'
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Required permissions
+permissions:
+  actions: write
+  contents: write # can be 'read' if signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CTA:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: walletconnect/actions/github/cta-assistant@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
- Adds Copyright Transfer Agreement (CTA) workflow to require external contributors to sign an agreement when submitting changes

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
