### PR TITLE
chore: remove verbose flag from workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -55,8 +55,7 @@ jobs:
             --head "${{ github.ref_name }}" \
             --base main \
             --title "Merge ${{ github.ref_name }} back to main" \
-            --body  "Auto‑generated after publishing." \
-            --verbose
+            --body  "Auto‑generated after publishing."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_DEBUG: 1


### PR DESCRIPTION
# Description

- Removes `verbose` flag from workflow as `gh` no longer supports it

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the --verbose flag from the gh pr create step in the release-publish workflow and adjusts the command formatting.
> 
> - **CI/CD (release-publish workflow)**:
>   - Update `Open PR → main` step in `.github/workflows/release-publish.yml`:
>     - Remove `--verbose` from `gh pr create`.
>     - Adjust command by dropping the trailing line continuation after `--body`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab80ac4a19b0e5ea379ea522c28d84deca542795. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->