### PR TITLE
fix: flip background styles on fund from exchange

### DIFF
--- a/packages/controllers/src/utils/TypeUtil.ts
+++ b/packages/controllers/src/utils/TypeUtil.ts
@@ -1479,3 +1479,8 @@ export type FeatureConfigMap = {
 }
 
 export type FeatureKey = keyof FeatureConfigMap
+
+export type ThemeOverrides = {
+  padding?: string
+  backgroundColor?: string
+}

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -22,7 +22,7 @@ import {
   SwapController,
   ThemeController
 } from '@reown/appkit-controllers'
-import { UiHelperUtil, customElement, initializeTheming } from '@reown/appkit-ui'
+import { UiHelperUtil, customElement, initializeTheming, vars } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-card'
 import '@reown/appkit-ui/wui-flex'
 
@@ -37,6 +37,12 @@ import styles from './styles.js'
 
 // -- Helpers --------------------------------------------- //
 const SCROLL_LOCK = 'scroll-lock'
+
+// -- Constants --------------------------------------------- //
+const PADDING_OVERRIDES: Record<string, string> = {
+  PayWithExchange: '0',
+  PayWithExchangeSelectAsset: '0'
+}
 
 export class W3mModalBase extends LitElement {
   public static override styles = styles
@@ -61,6 +67,8 @@ export class W3mModalBase extends LitElement {
 
   @state() private filterByNamespace = ConnectorController.state.filterByNamespace
 
+  @state() private padding = vars.spacing[1]
+
   public constructor() {
     super()
     this.initializeTheming()
@@ -80,6 +88,7 @@ export class W3mModalBase extends LitElement {
         }),
         RouterController.subscribeKey('view', () => {
           this.dataset['border'] = HelpersUtil.hasFooter() ? 'true' : 'false'
+          this.padding = PADDING_OVERRIDES[RouterController.state.view] ?? vars.spacing[1]
         })
       ]
     )
@@ -115,6 +124,7 @@ export class W3mModalBase extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
+    this.style.setProperty('--local-modal-padding', this.padding)
     this.style.cssText = `
       --local-border-bottom-mobile-radius: ${
         this.enableEmbedded ? 'clamp(0px, var(--apkt-borderRadius-8), 44px)' : '0px'

--- a/packages/scaffold-ui/src/modal/w3m-modal/styles.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/styles.ts
@@ -53,7 +53,7 @@ export default css`
         ${({ easings }) => easings['ease-out-power-1']};
     will-change: border-radius, background-color, transform, box-shadow;
     background-color: ${({ tokens }) => tokens.theme.backgroundPrimary};
-    padding: ${({ spacing }) => spacing[1]};
+    padding: var(--local-modal-padding);
     box-sizing: border-box;
   }
 

--- a/packages/scaffold-ui/src/partials/w3m-header/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-header/index.ts
@@ -13,7 +13,7 @@ import {
   OptionsController,
   RouterController
 } from '@reown/appkit-controllers'
-import { customElement } from '@reown/appkit-ui'
+import { customElement, vars } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-flex'
 import '@reown/appkit-ui/wui-icon-button'
 import '@reown/appkit-ui/wui-select'
@@ -25,6 +25,10 @@ import styles from './styles.js'
 
 // -- Constants ----------------------------------------- //
 const BETA_SCREENS: string[] = ['SmartSessionList']
