### PR TITLE
chore: Add SEND_SUCCESS Analytics Event for Solana Transactions

### DIFF
--- a/.changeset/young-laws-swim.md
+++ b/.changeset/young-laws-swim.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fixes an issue where we wouldn't send an event after SOL send transaction

--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.8.9'
+export const PACKAGE_VERSION = '1.8.10'

--- a/packages/controllers/exports/testing.ts
+++ b/packages/controllers/exports/testing.ts
@@ -30,6 +30,16 @@ export const extendedMainnet = {
   }
 } as CaipNetwork
 
+export const solanaCaipNetwork = {
+  id: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  caipNetworkId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  name: 'Solana',
+  chainNamespace: 'solana',
+  nativeCurrency: { name: 'Solana', symbol: 'SOL', decimals: 9 },
+  rpcUrls: { default: { http: [] } },
+  blockExplorers: { default: { name: 'Solscan', url: 'https://solscan.io' } }
+} as CaipNetwork
+
 export function mockChainControllerState(
   state: Partial<
     Omit<ChainControllerState, 'chains'> & {

--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -400,6 +400,19 @@ const controller = {
     }
 
     ConnectionController._getClient()?.updateBalance('solana')
+
+    EventsController.sendEvent({
+      type: 'track',
+      event: 'SEND_SUCCESS',
+      properties: {
+        isSmartAccount: false,
+        token: SendController.state.token?.symbol || '',
+        amount: SendController.state.sendTokenAmount,
+        network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
+        hash: hash || ''
+      }
+    })
+
     SendController.resetSend()
   },
 

--- a/packages/controllers/tests/controllers/SendController.test.ts
+++ b/packages/controllers/tests/controllers/SendController.test.ts
@@ -7,12 +7,17 @@ import {
   ChainController,
   ConnectionController,
   CoreHelperUtil,
+  EventsController,
   RouterController,
   SendController,
   type SendControllerState,
   SnackController
 } from '../../exports/index.js'
-import { extendedMainnet, mockChainControllerState } from '../../exports/testing.js'
+import {
+  extendedMainnet,
+  mockChainControllerState,
+  solanaCaipNetwork
+} from '../../exports/testing.js'
 import { BalanceUtil } from '../../src/utils/BalanceUtil.js'
 
 // -- Setup --------------------------------------------------------------------
@@ -226,6 +231,10 @@ describe('SendController', () => {
       } as any)
       vi.spyOn(CoreHelperUtil, 'isCaipAddress').mockReturnValue(false)
       vi.spyOn(SendController, 'resetSend').mockImplementation(() => {})
+      vi.spyOn(EventsController, 'sendEvent').mockImplementation(() => {})
+      mockChainControllerState({
+        activeCaipNetwork: extendedMainnet
+      })
     })
 
     it('should call sendTransaction without tokenMint', async () => {
@@ -280,6 +289,43 @@ describe('SendController', () => {
       })
       expect(ConnectionController._getClient()?.updateBalance).toHaveBeenCalledWith('solana')
       expect(SendController.resetSend).toHaveBeenCalled()
+    })
+
+    it('should trigger SEND_SUCCESS event after successful transaction', async () => {
+      mockChainControllerState({
+        activeCaipNetwork: solanaCaipNetwork
+      })
+
+      const solanaToken = {
+        name: 'SOL',
+        address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:11111111111111111111111111111111',
+        symbol: 'SOL',
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        value: 100,
+        price: 1,
+        quantity: {
+          decimals: '9',
+          numeric: '100000000'
+        }
+      }
+
+      SendController.setToken(solanaToken as SendControllerState['token'])
+      SendController.setTokenAmount(50)
+      SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
+
+      await SendController.sendSolanaToken()
+
+      expect(EventsController.sendEvent).toHaveBeenCalledWith({
+        type: 'track',
+        event: 'SEND_SUCCESS',
+        properties: {
+          isSmartAccount: false,
+          token: 'SOL',
+          amount: 50,
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          hash: ''
+        }
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

This PR adds analytics tracking for successful Solana token transactions by emitting a `SEND_SUCCESS` event through the `EventsController` after completing a transaction. This enables better tracking and monitoring of send transaction success rates and patterns.

## Changes Made

### Core Changes
- **SendController**: Added `SEND_SUCCESS` event tracking in `sendSolanaToken()` method
  - Captures transaction metadata including token symbol, amount, network, and transaction hash
  - Emits event after successful transaction but before resetting the controller state
  - Includes `isSmartAccount` flag (currently set to `false` for Solana transactions)


### Testing Infrastructure
- **Added Solana network mock** to `packages/controllers/exports/testing.ts`
  - Exported `solanaCaipNetwork` for use in Solana-specific tests
  - Properly configured with Solana mainnet details and native currency

### Test Coverage
- **Added new test**: `should trigger SEND_SUCCESS event after successful transaction`
  - Verifies `EventsController.sendEvent` is called with correct parameters
  - Uses Solana-specific network configuration and token details
  - Validates event structure matches expected analytics schema


## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3937
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Emits a SEND_SUCCESS analytics event after Solana transactions, adds Solana network test mock and coverage, and bumps version to 1.8.10.
> 
> - **Controllers**:
>   - `packages/controllers/src/controllers/SendController.ts`: After successful Solana `sendTransaction`, track `SEND_SUCCESS` via `EventsController.sendEvent` with `isSmartAccount`, `token`, `amount`, `network`, and `hash`; then reset state.
> - **Testing**:
>   - `packages/controllers/exports/testing.ts`: Add `solanaCaipNetwork` mock for tests.
>   - `packages/controllers/tests/controllers/SendController.test.ts`: Spy on `EventsController.sendEvent` and add test asserting `SEND_SUCCESS` is fired with correct properties.
> - **Versioning**:
>   - `packages/appkit/exports/constants.ts`: Bump `PACKAGE_VERSION` to `1.8.10`.
>   - `.changeset/young-laws-swim.md`: Patch note for `@reown/appkit-controllers` about sending event after SOL send transaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1053c13f299644b9e758e160a4b6b4a74e17849d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->