### PR TITLE
fix: missing `walletRank` for external connectors

### DIFF
--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1278,7 +1278,7 @@ export abstract class AppKitBaseClient {
       address,
       properties: {
         method: CoreHelperUtil.isMobile() ? 'mobile' : 'qrcode',
-        name: this.universalProvider?.session?.peer?.metadata?.name || 'Unknown',
+        name: recentWallet?.name || 'Unknown',
         reconnect: true,
         view: RouterController.state.view,
         walletRank: recentWallet?.order

--- a/packages/scaffold-ui/src/partials/w3m-connect-announced-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-announced-widget/index.ts
@@ -87,7 +87,7 @@ export class W3mConnectAnnouncedWidget extends LitElement {
         RouterController.push('ConnectingWalletConnect')
       }
     } else {
-      RouterController.push('ConnectingExternal', { connector })
+      RouterController.push('ConnectingExternal', { connector, wallet: connector.explorerWallet })
     }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connect-injected-widget/index.ts
@@ -79,7 +79,7 @@ export class W3mConnectInjectedWidget extends LitElement {
   // -- Private Methods ----------------------------------- //
   private onConnector(connector: Connector) {
     ConnectorController.setActiveConnector(connector)
-    RouterController.push('ConnectingExternal', { connector })
+    RouterController.push('ConnectingExternal', { connector, wallet: connector.explorerWallet })
   }
 }
 

--- a/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connector-list/index.ts
@@ -105,7 +105,9 @@ export class W3mConnectorList extends LitElement {
               (connectorRdns.includes(wallet.rdns) || connectorIds.includes(wallet.rdns)))
         )
 
-        return { ...connector, explorerWallet }
+        connector.explorerWallet = explorerWallet
+
+        return connector
       }
 
       const explorerWallet = explorerWallets.find(
@@ -115,7 +117,9 @@ export class W3mConnectorList extends LitElement {
           wallet.name === connector.name
       )
 
-      return { ...connector, explorerWallet }
+      connector.explorerWallet = explorerWallet
+
+      return connector
     })
   }
 

--- a/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
+++ b/packages/scaffold-ui/src/utils/w3m-connecting-widget/index.ts
@@ -46,7 +46,7 @@ export class W3mConnectingWidget extends LitElement {
   protected unsubscribe: (() => void)[] = []
 
   private imageSrc =
-    AssetUtil.getWalletImage(this.wallet) ?? AssetUtil.getConnectorImage(this.connector)
+    AssetUtil.getConnectorImage(this.connector) ?? AssetUtil.getWalletImage(this.wallet)
 
   private name = this.wallet?.name ?? this.connector?.name ?? 'Wallet'
 

--- a/packages/scaffold-ui/src/views/w3m-connecting-multi-chain-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-multi-chain-view/index.ts
@@ -115,7 +115,8 @@ export class W3mConnectingMultiChainView extends LitElement {
       }
     } else {
       RouterController.push('ConnectingExternal', {
-        connector
+        connector,
+        wallet: this.activeConnector?.explorerWallet
       })
     }
   }

--- a/packages/scaffold-ui/test/partials/w3m-connect-announced-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connect-announced-widget.test.ts
@@ -188,6 +188,36 @@ describe('W3mConnectAnnouncedWidget', () => {
     expect(pushSpy).toHaveBeenCalledWith('ConnectingExternal', { connector: MOCK_CONNECTOR })
   })
 
