### PR TITLE
fix: `CONNECT_SUCCESS` event not including `walletRank` property and keep track of recent connected wallet

### DIFF
--- a/.changeset/bitter-facts-work.md
+++ b/.changeset/bitter-facts-work.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-common': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Added `walletRank` property to the `CONNECT_SUCCESS` event and created a new `@appkit/recent_wallet` local storage key to track the most recently connected wallet

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1266,6 +1266,12 @@ export abstract class AppKitBaseClient {
     await this.syncWalletConnectAccount()
     const address = this.getAddress()
 
+    if (!this.getCaipAddress()) {
+      StorageUtil.deleteRecentWallet()
+    }
+
+    const recentWallet = StorageUtil.getRecentWallet()
+
     EventsController.sendEvent({
       type: 'track',
       event: 'CONNECT_SUCCESS',
@@ -1275,7 +1281,7 @@ export abstract class AppKitBaseClient {
         name: this.universalProvider?.session?.peer?.metadata?.name || 'Unknown',
         reconnect: true,
         view: RouterController.state.view,
-        walletRank: undefined
+        walletRank: recentWallet?.order
       }
     })
   }

--- a/packages/common/src/utils/SafeLocalStorage.ts
+++ b/packages/common/src/utils/SafeLocalStorage.ts
@@ -10,6 +10,7 @@ export type SafeLocalStorageItems = {
   '@appkit/connected_social': string
   '@appkit-wallet/SOCIAL_USERNAME': string
   '@appkit/recent_wallets': string
+  '@appkit/recent_wallet': string
   '@appkit/active_namespace': string
   '@appkit/connected_namespaces': string
   '@appkit/connection_status': string
@@ -43,6 +44,7 @@ export const SafeLocalStorageKeys = {
   CONNECTED_SOCIAL: '@appkit/connected_social',
   CONNECTED_SOCIAL_USERNAME: '@appkit-wallet/SOCIAL_USERNAME',
   RECENT_WALLETS: '@appkit/recent_wallets',
+  RECENT_WALLET: '@appkit/recent_wallet',
   DEEPLINK_CHOICE: 'WALLETCONNECT_DEEPLINK_CHOICE',
   ACTIVE_NAMESPACE: '@appkit/active_namespace',
   CONNECTED_NAMESPACES: '@appkit/connected_namespaces',

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -366,6 +366,7 @@ const controller = {
     state.status = 'disconnected'
     TransactionsController.resetTransactions()
     StorageUtil.deleteWalletConnectDeepLink()
+    StorageUtil.deleteRecentWallet()
   },
 
   resetUri() {
@@ -394,7 +395,7 @@ const controller = {
           method: wcLinking ? 'mobile' : 'qrcode',
           name: RouterController.state.data?.wallet?.name || 'Unknown',
           view: RouterController.state.view,
-          walletRank: RouterController.state.data?.wallet?.order
+          walletRank: recentWallet?.order
         }
       })
     }

--- a/packages/controllers/src/utils/StorageUtil.ts
+++ b/packages/controllers/src/utils/StorageUtil.ts
@@ -148,6 +148,7 @@ export const StorageUtil = {
           recentWallets.pop()
         }
         SafeLocalStorage.setItem(SafeLocalStorageKeys.RECENT_WALLETS, JSON.stringify(recentWallets))
+        SafeLocalStorage.setItem(SafeLocalStorageKeys.RECENT_WALLET, JSON.stringify(wallet))
       }
     } catch {
       console.info('Unable to set AppKit recent')
@@ -164,6 +165,26 @@ export const StorageUtil = {
     }
 
     return []
+  },
+
+  getRecentWallet(): WcWallet | null {
+    try {
+      const recent = SafeLocalStorage.getItem(SafeLocalStorageKeys.RECENT_WALLET)
+
+      return recent ? JSON.parse(recent) : null
+    } catch {
+      console.info('Unable to get AppKit recent')
+    }
+
+    return null
+  },
+
+  deleteRecentWallet() {
+    try {
+      SafeLocalStorage.removeItem(SafeLocalStorageKeys.RECENT_WALLET)
+    } catch {
+      console.info('Unable to delete AppKit recent')
+    }
   },
 
   setConnectedConnectorId(namespace: ChainNamespace, connectorId: string) {


### PR DESCRIPTION
# Description

Added `walletRank` property to the `CONNECT_SUCCESS` event and created a new `@appkit/recent_wallet` local storage key to track the most recently connected wallet

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
