### PR TITLE
fix: skip pay URL encoding in Telegram Android context

### DIFF
--- a/packages/controllers/src/utils/CoreHelperUtil.ts
+++ b/packages/controllers/src/utils/CoreHelperUtil.ts
@@ -559,6 +559,11 @@ export const CoreHelperUtil = {
       return wcUri
     }
 
+    // Avoid encoding in telegram android context
+    if (this.isTelegram() && this.isAndroid()) {
+      return `${wcUri}&pay=${wcPayUrl}`
+    }
+
     return `${wcUri}&pay=${encodeURIComponent(wcPayUrl)}`
   }
 }

--- a/packages/controllers/tests/utils/CoreHelperUtil.test.ts
+++ b/packages/controllers/tests/utils/CoreHelperUtil.test.ts
@@ -216,5 +216,45 @@ describe('CoreHelperUtil', () => {
       expect(result).toBe(`${wcUri}&pay=${encodeURIComponent(wcPayUrl)}`)
       expect(result).toContain('&pay=https%3A%2F%2Fpay.example.com')
     })
+
+    it('should NOT encode pay param in Telegram Android context', () => {
+      const wcPayUrl = 'https://pay.walletconnect.com/?pid=pay_123'
+
+      vi.spyOn(CoreHelperUtil, 'isTelegram').mockReturnValue(true)
+      vi.spyOn(CoreHelperUtil, 'isAndroid').mockReturnValue(true)
+
+      const result = CoreHelperUtil.appendPayToUri(wcUri, wcPayUrl)
+
+      expect(result).toBe(`${wcUri}&pay=${wcPayUrl}`)
+      expect(result).not.toContain(encodeURIComponent(wcPayUrl))
+
+      vi.restoreAllMocks()
+    })
+
+    it('should encode pay param in Telegram iOS context', () => {
+      const wcPayUrl = 'https://pay.walletconnect.com/?pid=pay_123'
+
+      vi.spyOn(CoreHelperUtil, 'isTelegram').mockReturnValue(true)
+      vi.spyOn(CoreHelperUtil, 'isAndroid').mockReturnValue(false)
+
+      const result = CoreHelperUtil.appendPayToUri(wcUri, wcPayUrl)
+
+      expect(result).toBe(`${wcUri}&pay=${encodeURIComponent(wcPayUrl)}`)
+
+      vi.restoreAllMocks()
+    })
+
+    it('should encode pay param in non-Telegram Android context', () => {
+      const wcPayUrl = 'https://pay.walletconnect.com/?pid=pay_123'
+
+      vi.spyOn(CoreHelperUtil, 'isTelegram').mockReturnValue(false)
+      vi.spyOn(CoreHelperUtil, 'isAndroid').mockReturnValue(true)
+
+      const result = CoreHelperUtil.appendPayToUri(wcUri, wcPayUrl)
+
+      expect(result).toBe(`${wcUri}&pay=${encodeURIComponent(wcPayUrl)}`)
+
+      vi.restoreAllMocks()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes broken WalletConnect Pay deep links in Telegram on Android by skipping URL encoding of the `wcPayUrl` parameter in that specific context. Telegram Android has issues handling double-encoded URLs, which was causing deep links to fail when using WalletConnect Pay.

## Changes Made

- **`CoreHelperUtil.ts`**: Added conditional check in `appendPayToUri` to skip `encodeURIComponent` when running in Telegram on Android
- **`CoreHelperUtil.test.ts`**: Added 3 new test cases covering:
  - Telegram Android context (should NOT encode)
  - Telegram iOS context (should encode)
  - Non-Telegram Android context (should encode)

## Testing

- [x] Added unit tests for the new behavior with all edge cases
- [x] All 30 `CoreHelperUtil` tests pass
- [x] Tests use mocked `isTelegram()` and `isAndroid()` to verify correct behavior across platform combinations

**Test matrix:**

| Context | Telegram | Android | Should Encode |
|---------|----------|---------|---------------|
| Telegram Android | ✓ | ✓ | ✗ |
| Telegram iOS | ✓ | ✗ | ✓ |
| Browser Android | ✗ | ✓ | ✓ |
| Browser Desktop | ✗ | ✗ | ✓ |

## Related Issues

- Fixes deep link issues for WalletConnect Pay in Telegram Mini Apps on Android

## Additional Notes

- This follows the same pattern used in `formatNativeUrl` which already double-encodes URIs specifically for Telegram Android
- The fix is targeted to only affect Telegram Android; all other platforms continue to encode as expected
- No breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes WalletConnect Pay deep links by adjusting URL handling for Telegram on Android.
> 
> - Updates `appendPayToUri` in `CoreHelperUtil.ts` to bypass `encodeURIComponent` when `isTelegram()` and `isAndroid()` are true; otherwise continues encoding
> - Adds unit tests in `CoreHelperUtil.test.ts` covering Telegram Android (no encode), Telegram iOS (encode), and non-Telegram Android (encode), plus existing encoding cases (including special characters)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1c6492ad96e8e7d29ace0711fab0551476e911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->