### PR TITLE
chore(analytics): write to Data Lake directly

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -74,9 +74,12 @@ on:
         required: false
       PLAYWRIGHT_REPORT_AWS_SECRET_ACCESS_KEY:
         required: false
+      AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME:
+        required: false
 
 env:
   BRANCH_NAME: ${{ inputs.branch }}
+  AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME: ${{ secrets.AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME }}
 
 permissions:
   id-token: write
@@ -477,7 +480,7 @@ jobs:
         if: inputs.build_trigger_type != '' # Also skip if not uploading
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::898587786287:role/prod_github_actions_appkit_role
+          role-to-assume: ${{ env.AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME }}
           aws-region: eu-central-1
 
       # Required for Athena/Trino processing


### PR DESCRIPTION
# Description

Writes AppKit Playwright summaries directly into the data lake.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `ui_tests.yml` to assume an AWS role via OIDC and uploads merged Playwright reports to `s3://walletconnect.data-lake.prod/appkit-test-results`.
> 
> - **CI/CD (`.github/workflows/ui_tests.yml`)**:
>   - **Auth**: Add OIDC permissions (`permissions: id-token: write`) and assume role via `role-to-assume: ${{ env.AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME }}`; remove static access keys.
>   - **S3 Target**: Change upload bucket/prefix to `walletconnect.data-lake.prod/appkit-test-results` for merged JSONL report.
>   - **Env/Secrets**: Introduce `AWS_APPKIT_DATA_LAKE_ROLE_TO_ASSUME` secret and export to `env`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafdd9f2924c6ef46c4b0a2036f30372aa8791b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->