### PR TITLE
feat: allow specifiying networks in SIWX Config

### DIFF
--- a/.changeset/wicked-baboons-reply.md
+++ b/.changeset/wicked-baboons-reply.md
@@ -1,0 +1,7 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit': patch
+'@reown/appkit-siwx': patch
+---
+
+Adds `network` parameter to SIWXUtil to enable selection of specific networks where to apply SIWX.

--- a/apps/laboratory/next-env.d.ts
+++ b/apps/laboratory/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './out/types/routes.d.ts'
+import "./out/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/laboratory/src/constants/appKitConfigs.ts
+++ b/apps/laboratory/src/constants/appKitConfigs.ts
@@ -392,6 +392,12 @@ export const appKitConfigs = {
   },
 
   // ----- Flags -------------------------
+  'flag-siwx-custom-networks': {
+    ...commonAppKitConfig,
+    adapters: ['ethers', 'solana', 'bitcoin'],
+    networks: ConstantsUtil.AllNetworks,
+    siwx: new DefaultSIWX({ networks: ['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'] })
+  },
   'flag-custom-rpc-url': {
     ...commonAppKitConfig,
     adapters: ['wagmi'],

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.8.7'
+export const PACKAGE_VERSION = '1.8.9'

--- a/packages/controllers/src/utils/SIWXUtil.ts
+++ b/packages/controllers/src/utils/SIWXUtil.ts
@@ -39,6 +39,13 @@ export const SIWXUtil = {
       return
     }
 
+    if (
+      siwx.networks?.length &&
+      !siwx.networks.some(network => network === `${namespace}:${chainId}`)
+    ) {
+      return
+    }
+
     try {
       if (OptionsController.state.remoteFeatures?.emailCapture) {
         const user = ChainController.getAccountData(namespace)?.user
@@ -566,6 +573,13 @@ export interface SIWXConfig {
    * @returns {boolean}
    */
   signOutOnDisconnect?: boolean
+
+  /**
+   * This determines which networks to use siwx for. Defaults to the networks in appkit config.
+   * @type [CaipNetworkId, ...CaipNetworkId[]]
+   * @default [appkit.networks]
+   */
+  networks?: [CaipNetworkId, ...CaipNetworkId[]]
 }
 
 /**

--- a/packages/controllers/tests/utils/SIWXUtil.test.ts
+++ b/packages/controllers/tests/utils/SIWXUtil.test.ts
@@ -67,6 +67,41 @@ describe('SIWXUtil', () => {
     })
   })
 
+  describe('initializeIfEnabled', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+
+      mockChainControllerState({
+        activeCaipAddress: 'eip155:1:0x1234567890123456789012345678901234567890',
+        activeCaipNetwork: ref(extendedMainnet)
+      })
+    })
+
+    it('should return early when SIWX networks are configured and current network is not in the allowed list', async () => {
+      const mockSIWX = {
+        networks: ['eip155:137', 'eip155:56'], // Only allow Polygon and BSC
+        createMessage: vi.fn()
+      }
+
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        siwx: mockSIWX as unknown as SIWXConfig
+      })
+
+      // Mock ChainController.checkIfSupportedNetwork to return true
+      vi.spyOn(ChainController, 'checkIfSupportedNetwork').mockReturnValue(true)
+
+      const result = await SIWXUtil.initializeIfEnabled(
+        'eip155:1:0x1234567890123456789012345678901234567890'
+      )
+
+      // Should return undefined (early return)
+      expect(result).toBeUndefined()
+      // createMessage should not be called since we return early
+      expect(mockSIWX.createMessage).not.toHaveBeenCalled()
+    })
+  })
+
   describe('authConnectorAuthenticate', () => {
     beforeEach(() => {
       vi.clearAllMocks()

--- a/packages/siwx/src/configs/DefaultSIWX.ts
+++ b/packages/siwx/src/configs/DefaultSIWX.ts
@@ -1,3 +1,5 @@
+import type { CaipNetworkId } from '@reown/appkit-common'
+
 import { SIWXConfig } from '../core/SIWXConfig.js'
 import { InformalMessenger } from '../messengers/index.js'
 import { LocalStorage } from '../storages/index.js'
@@ -35,7 +37,8 @@ export class DefaultSIWX extends SIWXConfig {
       messenger: params.messenger || DEFAULTS.getDefaultMessenger(),
       verifiers: params.verifiers || DEFAULTS.getDefaultVerifiers(),
       storage: params.storage || DEFAULTS.getDefaultStorage(),
-      required: params.required
+      required: params.required,
+      networks: params.networks as [CaipNetworkId, ...CaipNetworkId[]]
     })
   }
 }

--- a/packages/siwx/src/core/SIWXConfig.ts
+++ b/packages/siwx/src/core/SIWXConfig.ts
@@ -17,7 +17,7 @@ export abstract class SIWXConfig implements SIWXConfigInterface {
   private messenger: SIWXMessenger
   private verifiers: SIWXVerifier[]
   private storage: SIWXStorage
-
+  public networks: [CaipNetworkId, ...CaipNetworkId[]]
   public required: boolean
 
   constructor(params: SIWXConfig.ConstructorParams) {
@@ -25,6 +25,7 @@ export abstract class SIWXConfig implements SIWXConfigInterface {
     this.verifiers = params.verifiers
     this.storage = params.storage
     this.required = params.required ?? true
+    this.networks = params.networks
   }
 
   /**
@@ -157,5 +158,11 @@ export namespace SIWXConfig {
      * @default true
      */
     required?: boolean
+
+    /**
+     * This determines which networks to use siwx for.
+     * @type [CaipNetworkId, ...CaipNetworkId[]]
+     */
+    networks: [CaipNetworkId, ...CaipNetworkId[]]
   }
 }


### PR DESCRIPTION
# Description

- Add `networks` prop to `SIWXConfig` to enable users to specify which networks to apply siwx on.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
