### PR TITLE
chore: trigger devin to update `@reown/*` dependencies on secure site after release

### DIFF
--- a/.github/workflows/devin_secure_site_update.yml
+++ b/.github/workflows/devin_secure_site_update.yml
@@ -27,19 +27,19 @@ jobs:
             ## Task — Update secure-site
             In **reown-com/secure-site**:
             1. Create a branch from `main`.
-            2. In **reown-com/appkit**, read the `name` and `version` fields from each `package.json` and build a map of `@reown/*` → `version`.
-            3. In **reown-com/secure-site**, go through all `package.json` files. For every dependency or devDependency that starts with `@reown/appkit/*`, update it to the exact version `<version>` from the map.
+            2. In **reown-com/appkit** repository, read the `name` and `version` fields from each `package.json` and build a map of `@reown/appkit/*` → `version`.
+            3. In **reown-com/secure-site** repository, scan all `package.json` files. For every dependency or devDependency that starts with `@reown/appkit/`, update it to the exact version `<version>` from the map.
             4. If everything is already up to date, respond **"No secure-site update needed."** and stop.
             5. Otherwise, commit the changes and open a PR to `main`.
 
             ## PR requirements
-            * **Title:** `chore: bump @reown/* dependencies to latest`
+            * **Title:** `chore: bump @reown/appkit/* dependencies to latest`
             * **Body:**
               - Bullet list of updated packages and versions
               - Link to the triggering commit: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
 
             ## Notes
-            • Only update packages under the `@reown/` scope.  
+            • Only update packages under the `@reown/appkit/` scope.  
             • Keep the PR concise.
 
         run: |


### PR DESCRIPTION
# Description

Added Devin to update `@reown/*` dependencies on secure-site after release

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow that posts a Slack prompt to Devin on release merges to update @reown/appkit dependencies in secure-site.
> 
> - **CI/CD**:
>   - **New workflow** `/.github/workflows/devin_secure_site_update.yml`:
>     - Triggers on pushes to `main` when the head commit message contains `Release/` or `release/`.
>     - Sends a Slack message (via webhook) tagging a specific user with instructions to update `@reown/appkit/*` versions across `reown-com/secure-site` package.json files.
>     - Uses `jq` to build payload and `curl` to post; requires `DEGIN_SLACK_WEBHOOK_URL` secret and includes commit/Repo context in the message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a02709dd5e2af3976efb59cb468ae0743909281. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->