### PR TITLE
fix: use tron_getAddressBalance JSON-RPC for TRON balance and update network preset IDs

### DIFF
--- a/packages/appkit-utils/src/PresetsUtil.ts
+++ b/packages/appkit-utils/src/PresetsUtil.ts
@@ -122,11 +122,11 @@ export const PresetsUtil = {
     // TON Testnet
     '-3': '20f673c0-095e-49b2-07cf-eb5049dcf600',
     // TRON
-    '0x2b6653dc': 'dd9de794-d4ce-4c94-682f-a367f926d500',
+    '0x2b6653dc': '3502bb86-cc4e-420f-a387-59ea63a28b00',
     // TRON Shasta Testnet
-    '0x94a9059e': 'dd9de794-d4ce-4c94-682f-a367f926d500',
+    '0x94a9059e': '3502bb86-cc4e-420f-a387-59ea63a28b00',
     // TRON Nile Testnet
-    '0xcd8690dc': 'dd9de794-d4ce-4c94-682f-a367f926d500'
+    '0xcd8690dc': '3502bb86-cc4e-420f-a387-59ea63a28b00'
   } as Record<string, string>,
 
   ConnectorImageIds: {

--- a/packages/controllers/src/controllers/BlockchainApiController.ts
+++ b/packages/controllers/src/controllers/BlockchainApiController.ts
@@ -298,15 +298,20 @@ export const BlockchainApiController = {
     })
   },
 
-  async getAddressBalance({ caipNetworkId, address }: BlockchainApiGetAddressBalanceRequest) {
+  async getAddressBalance<T = string>({
+    caipNetworkId,
+    address,
+    method = 'getAddressBalance',
+    params
+  }: BlockchainApiGetAddressBalanceRequest) {
     return state.api
-      .post<BlockchainApiGetAddressBalanceResponse>({
+      .post<BlockchainApiGetAddressBalanceResponse<T>>({
         path: `/v1?chainId=${caipNetworkId}&projectId=${OptionsController.state.projectId}`,
         body: {
           id: '1',
           jsonrpc: '2.0',
-          method: 'getAddressBalance',
-          params: { address }
+          method,
+          params: params ?? { address }
         }
       })
       .then(result => result.result)

--- a/packages/controllers/src/utils/TypeUtil.ts
+++ b/packages/controllers/src/utils/TypeUtil.ts
@@ -276,11 +276,13 @@ export interface BlockchainApiSwapTokensRequest {
 export interface BlockchainApiGetAddressBalanceRequest {
   caipNetworkId: string
   address: string
+  method?: string
+  params?: unknown
 }
 
-export interface BlockchainApiGetAddressBalanceResponse {
+export interface BlockchainApiGetAddressBalanceResponse<T = string> {
   ok: boolean
-  result: string
+  result: T
   jsonrpc: string
   id: string
 }


### PR DESCRIPTION
## Summary

- **TRON balance**: Switched from the `/v1/account/{address}/balance` REST endpoint (which uses TronGrid with free-plan rate limits) to the `tron_getAddressBalance` custom JSON-RPC method via BAPI (uses Quicknode, [BAPI PR #1350](https://github.com/reown-com/blockchain-api/pull/1350)). Parses the Quicknode account response to extract balance in SUN and converts to TRX (÷ 10^6).
- **Generic `getAddressBalance`**: Made the method accept optional `method` and `params` parameters so chain-specific adapters (TRON, TON, etc.) can customize the JSON-RPC call without needing separate controller methods. TON adapter is unaffected (uses defaults).
- **TRON network images**: Updated preset IDs for TRON mainnet, Shasta, and Nile testnet to use the correct network images.

## Changes

| File | What changed |
|------|-------------|
| `controllers/BlockchainApiController.ts` | `getAddressBalance` now accepts optional `method` and `params`, generic `<T>` for response type |
| `controllers/utils/TypeUtil.ts` | Updated request/response types with optional fields and generic |
| `adapters/tron/adapter.ts` | Uses `tron_getAddressBalance` method, parses `response.data[0].balance` from Quicknode |
| `appkit-utils/PresetsUtil.ts` | Updated TRON network image preset IDs |

## Note

Requires `tron_getAddressBalance` to be available on the BAPI RPC provider for the project ID being used. Currently confirmed working on Quicknode provider. See [BAPI PR #1350](https://github.com/reown-com/blockchain-api/pull/1350).

## Test plan

- [ ] Connect TronLink wallet — TRX balance should display correctly
- [ ] TON adapter balance still works (uses default `getAddressBalance` params)
- [ ] TRON network images display correctly in network selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates TRON balance retrieval to a new JSON-RPC method and loosens `BlockchainApiController.getAddressBalance` typing/parameters, which could break balance display if the RPC method/response shape differs or is unavailable.
> 
> **Overview**
> TRON balance fetching now uses `BlockchainApiController.getAddressBalance` with the `tron_getAddressBalance` JSON-RPC method and converts the returned SUN value to TRX via `NumberUtil`.
> 
> `BlockchainApiController.getAddressBalance` is generalized to accept optional `method`/`params` and a generic response type, and TRON mainnet/testnet preset network image IDs are updated in `PresetsUtil`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be0e9ef1f8defd526cc04a80fdf562049f4f2ba7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->