### PR TITLE
fix: sendTransaction chain param

### DIFF
--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -401,6 +401,8 @@ export class WagmiAdapter extends AdapterBlueprint {
     params: AdapterBlueprint.SendTransactionParams
   ): Promise<AdapterBlueprint.SendTransactionResult> {
     const { chainId, address } = getAccount(this.wagmiConfig)
+    const wagmiChain = this.wagmiChains?.find(chain => chain.id === chainId)
+
     const txParams = {
       account: address,
       to: params.to as Hex,
@@ -408,7 +410,7 @@ export class WagmiAdapter extends AdapterBlueprint {
       gas: params.gas ? BigInt(params.gas) : undefined,
       gasPrice: params.gasPrice ? BigInt(params.gasPrice) : undefined,
       data: params.data as Hex,
-      chainId,
+      chain: wagmiChain,
       type: 'legacy' as const,
       parameters: ['nonce'] as const
     }


### PR DESCRIPTION
# Description

Similar to this: https://github.com/reown-com/appkit/pull/5317

> Wagmi is getting the chain object with wrong parameters and finding the CAIP id from the network object. Passing the right Wagmi chain object to `chain` and removing `chainId` parameter (Viem doesn't have `chainId` param, [see docs](https://viem.sh/docs/contract/writeContract)).


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `sendTransaction` to pass the resolved Wagmi `chain` object rather than `chainId`.
> 
> - **Wagmi Adapter (`packages/adapters/wagmi/src/client.ts`)**:
>   - `sendTransaction`: resolve current chain via `this.wagmiChains` and pass as `chain`, removing `chainId` from tx params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fcde320e9c7e28e43af5dde8fe88ffd78d9b89e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->