### PR TITLE
Fix `useAppKitProvider`: Don't wrap `walletProvider` with ref

### DIFF
--- a/packages/appkit/src/library/vue/index.ts
+++ b/packages/appkit/src/library/vue/index.ts
@@ -1,4 +1,4 @@
-import { onUnmounted, reactive, ref } from 'vue'
+import { onUnmounted, reactive, ref, shallowRef } from 'vue'
 
 import type { ChainNamespace } from '@reown/appkit-common'
 import { type ConnectorType, type Event } from '@reown/appkit-controllers'
@@ -63,8 +63,8 @@ export function getAppKit(appKit: AppKit) {
 export * from '@reown/appkit-controllers/vue'
 
 export function useAppKitProvider<T>(chainNamespace: ChainNamespace): UseAppKitReturnType<T> {
-  const walletProvider = ref(ProviderController.state.providers[chainNamespace] as T | undefined)
-  const walletProviderType = ref(ProviderController.state.providerIds[chainNamespace])
+  const walletProvider = shallowRef(ProviderController.state.providers[chainNamespace] as T | undefined)
+  const walletProviderType = shallowRef(ProviderController.state.providerIds[chainNamespace])
 
   const unsubscribe = ProviderController.subscribe(newState => {
     walletProvider.value = newState.providers[chainNamespace]


### PR DESCRIPTION
# Description

Currently `walletProvider` is wrapped with `ref` in `useAppKitProvider`. This creates Proxy for `walletProvider`, which could result in error like this on some wallets (e.g. MetaMask + Solana) when passing resulting `walletProvider` as argument to `AnchorProvider` (solana primary framework):
```
index-CCid8-zN.js:17 TypeError: Cannot read private member from an object whose class did not declare it
at G (inpage.js:2:131052)
at get accounts (inpage.js:2:255980)
at Reflect.get (<anonymous>)
at MutableReactiveHandler.get (index-CCid8-zN.js:10:11881)
at Proxy.getAccount (index-CCid8-zN.js:1032:4974)
at get publicKey (index-CCid8-zN.js:1032:2238)
at Reflect.get (<anonymous>)
at MutableReactiveHandler.get (index-CCid8-zN.js:10:11881)
at new AnchorProvider (index-CCid8-zN.js:1033:1295)
...
```

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