+const BACKGROUND_OVERRIDES: Record<string, string> = {
+  PayWithExchange: vars.tokens.theme.foregroundPrimary,
+  PayWithExchangeSelectAsset: vars.tokens.theme.foregroundPrimary
+}
 
 // -- Helpers ------------------------------------------- //
 function headings() {
@@ -154,6 +158,11 @@ export class W3mHeader extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
+    const backgroundColor =
+      BACKGROUND_OVERRIDES[RouterController.state.view] ?? vars.tokens.theme.backgroundPrimary
+
+    this.style.setProperty('--local-header-background-color', backgroundColor)
+
     return html`
       <wui-flex
         .padding=${['0', '4', '0', '4'] as const}

--- a/packages/scaffold-ui/src/partials/w3m-header/styles.ts
+++ b/packages/scaffold-ui/src/partials/w3m-header/styles.ts
@@ -7,11 +7,11 @@ export default css`
 
   :host > wui-flex {
     box-sizing: border-box;
-    background-color: ${({ tokens }) => tokens.theme.backgroundPrimary};
+    background-color: var(--local-header-background-color);
   }
 
   wui-text {
-    background-color: ${({ tokens }) => tokens.theme.backgroundPrimary};
+    background-color: var(--local-header-background-color);
   }
 
   wui-flex.w3m-header-title {

--- a/packages/scaffold-ui/src/views/w3m-deposit-from-exchange-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-deposit-from-exchange-view/index.ts
@@ -119,7 +119,7 @@ export class W3mDepositFromExchangeView extends LitElement {
               imageSrc=${exchange.imageUrl}
               ?loading=${this.isLoading}
             >
-              <wui-text variant="md-regular" color="secondary">
+              <wui-text variant="md-regular" color="primary">
                 Deposit from ${exchange.name}
               </wui-text>
             </wui-list-item>`
@@ -180,15 +180,15 @@ export class W3mDepositFromExchangeView extends LitElement {
           </w3m-fund-input>
           ${this.tokenAmountTemplate()}
         </wui-flex>
-        <wui-flex justifyContent="space-between" gap="2">
+        <wui-flex justifyContent="center" gap="2">
           ${PRESET_AMOUNTS.map(
             amount =>
-              html`<wui-button
+              html`<wui-chip-button
                 @click=${() => ExchangeController.setAmount(amount)}
-                variant=${this.amount === amount ? 'neutral-primary' : 'neutral-secondary'}
+                variant="neutral"
                 size="sm"
                 fullWidth
-                >$${amount}</wui-button
+                >$${amount}</wui-chip-button
               >`
           )}
         </wui-flex>

--- a/packages/scaffold-ui/src/views/w3m-deposit-from-exchange-view/styles.ts
+++ b/packages/scaffold-ui/src/views/w3m-deposit-from-exchange-view/styles.ts
@@ -5,12 +5,11 @@ export default css`
     border-radius: ${({ borderRadius }) => borderRadius['5']};
     border-top-right-radius: 0;
     border-top-left-radius: 0;
-    border-bottom: 1px solid ${({ tokens }) => tokens.core.glass010};
-    background-color: ${({ tokens }) => tokens.theme.backgroundPrimary};
+    background-color: ${({ tokens }) => tokens.theme.foregroundPrimary};
+    padding: ${({ spacing }) => spacing[1]};
   }
 
   .container {
-    background-color: ${({ tokens }) => tokens.theme.foregroundSecondary};
     border-radius: 30px;
   }
 `

--- a/packages/ui/exports/index.ts
+++ b/packages/ui/exports/index.ts
@@ -4,7 +4,7 @@ export { UiHelperUtil } from '../src/utils/UiHelperUtil.js'
 export { TransactionUtil } from '../src/utils/TransactionUtil.js'
 export { customElement } from '../src/utils/WebComponentsUtil.js'
 export { borderRadius, colors, spacing } from '../src/utils/ThemeConstantsUtil.js'
-export { css } from '../src/utils/ThemeHelperUtil.js'
+export { css, vars } from '../src/utils/ThemeHelperUtil.js'
 
 export type {
   IconType,

--- a/packages/ui/src/components/wui-card/styles.ts
+++ b/packages/ui/src/components/wui-card/styles.ts
@@ -5,7 +5,6 @@ export default css`
     display: block;
     border-radius: clamp(0px, ${({ borderRadius }) => borderRadius['8']}, 44px);
     box-shadow: 0 0 0 1px ${({ tokens }) => tokens.theme.foregroundPrimary};
-    background-color: ${({ tokens }) => tokens.theme.backgroundPrimary};
     overflow: hidden;
   }
 `


### PR DESCRIPTION
# Description

- Flips background color on `w3m-header` when on deposit from exchange view
- Adds padding override on `wui-card` when on deposit from exchange view
- Flips screen background color to use `foreground-secondary` as top background and `background-primary` on bottom one.
- Use `wui-chip-button` instead of `wui-button`

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues
APKt-3788 APKT-3726

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
