### PR TITLE
fix: allAccounts empty on page reload when social features disabled

### DIFF
--- a/.changeset/fix-allaccounts-on-reload.md
+++ b/.changeset/fix-allaccounts-on-reload.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit': patch
+---
+
+Fixed `allAccounts` being empty on page reload when using vanilla JS `subscribeAccount`. The callback was not subscribed to `ConnectionController` state changes, so it never fired when connections were populated after reconnection.

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2485,6 +2485,9 @@ export abstract class AppKitBaseClient {
     const unsub = ConnectorController.subscribe(updateVal)
     unsubArr.push(unsub)
 
+    const unsubConnections = ConnectionController.subscribeKey('connections', updateVal)
+    unsubArr.push(unsubConnections)
+
     return () => {
       unsubArr.forEach(fn => fn())
     }

--- a/packages/appkit/tests/client/appkit-core.test.ts
+++ b/packages/appkit/tests/client/appkit-core.test.ts
@@ -137,14 +137,57 @@ describe('AppKitCore', () => {
 
     it('should call all unsubscribe functions in subscribeAccount', () => {
       const mockUnsub = vi.fn()
-      vi.spyOn(ChainController, 'subscribe').mockReturnValue(mockUnsub)
-      vi.spyOn(ConnectorController, 'subscribe').mockReturnValue(mockUnsub)
-      vi.spyOn(ConnectionController, 'subscribeKey').mockReturnValue(mockUnsub)
+      const chainSubscribeSpy = vi.spyOn(ChainController, 'subscribe').mockReturnValue(mockUnsub)
+      const connectorSubscribeSpy = vi
+        .spyOn(ConnectorController, 'subscribe')
+        .mockReturnValue(mockUnsub)
+      const connectionSubscribeKeySpy = vi
+        .spyOn(ConnectionController, 'subscribeKey')
+        .mockReturnValue(mockUnsub)
 
       const unsubscribe = appKit.subscribeAccount(() => {})
       unsubscribe()
 
+      expect(chainSubscribeSpy).toHaveBeenCalledTimes(1)
+      expect(connectorSubscribeSpy).toHaveBeenCalledTimes(1)
+      expect(connectionSubscribeKeySpy).toHaveBeenCalledTimes(1)
+      expect(connectionSubscribeKeySpy).toHaveBeenCalledWith('connections', expect.any(Function))
       expect(mockUnsub).toHaveBeenCalledTimes(3)
+    })
+
+    it('should fire subscribeAccount callback when ConnectionController connections change', async () => {
+      const callback = vi.fn()
+      const namespace = ConstantsUtil.CHAIN.EVM
+
+      vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
+        caipAddress: `eip155:1:0xABC`,
+        status: 'connected'
+      } as unknown as AccountState)
+
+      vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue(namespace)
+
+      const unsubscribe = appKit.subscribeAccount(callback, namespace)
+
+      ConnectionController.setConnections(
+        [
+          {
+            connectorId: 'io.metamask',
+            accounts: [{ address: '0xABC' }],
+            caipNetwork: { caipNetworkId: 'eip155:1', id: 1, chainNamespace: 'eip155' }
+          }
+        ] as any,
+        namespace
+      )
+
+      // valtio subscribeKey notifies asynchronously via microtask
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(callback).toHaveBeenCalled()
+      const lastCall = callback.mock.calls[callback.mock.calls.length - 1]![0]
+      expect(lastCall.allAccounts.length).toBeGreaterThan(0)
+      expect(lastCall.allAccounts[0].address).toBe('0xABC')
+
+      unsubscribe()
     })
   })
 })

--- a/packages/appkit/tests/client/appkit-core.test.ts
+++ b/packages/appkit/tests/client/appkit-core.test.ts
@@ -139,11 +139,12 @@ describe('AppKitCore', () => {
       const mockUnsub = vi.fn()
       vi.spyOn(ChainController, 'subscribe').mockReturnValue(mockUnsub)
       vi.spyOn(ConnectorController, 'subscribe').mockReturnValue(mockUnsub)
+      vi.spyOn(ConnectionController, 'subscribeKey').mockReturnValue(mockUnsub)
 
       const unsubscribe = appKit.subscribeAccount(() => {})
       unsubscribe()
 
-      expect(mockUnsub).toHaveBeenCalledTimes(2)
+      expect(mockUnsub).toHaveBeenCalledTimes(3)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Fixes `subscribeAccount()` not reacting to `ConnectionController.state.connections` changes, causing `allAccounts` to be empty on page reload in vanilla JS apps
- Closes #5562, #5191, #5256

## Root Cause

`subscribeAccount()` in `appkit-base-client.ts` subscribed to `ChainController` and `ConnectorController` changes, but **not** to `ConnectionController`. Since `allAccounts` is derived from `ConnectionController.state.connections`, the callback never fired when connections were populated during reconnection.

**Why it appeared to be related to social features config:**
When social login was enabled, `createAuthProviderForAdapter()` added an AUTH connector → `ConnectorController` updated → `subscribeAccount` callback fired coincidentally → `getAccount()` read the already-populated connections → `allAccounts` had data. When social login was disabled, no such trigger occurred.

React and Vue hooks were unaffected because they subscribe to `ConnectionController.state` directly (`useSnapshot` / `subscribeKey`).

## Changes

- **`packages/appkit/src/client/appkit-base-client.ts`** — added `ConnectionController.subscribeKey('connections', updateVal)` subscription in `subscribeAccount()`
- **`packages/appkit/tests/client/appkit-core.test.ts`** — updated unsubscribe count assertion (2 → 3)

## Test plan

- [x] Verified fix on [live demo](https://de-don.github.io/appkit-web-examples/) by patching `node_modules`
- [x] Unit tests pass (`pnpm vitest run packages/appkit/tests/client/appkit-core.test.ts`)
- [x] Connect a web3 wallet → reload page → verify `allAccounts` is populated immediately without opening modal
- [x] Verify with social login disabled in cloud config
- [x] Verify React/Vue hooks are not affected (no duplicate callbacks)