### PR TITLE
feat: add caipNetworkIds parameter to fetchWallets

### DIFF
--- a/packages/appkit/exports/constants.ts
+++ b/packages/appkit/exports/constants.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = '1.8.14'
+export const PACKAGE_VERSION = '1.8.16'

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useSnapshot } from 'valtio'
 
-import { type ChainNamespace, type Connection, ConstantsUtil } from '@reown/appkit-common'
+import {
+  type CaipNetworkId,
+  type ChainNamespace,
+  type Connection,
+  ConstantsUtil
+} from '@reown/appkit-common'
 
 import { AlertController } from '../src/controllers/AlertController.js'
 import { ApiController } from '../src/controllers/ApiController.js'
@@ -54,6 +59,12 @@ interface SwitchConnectionParams {
 interface DeleteRecentConnectionProps {
   address: string
   connectorId: string
+}
+
+interface FetchWalletsProps {
+  page?: number
+  query?: string
+  caipNetworkIds?: CaipNetworkId[]
 }
 
 // -- Hooks ------------------------------------------------------------
@@ -345,7 +356,7 @@ export interface UseAppKitWalletsReturn {
    * @param options.page - Page number to fetch (default: 1)
    * @param options.query - Search query to filter wallets (default: '')
    */
-  fetchWallets: (options?: { page?: number; query?: string }) => Promise<void>
+  fetchWallets: (options?: FetchWalletsProps) => Promise<void>
 
   /**
    * Function to connect to a wallet.
@@ -382,15 +393,17 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
   } = useSnapshot(ApiController.state)
   const { initialized, connectingWallet } = useSnapshot(PublicStateController.state)
 
-  async function fetchWallets(fetchOptions?: { page?: number; query?: string }) {
+  async function fetchWallets(fetchOptions?: FetchWalletsProps) {
     setIsFetchingWallets(true)
     try {
-      if (fetchOptions?.query) {
-        await ApiController.searchWallet({ search: fetchOptions?.query })
+      const { query, caipNetworkIds } = fetchOptions ?? {}
+      if (query) {
+        await ApiController.searchWallet({ search: query, caipNetworkIds })
       } else {
         ApiController.state.search = []
         await ApiController.fetchWalletsByPage({
-          page: fetchOptions?.page ?? 1
+          page: fetchOptions?.page ?? 1,
+          caipNetworkIds
         })
       }
     } catch (error) {

--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -2,7 +2,7 @@ import { proxy } from 'valtio/vanilla'
 import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 
 import { ConstantsUtil } from '@reown/appkit-common'
-import type { ChainNamespace } from '@reown/appkit-common'
+import type { CaipNetworkId, ChainNamespace } from '@reown/appkit-common'
 
 import { AssetUtil } from '../utils/AssetUtil.js'
 import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
@@ -67,6 +67,14 @@ interface PrefetchParameters {
   fetchRecommendedWallets?: boolean
   fetchNetworkImages?: boolean
   fetchWalletRanks?: boolean
+}
+
+interface SearchWalletParams extends Pick<ApiGetWalletsRequest, 'search' | 'badge'> {
+  caipNetworkIds?: CaipNetworkId[]
+}
+
+interface FetchWalletsByPageParams extends Pick<ApiGetWalletsRequest, 'page'> {
+  caipNetworkIds?: CaipNetworkId[]
 }
 
 type StateKey = keyof ApiControllerState
@@ -385,9 +393,10 @@ export const ApiController = {
     }
   },
 
-  async fetchWalletsByPage({ page }: Pick<ApiGetWalletsRequest, 'page'>) {
+  async fetchWalletsByPage({ page, caipNetworkIds }: FetchWalletsByPageParams) {
     const { includeWalletIds, excludeWalletIds, featuredWalletIds } = OptionsController.state
-    const chains = ChainController.getRequestedCaipNetworkIds().join(',')
+    const ids = caipNetworkIds ?? ChainController.getRequestedCaipNetworkIds()
+    const chains = ids.join(',')
     const exclude = [
       ...state.recommended.map(({ id }) => id),
       ...(excludeWalletIds ?? []),
@@ -435,9 +444,10 @@ export const ApiController = {
     }
   },
 
-  async searchWallet({ search, badge }: Pick<ApiGetWalletsRequest, 'search' | 'badge'>) {
+  async searchWallet({ search, badge, caipNetworkIds }: SearchWalletParams) {
     const { includeWalletIds, excludeWalletIds } = OptionsController.state
-    const chains = ChainController.getRequestedCaipNetworkIds().join(',')
+    const ids = caipNetworkIds ?? ChainController.getRequestedCaipNetworkIds()
+    const chains = ids.join(',')
     state.search = []
 
     const params = {

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -1012,6 +1012,87 @@ describe('useAppKitWallets', () => {
     expect(fetchWalletsByPageSpy).toHaveBeenCalledWith({ page: 3 })
   })
 
+  it('should fetch wallets with custom caipNetworkIds', async () => {
+    const setIsFetchingWallets = vi.fn()
+    mockedReact.useState.mockReturnValue([false, setIsFetchingWallets])
+
+    useSnapshot
+      .mockReturnValueOnce({
+        features: { headless: true },
+        remoteFeatures: { headless: true }
+      })
+      .mockReturnValueOnce({
+        wcUri: undefined,
+        wcFetchingUri: false
+      })
+      .mockReturnValueOnce({
+        wallets: [],
+        search: [],
+        page: 1,
+        count: 0
+      })
+      .mockReturnValueOnce({
+        initialized: true,
+        connectingWallet: undefined
+      })
+
+    vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
+    vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
+    const fetchWalletsByPageSpy = vi
+      .spyOn(ApiController, 'fetchWalletsByPage')
+      .mockResolvedValue(undefined)
+
+    const result = useAppKitWallets()
+
+    await result.fetchWallets({ page: 2, caipNetworkIds: ['eip155:1', 'solana:mainnet'] })
+
+    expect(fetchWalletsByPageSpy).toHaveBeenCalledWith({
+      page: 2,
+      caipNetworkIds: ['eip155:1', 'solana:mainnet']
+    })
+  })
+
+  it('should search wallets with custom caipNetworkIds', async () => {
+    const setIsFetchingWallets = vi.fn()
+    mockedReact.useState.mockReturnValue([false, setIsFetchingWallets])
+
+    useSnapshot
+      .mockReturnValueOnce({
+        features: { headless: true },
+        remoteFeatures: { headless: true }
+      })
+      .mockReturnValueOnce({
+        wcUri: undefined,
+        wcFetchingUri: false
+      })
+      .mockReturnValueOnce({
+        wallets: [],
+        search: [],
+        page: 1,
+        count: 0
+      })
+      .mockReturnValueOnce({
+        initialized: true,
+        connectingWallet: undefined
+      })
+
+    vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
+    vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
+    const searchWalletSpy = vi.spyOn(ApiController, 'searchWallet').mockResolvedValue(undefined)
+
+    const result = useAppKitWallets()
+
+    await result.fetchWallets({
+      query: 'metamask',
+      caipNetworkIds: ['eip155:1', 'eip155:137']
+    })
+
+    expect(searchWalletSpy).toHaveBeenCalledWith({
+      search: 'metamask',
+      caipNetworkIds: ['eip155:1', 'eip155:137']
+    })
+  })
+
   it('should handle fetchWallets error gracefully', async () => {
     const setIsFetchingWallets = vi.fn()
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})


### PR DESCRIPTION
## Summary

This PR adds support for filtering wallets by specific CAIP network IDs when fetching or searching wallets through the `useAppKitWallets` hook. This allows consumers to request wallets for specific chains (e.g., `['eip155:1', 'solana:mainnet']`) rather than always using the globally configured networks from `ChainController`.

## Changes Made

### API Changes
- **`ApiController.fetchWalletsByPage`**: Added optional `caipNetworkIds` parameter that, when provided, overrides the default behavior of using `ChainController.getRequestedCaipNetworkIds()`
- **`ApiController.searchWallet`**: Added optional `caipNetworkIds` parameter with the same override behavior
- **New interfaces**: Added `SearchWalletParams` and `FetchWalletsByPageParams` interfaces to type the new parameters

### React Hooks
- **`useAppKitWallets.fetchWallets`**: Extended the `FetchWalletsProps` interface to include an optional `caipNetworkIds` parameter that gets passed through to the underlying `ApiController` methods

### Type Imports
- Added `CaipNetworkId` type import from `@reown/appkit-common` in both affected files

## Testing

### New Test Cases Added
- `ApiController.test.ts`:
  - `should fetch wallets by page with custom caipNetworkIds` - Verifies that custom network IDs are used and `ChainController.getRequestedCaipNetworkIds()` is not called
  - `should search wallet with custom caipNetworkIds` - Same verification for the search functionality

- `react.test.ts`:
  - `should fetch wallets with custom caipNetworkIds` - Tests the hook correctly passes `caipNetworkIds` to `fetchWalletsByPage`
  - `should search wallets with custom caipNetworkIds` - Tests the hook correctly passes `caipNetworkIds` to `searchWallet`

### Test Results
All 807 tests pass (3 skipped - pre-existing).

## Related Issues

N/A

## Additional Notes

### Usage Example
```typescript
const { fetchWallets } = useAppKitWallets()

// Fetch wallets for specific networks only
await fetchWallets({ 
  page: 1, 
  caipNetworkIds: ['eip155:1', 'eip155:137'] 
})

// Search wallets for specific networks
await fetchWallets({ 
  query: 'metamask', 
  caipNetworkIds: ['eip155:1'] 
})
```

### Backward Compatibility
- No breaking changes - the `caipNetworkIds` parameter is optional
- Existing behavior is preserved when `caipNetworkIds` is not provided (falls back to `ChainController.getRequestedCaipNetworkIds()`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables filtering wallet lists by explicit CAIP network IDs instead of global chain config.
> 
> - Adds optional `caipNetworkIds` to `ApiController.fetchWalletsByPage` and `ApiController.searchWallet`, overriding `ChainController.getRequestedCaipNetworkIds()` when provided; introduces `SearchWalletParams` and `FetchWalletsByPageParams`
> - Extends `useAppKitWallets.fetchWallets` options with `caipNetworkIds` and forwards to API methods
> - Updates tests in `ApiController.test.ts` and `react.test.ts` to validate custom `caipNetworkIds` usage and hook propagation
> - Bumps `PACKAGE_VERSION` to `1.8.16`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb11ba029598ad50c34fd17e292298c732718567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->