+  it('should route to ConnectingExternal with wallet parameter when available', async () => {
+    const CONNECTOR_WITH_WALLET = {
+      ...MOCK_CONNECTOR,
+      explorerWallet: { id: 'mockConnector', name: 'Mock Wallet' }
+    }
+
+    const pushSpy = vi.spyOn(RouterController, 'push')
+
+    const element: W3mConnectAnnouncedWidget = await fixture(
+      html`<w3m-connect-announced-widget
+        .connectors=${[CONNECTOR_WITH_WALLET]}
+      ></w3m-connect-announced-widget>`
+    )
+
+    element.requestUpdate()
+    await elementUpdated(element)
+
+    const walletSelector = HelpersUtil.getByTestId(
+      element,
+      `wallet-selector-${CONNECTOR_WITH_WALLET.id}`
+    )
+    expect(walletSelector).not.toBeNull()
+    walletSelector.click()
+
+    expect(pushSpy).toHaveBeenCalledWith('ConnectingExternal', {
+      connector: CONNECTOR_WITH_WALLET,
+      wallet: CONNECTOR_WITH_WALLET.explorerWallet
+    })
+  })
+
   it('should handle unknown wallet names', async () => {
     const unknownConnector: ConnectorWithProviders = {
       ...MOCK_CONNECTOR,

--- a/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connect-injected-widget.test.ts
@@ -164,6 +164,34 @@ describe('W3mConnectInjectedWidget', () => {
     })
   })
 
+  it('should route to ConnectingExternal with wallet parameter when available', async () => {
+    const connectorWithWallet = {
+      ...MOCK_INJECTED_CONNECTOR,
+      explorerWallet: { id: 'mockInjected', name: 'Mock Injected Wallet' }
+    }
+
+    const setActiveConnectorSpy = vi.spyOn(ConnectorController, 'setActiveConnector')
+    const pushSpy = vi.spyOn(RouterController, 'push')
+
+    const element: W3mConnectInjectedWidget = await fixture(
+      html`<w3m-connect-injected-widget
+        .connectors=${[connectorWithWallet]}
+      ></w3m-connect-injected-widget>`
+    )
+
+    const walletSelector = HelpersUtil.getByTestId(
+      element,
+      `wallet-selector-${connectorWithWallet.id}`
+    )
+    walletSelector.click()
+
+    expect(setActiveConnectorSpy).toHaveBeenCalledWith(connectorWithWallet)
+    expect(pushSpy).toHaveBeenCalledWith('ConnectingExternal', {
+      connector: connectorWithWallet,
+      wallet: connectorWithWallet.explorerWallet
+    })
+  })
+
   it('should handle unknown wallet names', async () => {
     const unknownConnector: ConnectorWithProviders = {
       ...MOCK_INJECTED_CONNECTOR,

--- a/packages/scaffold-ui/test/views/w3m-connecting-multi-chain-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-connecting-multi-chain-view.test.ts
@@ -1,0 +1,58 @@
+import { elementUpdated, fixture } from '@open-wc/testing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { html } from 'lit'
+
+import { ConstantsUtil } from '@reown/appkit-common'
+import type { ConnectorWithProviders } from '@reown/appkit-controllers'
+import { ConnectorController, CoreHelperUtil, RouterController } from '@reown/appkit-controllers'
+
+import { W3mConnectingMultiChainView } from '../../src/views/w3m-connecting-multi-chain-view'
+import { HelpersUtil } from '../utils/HelpersUtil'
+
+describe('W3mConnectingMultiChainView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+  })
+
+  it('should push to ConnectingExternal with wallet parameter', async () => {
+    const multiChainConnector = {
+      id: 'multi',
+      name: 'Multi Wallet',
+      type: 'MULTI_CHAIN',
+      chain: ConstantsUtil.CHAIN.EVM,
+      explorerWallet: { id: 'multi', name: 'Multi Wallet' },
+      connectors: [
+        {
+          id: 'evmProvider',
+          name: 'EVM',
+          chain: ConstantsUtil.CHAIN.EVM
+        }
+      ]
+    } as unknown as ConnectorWithProviders
+
+    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
+      ...ConnectorController.state,
+      activeConnector: multiChainConnector
+    })
+
+    const pushSpy = vi.spyOn(RouterController, 'push')
+
+    const element: W3mConnectingMultiChainView = await fixture(
+      html`<w3m-connecting-multi-chain-view></w3m-connecting-multi-chain-view>`
+    )
+
+    element.requestUpdate()
+    await elementUpdated(element)
+
+    const walletSelector = HelpersUtil.getByTestId(element, 'wui-list-chain-eip155')
+    expect(walletSelector).not.toBeNull()
+    walletSelector?.click()
+
+    expect(pushSpy).toHaveBeenCalledWith('ConnectingExternal', {
+      connector: expect.objectContaining({ id: 'evmProvider' }),
+      wallet: expect.objectContaining({ id: 'multi' })
+    })
+  })
+})


### PR DESCRIPTION
# Description

When connecting to an external wallet without going to `AllWallets` view the wallet is missing wallet rank number. If we don't detect the wallet rank we're going to fetch it from web3modal api when landing on the `W3mConnectingExternalView` view

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
