### PR TITLE
docs: update documentation links to current URL format

### DIFF
--- a/packages/experimental/README.md
+++ b/packages/experimental/README.md
@@ -1,4 +1,4 @@
-#### 📚 [Documentation](https://docs.reown.com/2.0/appkit/about)
+#### 📚 [Documentation](https://docs.reown.com/appkit/overview)
 
 #### 🔗 [Website](https://reown.com/appkit)
 

--- a/packages/siwx/README.md
+++ b/packages/siwx/README.md
@@ -1,4 +1,4 @@
-#### 📚 [Documentation](https://docs.reown.com/2.0/appkit/about)
+#### 📚 [Documentation](https://docs.reown.com/appkit/overview)
 
 #### 🔗 [Website](https://reown.com/appkit)
 


### PR DESCRIPTION
## Summary
- Update documentation links in `@reown/appkit-siwx` and `@reown/appkit-experimental` package READMEs
- Changed from old URL format `/2.0/appkit/about` to current format `/appkit/overview`
- This makes these READMEs consistent with the rest of the repository

## Test plan
- [x] Documentation-only change
- [x] Verified other package READMEs use `/appkit/overview` format