### PR TITLE
chore: fix broken TODO comment with accidental URL

### DIFF
--- a/packages/ui/src/utils/ThemeConstantsUtil.ts
+++ b/packages/ui/src/utils/ThemeConstantsUtil.ts
@@ -214,7 +214,7 @@ export const borderRadius = {
   round: '9999px'
 }
 
-// @TODO: Provide proper values to something sm, md, lg, http://localhost:6006/?path=/docs/theme-spacing--docsxl, etc.
+// @TODO: Provide proper values using named sizes (sm, md, lg, xl, etc.)
 export const spacing = {
   '0': '0px',
   '01': '2px',


### PR DESCRIPTION
## Summary
- Clean up a TODO comment in `ThemeConstantsUtil.ts` that had a localhost URL accidentally pasted into it
- The original comment `@TODO: Provide proper values to something sm, md, lg, http://localhost:6006/?path=/docs/theme-spacing--docsxl, etc.` is now cleaned to `@TODO: Provide proper values using named sizes (sm, md, lg, xl, etc.)`

## Test plan
- [x] Comment-only change, no functional impact
- [x] Improves code readability