### PR TITLE
fix: correct typo 'succesfully' to 'successfully'

### DIFF
--- a/apps/laboratory/src/components/Wagmi/WagmiCreatePasskeySignerTest.tsx
+++ b/apps/laboratory/src/components/Wagmi/WagmiCreatePasskeySignerTest.tsx
@@ -22,7 +22,7 @@ export function WagmiCreatePasskeySignerTest() {
       setPasskey(credential)
       toast({
         type: 'success',
-        title: 'Passkey created succesfully',
+        title: 'Passkey created successfully',
         description: ''
       })
     } catch (error) {

--- a/packages/adapters/wagmi/src/tests/client.test.ts
+++ b/packages/adapters/wagmi/src/tests/client.test.ts
@@ -727,7 +727,7 @@ describe('WagmiAdapter', () => {
       expect(adapter.wagmiConfig.state.connections.size).toBe(0)
     })
 
-    it('should disconnect wagmi context succesfully even if one of the connectors fails to disconnect', async () => {
+    it('should disconnect wagmi context successfully even if one of the connectors fails to disconnect', async () => {
       const mockConnections = [
         {
           accounts: ['0x123'],

--- a/packages/controllers/src/utils/SIWXUtil.ts
+++ b/packages/controllers/src/utils/SIWXUtil.ts
@@ -575,7 +575,7 @@ export interface SIWXConfig {
    *
    * Constraints:
    * - This method MUST verify all the sessions before storing them in the storage;
-   * - This method MUST replace all the sessions in the storage with the new ones succesfully otherwise it MUST throw an error.
+   * - This method MUST replace all the sessions in the storage with the new ones successfully otherwise it MUST throw an error.
    *
    * @param sessions SIWXSession[]
    */


### PR DESCRIPTION
## Summary
Fix spelling error "succesfully" to "successfully" in multiple files:
- `apps/laboratory/src/components/Wagmi/WagmiCreatePasskeySignerTest.tsx` - toast message
- `packages/adapters/wagmi/src/tests/client.test.ts` - test description
- `packages/controllers/src/utils/SIWXUtil.ts` - JSDoc comment

## Test plan
- [x] String and comment fixes only
- [x] No functional changes