### PR TITLE
fix: correct typos in CLI README and dangerfile

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -226,7 +226,7 @@ async function checkCorePackage() {
 
   if (modified_core_controllers.length && !modified_core_controllers_tests) {
     message(`
-      The following controllers were modified, but not tests were changed:
+      The following controllers were modified, but no tests were changed:
       ${modified_core_controllers.join('\n')}
     `)
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # Reown AppKit CLI
 
-**AppKit CLI** is a command-line tool to fast download a funcionaly boilerplate example for Reown Web AppKit SDK.
+**AppKit CLI** is a command-line tool to quickly download a functional boilerplate example for Reown Web AppKit SDK.
 
 ## Installation
 
@@ -45,7 +45,7 @@ npx appkit-cli
 
 ### Example Commands
 
-Provide examples of some paramaeters:
+Provide examples of some parameters:
 
 ```bash
 appkit-cli [project-name]


### PR DESCRIPTION
## Summary
- Fix typo "funcionaly" to "functional" in CLI README
- Fix typo "paramaeters" to "parameters" in CLI README  
- Improve phrasing from "fast download" to "quickly download" for better grammar
- Fix grammar "but not tests were changed" to "but no tests were changed" in dangerfile.ts

## Test plan
- [x] Verified changes are documentation/comment only
- [x] No functional code changes