### PR TITLE
fix: random object error thrown when rejecting connection request from universal provider

### DIFF
--- a/.changeset/all-bears-flash.md
+++ b/.changeset/all-bears-flash.md
@@ -26,4 +26,4 @@
 '@reown/appkit-wallet-button': patch
 ---
 
-Fixed an issue where the universal provider threw a random object error when a wallet rejected a request
+Fixed an issue where the universal provider threw a random object error when the wallet rejected connection request

--- a/.changeset/all-bears-flash.md
+++ b/.changeset/all-bears-flash.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit-controllers': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where the universal provider threw a random object error when a wallet rejected a request

--- a/packages/controllers/src/utils/withErrorBoundary.ts
+++ b/packages/controllers/src/utils/withErrorBoundary.ts
@@ -73,7 +73,11 @@ function errorHandler(err: any, defaultCategory: TelemetryErrorCategory) {
     } else if (typeof err === 'string') {
       errMessage = err
     } else if (typeof err === 'object' && err !== null) {
-      errMessage = err?.message || JSON.stringify(err)
+      if (Object.keys(err).length === 0) {
+        errMessage = 'Unknown error'
+      } else {
+        errMessage = err?.message || JSON.stringify(err)
+      }
     } else {
       errMessage = String(err)
     }

--- a/packages/controllers/tests/utils/withErrorBoundary.test.ts
+++ b/packages/controllers/tests/utils/withErrorBoundary.test.ts
@@ -211,6 +211,27 @@ describe('withErrorBoundary', () => {
         expect(appKitError.originalError).toBe(errorObject)
       }
       expect(sendErrorSpy).toHaveBeenCalledWith(expect.any(AppKitError), 'SECURE_SITE_ERROR')
+
+      // empty object
+      const emptyObject = {}
+      const mockController2 = {
+        async errorMethod() {
+          throw emptyObject
+        }
+      }
+
+      const wrappedController2 = withErrorBoundary(mockController2, 'SECURE_SITE_ERROR')
+
+      try {
+        await wrappedController2.errorMethod()
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(AppKitError)
+        const appKitError = err as AppKitError
+        expect(appKitError.message).toBe('Unknown error')
+        expect(appKitError.category).toBe('SECURE_SITE_ERROR')
+        expect(appKitError.originalError).toBe(emptyObject)
+      }
+      expect(sendErrorSpy).toHaveBeenCalledWith(expect.any(AppKitError), 'SECURE_SITE_ERROR')
     })
 
     it('should handle null errors correctly', async () => {


### PR DESCRIPTION
# Description

Fixed an issue where the universal provider threw a random object error when the wallet rejected connection request

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3645
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
