### PR TITLE
chore(tests): extend more initial loading time

### DIFF
--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -113,7 +113,7 @@ export class ModalPage {
     await this.page.goto(this.url)
 
     // Wait for w3m-modal to be injected
-    await this.page.waitForSelector('w3m-modal', { state: 'visible', timeout: 5_000 })
+    await this.page.waitForSelector('w3m-modal', { state: 'visible', timeout: 10_000 })
   }
 
   assertDefined<T>(value: T | undefined | null): T {


### PR DESCRIPTION
# Description

Please include a brief summary of the change.

<img width="751" height="519" alt="Screenshot 2025-10-12 at 8 31 46 AM" src="https://github.com/user-attachments/assets/3de49c24-5e69-4bc6-8760-405358a94bae" />

In Canary runs we occasionally see a timeout when loading the page. The Canary runs a little CPU/IO constrained so extending more time here to rule out this was the issue.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
