### PR TITLE
fix(multi-wallet): walletconnect not reconnecting after page refresh

### DIFF
--- a/.changeset/odd-spies-work.md
+++ b/.changeset/odd-spies-work.md
@@ -1,0 +1,30 @@
+---
+'@reown/appkit': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where WalletConnect would not reconnect after page refresh when using multi-wallet

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1841,6 +1841,13 @@ export abstract class AppKitBaseClient {
           onConnect: accounts => {
             const { address } = CoreHelperUtil.getAccount(accounts[0])
 
+            for (const namespace of this.chainNamespaces) {
+              StorageUtil.removeDisconnectedConnectorId(
+                ConstantsUtil.CONNECTOR_ID.WALLET_CONNECT,
+                namespace
+              )
+            }
+
             ConnectionController.finalizeWcConnection(address as string)
           },
           onDisconnect: () => {


### PR DESCRIPTION
# Description

Fixed an issue where WalletConnect would not reconnect after page refresh when using multi-wallet

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-4176

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
