### PR TITLE
fix: correct typo 'reuqestedCaipNetworks' to 'requestedCaipNetworks'

### DIFF
--- a/packages/controllers/tests/controllers/ApiController.test.ts
+++ b/packages/controllers/tests/controllers/ApiController.test.ts
@@ -211,7 +211,7 @@ describe('ApiController', () => {
   })
 
   it('should fetch network images ', async () => {
-    const reuqestedCaipNetworks = [
+    const requestedCaipNetworks = [
       {
         caipNetworkId: 'eip155:1',
         id: 1,
@@ -273,10 +273,10 @@ describe('ApiController', () => {
       [
         {
           namespace: ConstantsUtil.CHAIN.EVM,
-          caipNetworks: reuqestedCaipNetworks
+          caipNetworks: requestedCaipNetworks
         }
       ],
-      reuqestedCaipNetworks,
+      requestedCaipNetworks,
       {
         connectionControllerClient: vi.fn() as unknown as ConnectionControllerClient
       }


### PR DESCRIPTION
## Summary
- Fix variable name typo "reuqestedCaipNetworks" to "requestedCaipNetworks" in `ApiController.test.ts`

## Test plan
- [x] Variable name fix in test file only
- [x] Test behavior unchanged