### PR TITLE
chore(canary): fail container when Canary fails

### DIFF
--- a/apps/laboratory/docker-canary.sh
+++ b/apps/laboratory/docker-canary.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Not adding `set -e` so that S3 upload happens regardless
 
 pnpm playwright:test:canary
@@ -6,17 +7,24 @@ TEST_EXIT_CODE=$?
 echo ""
 echo "✅ Playwright Test Results (json)"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-cat test-results.json
+if [ -f "test-results.json" ]; then
+  cat test-results.json
+else
+  echo "test-results.json not found"
+fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
 destination="s3://$TEST_RESULTS_BUCKET/web3modal-canary/$(date --iso-8601=seconds)/test-results/"
 echo "Uploading test results to $destination"
 aws s3 cp ./test-results/ $destination --recursive
+S3_EXIT_CODE=$?
+echo "S3 upload command completed with exit code: $S3_EXIT_CODE"
 
 echo ""
-echo "✅ Exit code"
+echo "✅ Upload Complete"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "S3 upload exit code: $S3_EXIT_CODE"
 echo "Test exit code: $TEST_EXIT_CODE"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""


### PR DESCRIPTION
# Description

The Log Analyzer sidecar assumes that the main container actually fails with a non-0 exit code. The Canary had suppressed this in order to always upload logs. This change captures the exit code and exits correctly after S3 upload.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
