### PR TITLE
fix: lazy load cb on wagmi

### DIFF
--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -695,6 +695,7 @@ export class WagmiAdapter extends AdapterBlueprint {
       })
 
       const resolvedProvider = provider ?? (await connector.getProvider())
+
       return {
         address: this.toChecksummedAddress(res.accounts[0]),
         chainId: res.chainId,


### PR DESCRIPTION
# Description
- Lazy load CB connector on wagmi to prevent unnecessary calls to 3rd party services if unused.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers Base Account provider initialization until connect, awaits third-party connector setup, and adds tests to validate lazy initialization.
> 
> - **WagmiAdapter (core)**:
>   - Defer provider initialization for `BASE_ACCOUNT` in `addWagmiConnector` (skip `getProvider`).
>   - Resolve provider during `connect()` (`provider ?? await connector.getProvider()`).
>   - Await `addThirdPartyConnectors()` in `syncConnectors`.
> - **Tests**:
>   - Add Base Account lazy initialization tests (no provider fetch during sync; fetched on connect).
>   - Update connectors test to skip third-party connectors for asserting initial wagmi connectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9aa989e467a54dcada5e6a8e0c71e34fc345fe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->