### PR TITLE
chore: set minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,6 @@ packages:
   - '!packages/appkit-new'
   - '!apps/gallery-new'
   - '!apps/laboratory-new'
+
+# 4320 minutes = 3 days
+minimumReleaseAge: 4320


### PR DESCRIPTION
# Description

Set minimum release age to 3 days. This will only pull dependences that have been released for longer than the amount specified, including transitive dependencies.

https://pnpm.io/settings#minimumreleaseage

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
