### PR TITLE
fix: social provider not connecting after switch between networks of different connectors

### DIFF
--- a/.changeset/poor-bars-smash.md
+++ b/.changeset/poor-bars-smash.md
@@ -2,4 +2,4 @@
 '@reown/appkit-scaffold-ui': patch
 ---
 
-Fixes issue on email/socials not property connecting after network switches and disconnecting
+Fixes issue on socials not properly connecting due to state listeners

--- a/.changeset/poor-bars-smash.md
+++ b/.changeset/poor-bars-smash.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-scaffold-ui': patch
+---
+
+Fixes issue on email/socials not property connecting after network switches and disconnecting

--- a/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-account-wallet-features-widget/index.ts
@@ -61,21 +61,19 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
 
   @state() private remoteFeatures = OptionsController.state.remoteFeatures
 
-  public constructor() {
-    super()
+  public override firstUpdated() {
+    AccountController.fetchTokenBalance()
     this.unsubscribe.push(
-      ...[
-        AccountController.subscribe(val => {
-          if (val.address) {
-            this.address = val.address
-            this.profileName = val.profileName
-            this.currentTab = val.currentTab
-            this.tokenBalance = val.tokenBalance
-          } else {
-            ModalController.close()
-          }
-        })
-      ],
+      AccountController.subscribe(val => {
+        if (val.address) {
+          this.address = val.address
+          this.profileName = val.profileName
+          this.currentTab = val.currentTab
+          this.tokenBalance = val.tokenBalance
+        } else {
+          ModalController.close()
+        }
+      }),
       ConnectorController.subscribeKey('activeConnectorIds', newActiveConnectorIds => {
         this.activeConnectorIds = newActiveConnectorIds
       }),
@@ -90,10 +88,6 @@ export class W3mAccountWalletFeaturesWidget extends LitElement {
   public override disconnectedCallback() {
     this.unsubscribe.forEach(unsubscribe => unsubscribe())
     clearInterval(this.watchTokenBalance)
-  }
-
-  public override firstUpdated() {
-    AccountController.fetchTokenBalance()
   }
 
   // -- Render -------------------------------------------- //


### PR DESCRIPTION
# Description

There is a really weird issue where is happening when using socials - after connecting with socials on multichain instance, switching networks and trying to connect with Social again, moves AppKit to weird state where the modal is closed unexpectedly, thus the social flows getting broken.

### Detailed Breakdown

We have a `AccountController.subscribe` listener in the constructor of the `w3m-wallet-features-widget`. This page is only rendered as the home page of the Embedded Wallet. 

When user connected with EW, and switch between networks of non-embedded-wallet supported network (i.e Bitcoin), then switch back to EVM again, the AppKit's (or actually `w3m-wallet-features-widget`'s life cycle methods) goes into weird state where even tho it's calling the `disconnectedCallback` as expected (I've put some logs and saw), it's not unsubscribing the controller listeners. 

In the listeners we have a logic to call `ModalController.close`, and since the listeners not unsubscribed even tho we are not on the account page, the modal getting closed unexpectedly. And this causing social flows to be broken because modal should be open to listen social connections to complete the flow. 

### Why and How to Fix

Unfortunately not completely sure but I have some insights - we had similar problems with the account buttons that the subscriptions not really working when we use them in the `constructor`. We've fixed those issues by moving controller subscriptions to `firstUpdated` life cycle method. 

Same as the other issues, using `firstUpdated`, instead of `constructor` fixes this issue as well.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
