### PR TITLE
Fix: Respect enableWallets overrides in demo config

### DIFF
--- a/apps/demo/lib/config.ts
+++ b/apps/demo/lib/config.ts
@@ -117,7 +117,7 @@ export const appKitConfigs = {
   defaultNetwork: mainnet,
   metadata,
   features: initialConfig?.features || ConstantsUtil.DEFAULT_FEATURES,
-  enableWallets: initialConfig?.enableWallets || true,
+  enableWallets: initialConfig?.enableWallets ?? true,
   themeMode: initialConfig?.themeMode || 'dark',
   themeVariables: initialConfig?.themeVariables || {},
   termsConditionsUrl: initialConfig?.termsConditionsUrl || '',


### PR DESCRIPTION
Ensure that the demo configuration keeps wallet support disabled when explicitly set to false instead of forcing it back to true