### PR TITLE
fix: calling remote config in appkit core

### DIFF
--- a/.changeset/silver-llamas-watch.md
+++ b/.changeset/silver-llamas-watch.md
@@ -1,0 +1,29 @@
+---
+'@reown/appkit': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where remote config endpoint was being called when using appkit core

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -182,7 +182,9 @@ export abstract class AppKitBaseClient {
     } else {
       await this.unSyncExistingConnection()
     }
-    this.remoteFeatures = await ConfigUtil.fetchRemoteFeatures(options)
+    if (!options.basic && !options.manualWCControl) {
+      this.remoteFeatures = await ConfigUtil.fetchRemoteFeatures(options)
+    }
     await ApiController.fetchUsage()
     OptionsController.setRemoteFeatures(this.remoteFeatures)
     if (this.remoteFeatures.onramp) {


### PR DESCRIPTION
# Description

Fixed an issue where remote config endpoint was being called when using appkit core

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-4129

# Showcase (Optional)
<img width="1199" height="777" alt="image" src="https://github.com/user-attachments/assets/6f7330dd-5082-488c-97e3-a6c5c43b225c" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip remote config fetch when using basic mode or manual WalletConnect control; add tests to verify behavior.
> 
> - **Core (AppKitBaseClient)**:
>   - Only fetch `ConfigUtil.fetchRemoteFeatures` if `options.basic` is false and `options.manualWCControl` is false in `initialize`.
> - **Tests**:
>   - Add initialization tests ensuring remote config is not fetched in basic or manual WC control modes and is fetched otherwise (`packages/appkit/tests/client/appkit-base-client.test.ts`).
> - **Changeset**:
>   - Patch releases for affected packages with note: fixed remote config endpoint call when using appkit core.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a54834db067d5cfaf4321b574df2305dd29c1e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->