### PR TITLE
Fix: show customWallets in all wallets list when there are no adapters

### DIFF
--- a/.changeset/jolly-dolls-cover.md
+++ b/.changeset/jolly-dolls-cover.md
@@ -1,0 +1,6 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+---
+
+Fixed an issue where customWallets didn't show up in the all wallets list when there are no adapters


### PR DESCRIPTION
# Description

Fix: show customWallets in all wallets list when there are no adapters

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-3856
For GH issues: closes https://github.com/reown-com/appkit/issues/5062

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Includes `customWallets` in the all-wallets list by converting them to `WcWallet` when `noAdapters` is true, with tests and patch bumps.
> 
> - **Controllers (`packages/controllers/src/utils/WalletUtil.ts`)**:
>   - Update `getWalletConnectWallets` to include `OptionsController.state.customWallets` when `ChainController.state.noAdapters` is true by converting them to `WcWallet` (`supports_wc: true`) and excluding duplicates.
>   - Preserve existing flow: merge featured/recommended/filtered/all wallets, `uniqueBy('id')`, mark installed, filter by WC support, add `display_index`.
> - **Tests (`packages/scaffold-ui/test/WalletUtil.test.ts`)**:
>   - Add cases for converting custom wallets on `noAdapters`, not converting otherwise, handling empty custom list, de-duplication vs existing wallets, inclusion alongside featured/recommended, and preferring `filteredWallets`.
> - **Changesets**:
>   - Patch bumps for `@reown/appkit-controllers` and `@reown/appkit-scaffold-ui`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c7737dafea5db0fe3840b27657fbd51166fbb1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->