### PR TITLE
fix: remove unused client parameter from initializeModal function

### DIFF
--- a/examples/next-ak-basic-sign-client-app-router/src/app/config.ts
+++ b/examples/next-ak-basic-sign-client-app-router/src/app/config.ts
@@ -21,7 +21,7 @@ export async function initializeSignClient() {
   return signClient
 }
 
-export function initializeModal(client?: InstanceType<typeof SignClient>) {
+export function initializeModal() {
   if (!modal) {
     modal = createAppKit({
       projectId,


### PR DESCRIPTION
Remove unused client parameter from initializeModal function in sign-client example

The client parameter was never used in the function implementation and was never
passed by any callers. This parameter was misleading as it suggested SignClient
should be passed to AppKit when using manualWCControl, but the architecture
actually requires SignClient and AppKit to work independently. The parameter
was removed to clean up the API and eliminate confusion about the integration
pattern between SignClient and AppKit in manual control mode.