### PR TITLE
fix: update devin workflow triggers for new release commit format

### DIFF
--- a/.github/workflows/devin_docs_update.yml
+++ b/.github/workflows/devin_docs_update.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   trigger-devin-docs-analysis:
-    # This job runs only if the head commit message on the push to main contains 'Merge release/' and 'back to main'
+    # This job runs only if the head commit message on the push to main contains 'Release/' or 'release/'
     if: |
-      contains(github.event.head_commit.message, 'Merge release/') && contains(github.event.head_commit.message, 'back to main')
+      contains(github.event.head_commit.message, 'Release/') || contains(github.event.head_commit.message, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification for Docs Analysis

--- a/.github/workflows/devin_staking_dashboard_update.yml
+++ b/.github/workflows/devin_staking_dashboard_update.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   trigger-devin-appkit-staking-dashboard:
-    # This job runs only if the head commit message on the push to main contains 'Merge release/' and 'back to main'
+    # This job runs only if the head commit message on the push to main contains 'Release/' or 'release/'
     if: |
-      contains(github.event.head_commit.message, 'Merge release/') && contains(github.event.head_commit.message, 'back to main')
+      contains(github.event.head_commit.message, 'Release/') || contains(github.event.head_commit.message, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification for Staking Dashboard Update

--- a/.github/workflows/devin_unity_cdn_update.yml
+++ b/.github/workflows/devin_unity_cdn_update.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   trigger-devin-appkit-cdn-unity:
-    # This job runs only if the head commit message on the push to main contains 'Merge release/' and 'back to main'
+    # This job runs only if the head commit message on the push to main contains 'Release/' or 'release/'
     if: |
-      contains(github.event.head_commit.message, 'Merge release/') && contains(github.event.head_commit.message, 'back to main')
+      contains(github.event.head_commit.message, 'Release/') || contains(github.event.head_commit.message, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification for Unity Update


### PR DESCRIPTION
## Summary
- Updated all three Devin workflows to detect the new release commit format
- Release commits now use `Release/X.Y.Z (#PR)` instead of `Merge release/X.Y.Z back to main`
- Changed trigger conditions from checking for both `'Merge release/'` AND `'back to main'` to checking for `'Release/'` OR `'release/'`

## Files changed
- `.github/workflows/devin_docs_update.yml`
- `.github/workflows/devin_staking_dashboard_update.yml`
- `.github/workflows/devin_unity_cdn_update.yml`

## Test plan
- [x] Verified the new format matches recent release commits (e.g., https://github.com/reown-com/appkit/commit/7893e54c9)
- [ ] Workflows will trigger correctly on next release merge to main