### PR TITLE
fix: Fixed an issue where some subscription functions did not return the corresponding unsubscription function

### DIFF
--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2357,12 +2357,15 @@ export abstract class AppKitBaseClient {
       callback(account)
     }
 
-    if (namespace) {
-      ChainController.subscribeChainProp('accountState', updateVal, namespace)
-    } else {
-      ChainController.subscribe(updateVal)
+    const unsubscribeChain = namespace
+      ? ChainController.subscribeChainProp('accountState', updateVal, namespace)
+      : ChainController.subscribe(updateVal)
+    const unsubscribeConnector = ConnectorController.subscribe(updateVal)
+
+    return () => {
+      unsubscribeChain()
+      unsubscribeConnector()
     }
-    ConnectorController.subscribe(updateVal)
   }
 
   public subscribeNetwork(
@@ -2389,11 +2392,11 @@ export abstract class AppKitBaseClient {
   }
 
   public subscribeShouldUpdateToAddress(callback: (newState?: string) => void) {
-    AccountController.subscribeKey('shouldUpdateToAddress', callback)
+    return AccountController.subscribeKey('shouldUpdateToAddress', callback)
   }
 
   public subscribeCaipNetworkChange(callback: (newState?: CaipNetwork) => void) {
-    ChainController.subscribeKey('activeCaipNetwork', callback)
+    return ChainController.subscribeKey('activeCaipNetwork', callback)
   }
 
   public getState() {


### PR DESCRIPTION
# Description

Fixed an issue where subscribing to events using the subscribeAccount, subscribeShouldUpdateToAddress, and subscribeCaipNetworkChange functions did not return the corresponding unsubscribe functions.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

```
const appKit = createAppKit({
  projectId,
  networks,
});
// before: unsubscribe is void. Cannot unsubscribe.
const unsubscribe = appKit.subscribeAccount(callback, namespace);
// after: unsubscribe is a function. It can be called to unsubscribe.
```

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
