### PR TITLE
fix: wallet buttons not working in the in-app wallet browser

### DIFF
--- a/.changeset/sunny-pens-cross.md
+++ b/.changeset/sunny-pens-cross.md
@@ -1,0 +1,30 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-wagmi': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where wallet buttons were not working in the in-app wallet browser

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -395,6 +395,9 @@ export class EthersAdapter extends AdapterBlueprint {
           this.addConnector({
             id,
             type,
+            explorerId:
+              PresetsUtil.ConnectorExplorerIds[info.rdns || ''] ??
+              PresetsUtil.ConnectorExplorerIds[info.name || ''],
             imageUrl: info?.icon,
             name: info?.name || 'Unknown',
             provider,

--- a/packages/adapters/ethers/src/tests/client.test.ts
+++ b/packages/adapters/ethers/src/tests/client.test.ts
@@ -20,7 +20,7 @@ import {
   SIWXUtil,
   WcHelpersUtil
 } from '@reown/appkit-controllers'
-import { CaipNetworksUtil, HelpersUtil } from '@reown/appkit-utils'
+import { CaipNetworksUtil, HelpersUtil, PresetsUtil } from '@reown/appkit-utils'
 import type { W3mFrameProvider } from '@reown/appkit-wallet'
 import { mainnet, polygon } from '@reown/appkit/networks'
 
@@ -143,6 +143,41 @@ describe('EthersAdapter', () => {
       const injectedConnector = mockConnectors.filter((c: any) => c.id === 'injected')[0]
 
       expect(injectedConnector?.info).toBeUndefined()
+    })
+
+    it('should set explorerId from PresetsUtil based on rdns or name', () => {
+      const ethersAdapter = new EthersAdapter()
+      const addConnectorSpy = vi.spyOn(ethersAdapter as any, 'addConnector')
+
+      const mockEIP6963Provider = {
+        info: {
+          rdns: 'MetaMask',
+          name: 'MetaMask',
+          icon: 'data:image/png;base64,mock'
+        },
+        provider: mockProvider
+      }
+
+      const { info, provider } = mockEIP6963Provider
+
+      const id = info.rdns || info.name
+
+      ;(ethersAdapter as any).addConnector({
+        id,
+        type: 'ANNOUNCED',
+        explorerId:
+          PresetsUtil.ConnectorExplorerIds[info.rdns || ''] ??
+          PresetsUtil.ConnectorExplorerIds[info.name || ''],
+        imageUrl: info?.icon,
+        name: info?.name || 'Unknown',
+        provider
+      })
+
+      expect(addConnectorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explorerId: expect.any(String)
+        })
+      )
     })
   })
 

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -390,6 +390,9 @@ export class Ethers5Adapter extends AdapterBlueprint {
           this.addConnector({
             id,
             type,
+            explorerId:
+              PresetsUtil.ConnectorExplorerIds[info.rdns || ''] ??
+              PresetsUtil.ConnectorExplorerIds[info.name || ''],
             imageUrl: info?.icon,
             name: info?.name || 'Unknown',
             provider,

--- a/packages/adapters/ethers5/src/tests/client.test.ts
+++ b/packages/adapters/ethers5/src/tests/client.test.ts
@@ -17,7 +17,7 @@ import {
   SIWXUtil,
   WcHelpersUtil
 } from '@reown/appkit-controllers'
-import { CaipNetworksUtil, HelpersUtil } from '@reown/appkit-utils'
+import { CaipNetworksUtil, HelpersUtil, PresetsUtil } from '@reown/appkit-utils'
 import type { W3mFrameProvider } from '@reown/appkit-wallet'
 import { mainnet, polygon } from '@reown/appkit/networks'
 
@@ -111,6 +111,41 @@ describe('Ethers5Adapter', () => {
       const injectedConnector = mockConnectors.filter((c: any) => c.id === 'injected')[0]
 
       expect(injectedConnector?.info).toBeUndefined()
+    })
+
+    it('should set explorerId from PresetsUtil based on rdns or name', () => {
+      const ethers5Adapter = new Ethers5Adapter()
+      const addConnectorSpy = vi.spyOn(ethers5Adapter as any, 'addConnector')
+
+      const mockEIP6963Provider = {
+        info: {
+          rdns: 'MetaMask',
+          name: 'MetaMask',
+          icon: 'data:image/png;base64,mock'
+        },
+        provider: mockProvider
+      }
+
+      const { info, provider } = mockEIP6963Provider
+
+      const id = info.rdns || info.name
+
+      ;(ethers5Adapter as any).addConnector({
+        id,
+        type: 'ANNOUNCED',
+        explorerId:
+          PresetsUtil.ConnectorExplorerIds[info.rdns || ''] ??
+          PresetsUtil.ConnectorExplorerIds[info.name || ''],
+        imageUrl: info?.icon,
+        name: info?.name || 'Unknown',
+        provider
+      })
+
+      expect(addConnectorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explorerId: expect.any(String)
+        })
+      )
     })
   })
 

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -503,7 +503,9 @@ export class WagmiAdapter extends AdapterBlueprint {
     const customConnectorImages = AssetController.state.connectorImages
     this.addConnector({
       id: connector.id,
-      explorerId: PresetsUtil.ConnectorExplorerIds[connector.id],
+      explorerId:
+        PresetsUtil.ConnectorExplorerIds[connector.id] ??
+        PresetsUtil.ConnectorExplorerIds[connector.name],
       imageUrl: customConnectorImages?.[connector.id] ?? connector.icon,
       name: PresetsUtil.ConnectorNamesMap[connector.id] ?? connector.name,
       imageId: PresetsUtil.ConnectorImageIds[connector.id],

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -419,6 +419,30 @@ describe('WagmiAdapter', () => {
         }
       ])
     })
+
+    it('should set explorerId from PresetsUtil based on connector.id or connector.name', async () => {
+      const mockConnector = {
+        id: 'MetaMask',
+        name: 'MetaMask',
+        type: 'injected',
+        icon: 'data:image/png;base64,mock',
+        getProvider() {
+          return Promise.resolve({ connect: vi.fn(), request: vi.fn() })
+        }
+      } as unknown as wagmiCore.Connector
+
+      const addConnectorSpy = vi.spyOn(adapter as any, 'addConnector')
+
+      await (adapter as any).addWagmiConnector(mockConnector, {
+        enableEIP6963: false
+      })
+
+      expect(addConnectorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          explorerId: expect.any(String)
+        })
+      )
+    })
   })
 
   describe('WagmiAdapter - signMessage', () => {


### PR DESCRIPTION
# Description

Fixed an issue where wallet buttons were not working in the in-app wallet browser

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-4296

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populate connector `explorerId` via `PresetsUtil` (by `rdns`/`name`) in ethers/ethers5 EIP6963 handling and wagmi, with tests and patch bumps.
> 
> - **Adapters**
>   - **ethers / ethers5**: When adding EIP6963 connectors, set `explorerId` from `PresetsUtil.ConnectorExplorerIds` using `info.rdns` or `info.name`.
>   - **wagmi**: `explorerId` now falls back to `PresetsUtil.ConnectorExplorerIds[connector.name]` when `connector.id` is not mapped.
> - **Tests**
>   - Add unit tests validating `explorerId` is set for EIP6963 (ethers/ethers5) and wagmi connectors.
> - **Release**
>   - Changeset adds patch version bumps for multiple `@reown/*` packages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d2f78bf5a47b9af1753ad457b2feea0e8c65fb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->