### PR TITLE
fix: `useAppKitConnection` returning `null` when wallet is disconnected

### DIFF
--- a/.changeset/afraid-pens-tell.md
+++ b/.changeset/afraid-pens-tell.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the `useAppKitConnection` hook returned `null` when wallet is disconnected

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1094,7 +1094,7 @@ export abstract class AppKitBaseClient {
         blueprint.construct({
           namespace,
           projectId: this.options?.projectId,
-          networks: this.getCaipNetworks()
+          networks: this.caipNetworks?.filter(({ chainNamespace }) => chainNamespace === namespace)
         })
         adapters[namespace] = blueprint
       } else {
@@ -1943,7 +1943,7 @@ export abstract class AppKitBaseClient {
     adapterBlueprint.construct({
       namespace,
       projectId: this.options?.projectId,
-      networks: this.getCaipNetworks()
+      networks: this.caipNetworks?.filter(({ chainNamespace }) => chainNamespace === namespace)
     })
 
     if (!this.chainNamespaces.includes(namespace)) {

--- a/packages/appkit/tests/client/initialization.test.ts
+++ b/packages/appkit/tests/client/initialization.test.ts
@@ -1,7 +1,7 @@
 import UniversalProvider from '@walletconnect/universal-provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { type AppKitNetwork } from '@reown/appkit-common'
+import { type AppKitNetwork, ConstantsUtil as CommonConstantsUtil } from '@reown/appkit-common'
 import {
   AlertController,
   ApiController,
@@ -13,9 +13,10 @@ import {
   StorageUtil
 } from '@reown/appkit-controllers'
 import { ReownAuthentication } from '@reown/appkit-controllers/features'
-import { ErrorUtil } from '@reown/appkit-utils'
+import { CaipNetworksUtil, ErrorUtil } from '@reown/appkit-utils'
 
 import { AppKit } from '../../src/client/appkit.js'
+import { mockEvmAdapter, mockSolanaAdapter } from '../mocks/Adapter.js'
 import { mainnet, polygon, sepolia, solana } from '../mocks/Networks'
 import { mockOptions, mockRemoteFeaturesConfig } from '../mocks/Options'
 import { mockUniversalProvider } from '../mocks/Providers.js'
@@ -60,6 +61,34 @@ describe('Base', () => {
       expect(initialize).toHaveBeenCalledWith(mockOptions.adapters, [mainnet, sepolia, solana], {
         connectionControllerClient: expect.any(Object),
         networkControllerClient: expect.any(Object)
+      })
+    })
+
+    it('should construct', async () => {
+      const solanaConstruct = vi.spyOn(mockSolanaAdapter, 'construct')
+      const evmConstruct = vi.spyOn(mockEvmAdapter, 'construct')
+
+      new AppKit(mockOptions)
+
+      await vi.waitFor(() => {
+        expect(solanaConstruct).toHaveBeenCalledWith({
+          networks: CaipNetworksUtil.extendCaipNetworks([solana], {
+            projectId: mockOptions.projectId,
+            customNetworkImageUrls: {},
+            customRpcUrls: {}
+          }),
+          projectId: mockOptions.projectId,
+          namespace: CommonConstantsUtil.CHAIN.SOLANA
+        })
+        expect(evmConstruct).toHaveBeenCalledWith({
+          networks: CaipNetworksUtil.extendCaipNetworks([mainnet, sepolia], {
+            projectId: mockOptions.projectId,
+            customNetworkImageUrls: {},
+            customRpcUrls: {}
+          }),
+          projectId: mockOptions.projectId,
+          namespace: CommonConstantsUtil.CHAIN.EVM
+        })
       })
     })
 


### PR DESCRIPTION
# Description

Fixed an issue where the `useAppKitConnection` hook returned `null` when wallet is disconnected

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3829

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
