### PR TITLE
chore: fix TS typing for WuiIcon stories in Storybook

### DIFF
--- a/apps/gallery/stories/components/appkit-wui-icon.stories.ts
+++ b/apps/gallery/stories/components/appkit-wui-icon.stories.ts
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/web-components'
+import type { Meta, StoryObj } from '@storybook/web-components'
 
 import { html } from 'lit'
 
@@ -8,6 +8,7 @@ import type { WuiIcon } from '@reown/appkit-ui/wui-icon'
 import { colorOptions, iconOptions } from '../../utils/PresetUtils'
 
 type Component = Meta<WuiIcon>
+type Story = StoryObj<WuiIcon>
 
 export default {
   title: 'Components/appkit-wui-icon',
@@ -37,7 +38,7 @@ export default {
   }
 } as Component
 
-export const Default: Component = {
+export const Default: Story = {
   render: args =>
     html`<wui-icon
       color=${args.color}


### PR DESCRIPTION
# Description

fixed a typing issue in our Storybook stories for `WuiIcon`.

* imported `StoryObj` from `@storybook/web-components`.
* created `Story = StoryObj<WuiIcon>` for individual stories.
* updated `Default` type from `Component` to `Story` so TypeScript correctly differentiates between metadata (`Meta`) and individual stories (`StoryObj`).

type checking now works properly, and Storybook stories are fully typed.

## Type of change

* [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

N/A

# Showcase (Optional)

N/A

# Checklist

* [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
* [ ] My changes generate no new warnings
* [x] I have reviewed my own code
* [x] I have filled out all required sections
* [ ] I have tested my changes on the preview link
* [ ] Approver of this PR confirms that the changes are tested on the preview link