### PR TITLE
fix: correct typo 'deafult' to 'default' in test description

### DIFF
--- a/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
+++ b/packages/appkit-utils/tests/CaipNetworkUtil.test.ts
@@ -294,7 +294,7 @@ describe('CaipNetworksUtil', () => {
       )
     })
 
-    it('should create transport with deafult RPC URL if blockchain API is not supported', () => {
+    it('should create transport with default RPC URL if blockchain API is not supported', () => {
       CaipNetworksUtil.getViemTransport(
         { ...immutableZkEvmTestnet, chainNamespace: 'eip155', caipNetworkId: 'eip155:1' },
         mockProjectId


### PR DESCRIPTION
## Summary
- Fix spelling error "deafult" to "default" in the test case description in `CaipNetworkUtil.test.ts`

## Test plan
- [x] Test description fix only, no functional change
- [x] Test behavior unchanged