### PR TITLE
feat: expose WC relay clientId in useAppKitWallets

### DIFF
--- a/.changeset/fiery-carrots-grin.md
+++ b/.changeset/fiery-carrots-grin.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Exposes WC clientId in useAppKitWallets

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -12,6 +12,7 @@ import {
 import { AlertController } from '../src/controllers/AlertController.js'
 import { ApiController } from '../src/controllers/ApiController.js'
 import { AssetController } from '../src/controllers/AssetController.js'
+import { BlockchainApiController } from '../src/controllers/BlockchainApiController.js'
 import { ChainController } from '../src/controllers/ChainController.js'
 import { ConnectionController } from '../src/controllers/ConnectionController.js'
 import { ConnectorController } from '../src/controllers/ConnectorController.js'
@@ -422,6 +423,11 @@ export interface UseAppKitWalletsReturn {
    * Boolean that indicates if there was an error fetching the WalletConnect URI.
    */
   wcError: boolean
+
+  /**
+   * The WalletConnect relay client ID. Set after a WalletConnect connection is established.
+   */
+  clientId: string | null
 }
 
 /**
@@ -442,6 +448,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     count
   } = useSnapshot(ApiController.state)
   const { initialized, connectingWallet } = useSnapshot(PublicStateController.state)
+  const { clientId } = useSnapshot(BlockchainApiController.state)
 
   // Alert if headless is not enabled
   useEffect(() => {
@@ -595,7 +602,8 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
       fetchWallets: () => Promise.resolve(),
       resetWcUri,
       resetConnectingWallet,
-      getWcUri: () => Promise.resolve()
+      getWcUri: () => Promise.resolve(),
+      clientId: null
     }
   }
 
@@ -617,6 +625,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     fetchWallets,
     resetWcUri,
     resetConnectingWallet,
-    getWcUri
+    getWcUri,
+    clientId
   }
 }

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -427,7 +427,7 @@ export interface UseAppKitWalletsReturn {
   /**
    * The WalletConnect relay client ID. Set after a WalletConnect connection is established.
    */
-  clientId: string | null
+  wcClientId: string | null
 }
 
 /**
@@ -448,7 +448,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     count
   } = useSnapshot(ApiController.state)
   const { initialized, connectingWallet } = useSnapshot(PublicStateController.state)
-  const { clientId } = useSnapshot(BlockchainApiController.state)
+  const { clientId: wcClientId } = useSnapshot(BlockchainApiController.state)
 
   // Alert if headless is not enabled
   useEffect(() => {
@@ -603,7 +603,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
       resetWcUri,
       resetConnectingWallet,
       getWcUri: () => Promise.resolve(),
-      clientId: null
+      wcClientId: null
     }
   }
 
@@ -626,6 +626,6 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
     resetWcUri,
     resetConnectingWallet,
     getWcUri,
-    clientId
+    wcClientId
   }
 }

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -887,7 +887,7 @@ describe('useAppKitWallets', () => {
       resetConnectingWallet: expect.any(Function),
       getWcUri: expect.any(Function),
       wcError: false,
-      clientId: null
+      wcClientId: null
     })
   })
 
@@ -993,7 +993,7 @@ describe('useAppKitWallets', () => {
     expect(result.connectingWallet).toEqual(mockWalletItem)
     expect(result.page).toBe(2)
     expect(result.count).toBe(50)
-    expect(result.clientId).toBe('relay-client-abc123')
+    expect(result.wcClientId).toBe('relay-client-abc123')
   })
 
   it('should fetch wallets without query', async () => {

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -886,7 +886,8 @@ describe('useAppKitWallets', () => {
       resetWcUri: expect.any(Function),
       resetConnectingWallet: expect.any(Function),
       getWcUri: expect.any(Function),
-      wcError: false
+      wcError: false,
+      clientId: null
     })
   })
 
@@ -934,6 +935,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue(mockWallets)
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue(mockWcWallets)
@@ -974,6 +978,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: mockWalletItem
       })
+      .mockReturnValueOnce({
+        clientId: 'relay-client-abc123'
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -986,6 +993,7 @@ describe('useAppKitWallets', () => {
     expect(result.connectingWallet).toEqual(mockWalletItem)
     expect(result.page).toBe(2)
     expect(result.count).toBe(50)
+    expect(result.clientId).toBe('relay-client-abc123')
   })
 
   it('should fetch wallets without query', async () => {
@@ -1010,6 +1018,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1051,6 +1062,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1087,6 +1101,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1125,6 +1142,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1166,6 +1186,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1201,6 +1224,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1235,6 +1261,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1277,6 +1306,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1315,6 +1347,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1361,6 +1396,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1404,6 +1442,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1439,6 +1480,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1479,6 +1523,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
     vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
@@ -1511,6 +1558,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1547,6 +1597,9 @@ describe('useAppKitWallets', () => {
         initialized: true,
         connectingWallet: undefined
       })
+      .mockReturnValueOnce({
+        clientId: null
+      })
 
     const mockSearchWalletItems = mockSearchWallets.map(w => ({
       ...mockWalletItem,
@@ -1580,6 +1633,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
@@ -1621,6 +1677,9 @@ describe('useAppKitWallets', () => {
       .mockReturnValueOnce({
         initialized: true,
         connectingWallet: undefined
+      })
+      .mockReturnValueOnce({
+        clientId: null
       })
 
     vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])


### PR DESCRIPTION
## Summary
- Exposes the WalletConnect relay `clientId` from `BlockchainApiController.state` as a first-class property in the `useAppKitWallets` hook return type
- Returns `null` when headless mode is disabled, and the actual `clientId` value when enabled
- Adds test coverage including a non-null `clientId` assertion

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes (no new warnings)
- [x] `pnpm run prettier:format` — no changes
- [x] `pnpm typecheck` passes
- [x] `pnpm test -- packages/controllers/tests/hooks/react.test.ts` — 45/45 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)