### PR TITLE
fix: correct typo 'unsuported' to 'unsupported' in ConnectorUtil

### DIFF
--- a/apps/laboratory/src/utils/ConnectorUtil.ts
+++ b/apps/laboratory/src/utils/ConnectorUtil.ts
@@ -23,7 +23,7 @@ export function externalTestConnector() {
         chainId: 0,
         chain: {
           id: 0,
-          unsuported: false
+          unsupported: false
         }
       })
     },


### PR DESCRIPTION
## Summary
- Fix spelling error "unsuported" to "unsupported" in the test connector utility (`apps/laboratory/src/utils/ConnectorUtil.ts`)

## Test plan
- [x] Property name fix in test utility
- [x] No functional impact on production code