### PR TITLE
fix: ethers sign message

### DIFF
--- a/apps/laboratory/src/components/Ethers/EthersSignTypedDataTest.tsx
+++ b/apps/laboratory/src/components/Ethers/EthersSignTypedDataTest.tsx
@@ -2,7 +2,12 @@ import { Button } from '@chakra-ui/react'
 import { BrowserProvider, JsonRpcSigner } from 'ethers'
 import type { TypedDataField } from 'ethers'
 
-import { type Provider, useAppKitAccount, useAppKitProvider } from '@reown/appkit/react'
+import {
+  type Provider,
+  useAppKitAccount,
+  useAppKitNetwork,
+  useAppKitProvider
+} from '@reown/appkit/react'
 
 import { useChakraToast } from '@/src/components/Toast'
 
@@ -33,6 +38,7 @@ const message = {
 export function EthersSignTypedDataTest() {
   const toast = useChakraToast()
   const { address } = useAppKitAccount({ namespace: 'eip155' })
+  const { chainId } = useAppKitNetwork()
   const { walletProvider } = useAppKitProvider<Provider>('eip155')
 
   async function onSignTypedData() {
@@ -40,12 +46,12 @@ export function EthersSignTypedDataTest() {
       if (!walletProvider || !address) {
         throw Error('user is disconnected')
       }
-      const provider = new BrowserProvider(walletProvider, 1)
+      const provider = new BrowserProvider(walletProvider, chainId)
       const signer = new JsonRpcSigner(provider, address)
       const domain = {
         name: 'Ether Mail',
         version: '1',
-        chainId: 1,
+        chainId,
         verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'
       } as const
 


### PR DESCRIPTION
# Description

Fixed an issue where sign message didn't work for ethers

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the current network chainId from AppKit for Ethers typed data signing instead of a hardcoded value.
> 
> - **Ethers typed data signing (`apps/laboratory/src/components/Ethers/EthersSignTypedDataTest.tsx`)**:
>   - Use `useAppKitNetwork()` to get `chainId` and pass it to `BrowserProvider` and the EIP-712 `domain.chainId`.
>   - Adjust imports to include `useAppKitNetwork`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 205b329d200cdb0f8c9d233da76a5af8bf043df7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->