### PR TITLE
Add new images ids for Tron, Stacks, Near

### DIFF
--- a/packages/appkit-utils/src/PresetsUtil.ts
+++ b/packages/appkit-utils/src/PresetsUtil.ts
@@ -120,7 +120,13 @@ export const PresetsUtil = {
     // TON
     '-239': '20f673c0-095e-49b2-07cf-eb5049dcf600',
     // TON Testnet
-    '-3': '20f673c0-095e-49b2-07cf-eb5049dcf600'
+    '-3': '20f673c0-095e-49b2-07cf-eb5049dcf600',
+    // TRON
+    'tron:0x2b6653dc': 'dd9de794-d4ce-4c94-682f-a367f926d500',
+    // STACKS
+    'stacks:1': 'a694e2a1-03ee-46bd-2dc8-a04563041e00',
+    // NEAR
+    'near:mainnet': '6a5509e3-e58a-488a-19ee-17279677f800',
   } as Record<string, string>,
 
   ConnectorImageIds: {


### PR DESCRIPTION
# Description

Add new images ids for Tron, Stacks, Near

`NetworkImageIds` would have to be changed to CAIP-2 format instead of just chain ID

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
