### PR TITLE
revert: QR scan via main camera

### DIFF
--- a/packages/controllers/src/utils/CoreHelperUtil.ts
+++ b/packages/controllers/src/utils/CoreHelperUtil.ts
@@ -157,16 +157,15 @@ export const CoreHelperUtil = {
     let safeAppUrl = appUrl
     let safeUniversalLink = universalLink
 
-    if (safeAppUrl) {
-      if (!safeAppUrl.includes('://')) {
-        safeAppUrl = appUrl.replaceAll('/', '').replaceAll(':', '')
-        safeAppUrl = `${safeAppUrl}://`
-      }
-
-      if (!safeAppUrl.endsWith('/')) {
-        safeAppUrl = `${safeAppUrl}/`
-      }
+    if (!safeAppUrl.includes('://')) {
+      safeAppUrl = appUrl.replaceAll('/', '').replaceAll(':', '')
+      safeAppUrl = `${safeAppUrl}://`
     }
+
+    if (!safeAppUrl.endsWith('/')) {
+      safeAppUrl = `${safeAppUrl}/`
+    }
+
     if (safeUniversalLink && !safeUniversalLink?.endsWith('/')) {
       safeUniversalLink = `${safeUniversalLink}/`
     }

--- a/packages/controllers/tests/utils/CoreHelperUtil.test.ts
+++ b/packages/controllers/tests/utils/CoreHelperUtil.test.ts
@@ -189,16 +189,5 @@ describe('CoreHelperUtil', () => {
         href: `${appUrl}/`
       })
     })
-
-    it('should handle empty appUrl', () => {
-      const appUrl = ''
-
-      const result = CoreHelperUtil.formatNativeUrl(appUrl, wcUri, null)
-
-      expect(result).toEqual({
-        redirect: `wc?uri=${encodeURIComponent(wcUri)}`,
-        href: appUrl
-      })
-    })
   })
 })

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-qrcode/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-qrcode/index.ts
@@ -5,7 +5,6 @@ import { ifDefined } from 'lit/directives/if-defined.js'
 import {
   AssetUtil,
   ConnectionController,
-  CoreHelperUtil,
   EventsController,
   RouterController,
   ThemeController
@@ -88,20 +87,10 @@ export class W3mConnectingWcQrcode extends W3mConnectingWidget {
     const alt = this.wallet ? this.wallet.name : undefined
     ConnectionController.setWcLinking(undefined)
     ConnectionController.setRecentWallet(this.wallet)
-    let uriWithLink = this.uri
-
-    /*
-     * Assign the uri with the link if the wallet has a mobile link
-     * so when the QR is scanned via the main camera it will prompt the wallet to open
-     */
-    if (this.wallet?.mobile_link) {
-      const { redirect } = CoreHelperUtil.formatNativeUrl(this.wallet?.mobile_link, this.uri, null)
-      uriWithLink = redirect
-    }
 
     return html` <wui-qr-code
       theme=${ThemeController.state.themeMode}
-      uri=${uriWithLink}
+      uri=${this.uri}
       imageSrc=${ifDefined(AssetUtil.getWalletImage(this.wallet))}
       color=${ifDefined(ThemeController.state.themeVariables['--w3m-qr-color'])}
       alt=${ifDefined(alt)}

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-qrcode.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-qrcode.test.ts
@@ -63,38 +63,6 @@ describe('W3mConnectingWcQrcode', () => {
     })
   })
 
-  it('it should display a QR code with a mobile link', async () => {
-    vi.spyOn(ConnectionController, 'setWcLinking')
-    vi.spyOn(ConnectionController, 'setRecentWallet')
-    vi.spyOn(RouterController, 'state', 'get').mockReturnValue({
-      ...RouterController.state,
-      data: {
-        wallet: { ...WALLET, mobile_link: 'example://' }
-      }
-    })
-
-    const connectingQrCode = await fixture(
-      html`<w3m-connecting-wc-qrcode></w3m-connecting-wc-qrcode>`
-    )
-
-    await new Promise(resolve => setTimeout(resolve, 300))
-
-    const qrCode = HelpersUtil.querySelect(connectingQrCode, QR_CODE) as WuiQrCode
-
-    expect(qrCode).not.toBeNull()
-    expect(qrCode.getAttribute('uri')).toBe('example://wc?uri=xyz')
-    expect(ConnectionController.setWcLinking).toHaveBeenCalledWith(undefined)
-    expect(ConnectionController.setRecentWallet).toHaveBeenCalledWith({
-      ...WALLET,
-      mobile_link: 'example://'
-    })
-    expect(EventsController.sendEvent).toHaveBeenCalledWith({
-      type: 'track',
-      event: 'SELECT_WALLET',
-      properties: { name: WALLET.name, platform: 'qrcode' }
-    })
-  })
-
   it('it should not send event if basic is true', async () => {
     await fixture(html`<w3m-connecting-wc-qrcode basic></w3m-connecting-wc-qrcode>`)
 


### PR DESCRIPTION
Reverts reown-com/appkit#4936

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops embedding wallet mobile links in QR codes and simplifies `formatNativeUrl` (removes empty `appUrl` handling), updating tests accordingly.
> 
> - **UI (scaffold-ui)**:
>   - QR code now always uses raw `wc` `uri`; removes `CoreHelperUtil` usage for mobile deep-link embedding.
>   - Deletes test case asserting QR `uri` is rewritten with `mobile_link`.
> - **Controllers**:
>   - `CoreHelperUtil.formatNativeUrl` now unconditionally normalizes non-HTTP `appUrl` (ensures scheme and trailing slash); keeps universal link trailing slash handling.
>   - Removes support/test for empty `appUrl` case in `formatNativeUrl` tests.
>   - Retains existing behavior for HTTP URLs and Telegram/Android double-encoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5cb036e6a4c29f5b3bc0df9ab917d078a811994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->