### PR TITLE
fix: filter wallets without wc support from useAppKitWallets search results on mobile

### DIFF
--- a/packages/controllers/src/utils/ConnectUtil.ts
+++ b/packages/controllers/src/utils/ConnectUtil.ts
@@ -62,11 +62,9 @@ export const ConnectUtil = {
    */
   getWalletConnectWallets(wcAllWallets: WcWallet[], wcSearchWallets: WcWallet[]) {
     if (wcSearchWallets.length > 0) {
-      const withInstalled = WalletUtil.markWalletsAsInstalled(wcSearchWallets)
-      const filtered = WalletUtil.filterWalletsByWcSupport(withInstalled)
-      const withIndex = WalletUtil.markWalletsWithDisplayIndex(filtered)
-
-      return withIndex.map(w => this.mapWalletToWalletItem(w))
+      return WalletUtil.filterAndFlagWallets(wcSearchWallets).map(w =>
+        this.mapWalletToWalletItem(w)
+      )
     }
 
     return WalletUtil.getWalletConnectWallets(wcAllWallets).map(w => this.mapWalletToWalletItem(w))

--- a/packages/controllers/src/utils/ConnectUtil.ts
+++ b/packages/controllers/src/utils/ConnectUtil.ts
@@ -62,7 +62,11 @@ export const ConnectUtil = {
    */
   getWalletConnectWallets(wcAllWallets: WcWallet[], wcSearchWallets: WcWallet[]) {
     if (wcSearchWallets.length > 0) {
-      return wcSearchWallets.map(w => this.mapWalletToWalletItem(w))
+      const withInstalled = WalletUtil.markWalletsAsInstalled(wcSearchWallets)
+      const filtered = WalletUtil.filterWalletsByWcSupport(withInstalled)
+      const withIndex = WalletUtil.markWalletsWithDisplayIndex(filtered)
+
+      return withIndex.map(w => this.mapWalletToWalletItem(w))
     }
 
     return WalletUtil.getWalletConnectWallets(wcAllWallets).map(w => this.mapWalletToWalletItem(w))

--- a/packages/controllers/src/utils/WalletUtil.ts
+++ b/packages/controllers/src/utils/WalletUtil.ts
@@ -184,6 +184,13 @@ export const WalletUtil = {
     return wallets.map((w, index) => ({ ...w, display_index: index }))
   },
 
+  filterAndFlagWallets(wallets: WcWallet[]) {
+    const withInstalled = WalletUtil.markWalletsAsInstalled(wallets)
+    const filtered = WalletUtil.filterWalletsByWcSupport(withInstalled)
+
+    return WalletUtil.markWalletsWithDisplayIndex(filtered)
+  },
+
   /**
    * Filters wallets based on WalletConnect support and platform requirements.
    *
@@ -218,9 +225,7 @@ export const WalletUtil = {
     }
 
     const uniqueWallets = CoreHelperUtil.uniqueBy(wallets, 'id')
-    const walletsWithInstalled = WalletUtil.markWalletsAsInstalled(uniqueWallets)
-    const walletsByWcSupport = WalletUtil.filterWalletsByWcSupport(walletsWithInstalled)
 
-    return WalletUtil.markWalletsWithDisplayIndex(walletsByWcSupport)
+    return WalletUtil.filterAndFlagWallets(uniqueWallets)
   }
 }

--- a/packages/controllers/tests/utils/ConnectUtil.test.ts
+++ b/packages/controllers/tests/utils/ConnectUtil.test.ts
@@ -52,8 +52,9 @@ describe('ConnectUtil', () => {
       expect(result.map(w => w.id)).toEqual(['wc-wallet'])
     })
 
-    it('should include all search results on desktop regardless of wc support', () => {
+    it('should include all search results on desktop when wcBasic is false', () => {
       vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+      ConnectionController.state.wcBasic = false
 
       const walletWithWc = createMockWcWallet({
         id: 'wc-wallet',
@@ -71,7 +72,27 @@ describe('ConnectUtil', () => {
       expect(result.map(w => w.id)).toEqual(['wc-wallet', 'no-wc-wallet'])
     })
 
-    it('should preserve order of search results', () => {
+    it('should filter out wallets without wc support on desktop when wcBasic is true', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+      ConnectionController.state.wcBasic = true
+
+      const walletWithWc = createMockWcWallet({
+        id: 'wc-wallet',
+        name: 'WC Wallet',
+        supports_wc: true
+      })
+      const walletWithoutWc = createMockWcWallet({
+        id: 'no-wc-wallet',
+        name: 'No WC Wallet',
+        supports_wc: false
+      })
+
+      const result = ConnectUtil.getWalletConnectWallets([], [walletWithWc, walletWithoutWc])
+
+      expect(result.map(w => w.id)).toEqual(['wc-wallet'])
+    })
+
+    it('should preserve order of search results when no installed or featured wallets', () => {
       vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
 
       const wallets = [
@@ -86,6 +107,29 @@ describe('ConnectUtil', () => {
       expect(result[0]?.id).toBe('wallet-0')
       expect(result[1]?.id).toBe('wallet-1')
       expect(result[2]?.id).toBe('wallet-2')
+    })
+
+    it('should sort installed wallets first in search results', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+      ConnectorController.state.connectors = [
+        {
+          id: 'wallet-2-connector',
+          name: 'Wallet 2',
+          type: 'ANNOUNCED',
+          chain: 'eip155',
+          info: { rdns: 'com.wallet2' }
+        }
+      ] as any
+
+      const wallets = [
+        createMockWcWallet({ id: 'wallet-0', name: 'Wallet 0' }),
+        createMockWcWallet({ id: 'wallet-1', name: 'Wallet 1' }),
+        createMockWcWallet({ id: 'wallet-2', name: 'Wallet 2', rdns: 'com.wallet2' })
+      ]
+
+      const result = ConnectUtil.getWalletConnectWallets([], wallets)
+
+      expect(result[0]?.id).toBe('wallet-2')
     })
   })
 })

--- a/packages/controllers/tests/utils/ConnectUtil.test.ts
+++ b/packages/controllers/tests/utils/ConnectUtil.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ConnectionController,
+  ConnectorController,
+  OptionsController
+} from '../../exports/index.js'
+import { AssetUtil } from '../../src/utils/AssetUtil.js'
+import { ConnectUtil } from '../../src/utils/ConnectUtil.js'
+import { CoreHelperUtil } from '../../src/utils/CoreHelperUtil.js'
+import type { WcWallet } from '../../src/utils/TypeUtil.js'
+
+// -- Helpers ------------------------------------------------------------------
+function createMockWcWallet(overrides: Partial<WcWallet> = {}): WcWallet {
+  return {
+    id: 'wallet-id',
+    name: 'Test Wallet',
+    supports_wc: true,
+    mobile_link: 'testwalletapp://',
+    ...overrides
+  }
+}
+
+// -- Tests --------------------------------------------------------------------
+describe('ConnectUtil', () => {
+  describe('getWalletConnectWallets', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks()
+      ConnectorController.state.connectors = []
+      OptionsController.state.featuredWalletIds = undefined
+      ConnectionController.state.wcBasic = false
+      vi.spyOn(AssetUtil, 'getWalletImageUrl').mockReturnValue('')
+    })
+
+    it('should filter out wallets without wc support from search results on mobile', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+
+      const walletWithWc = createMockWcWallet({
+        id: 'wc-wallet',
+        name: 'WC Wallet',
+        supports_wc: true
+      })
+      const walletWithoutWc = createMockWcWallet({
+        id: 'no-wc-wallet',
+        name: 'No WC Wallet',
+        supports_wc: false,
+        mobile_link: 'noWcWalletapp://'
+      })
+
+      const result = ConnectUtil.getWalletConnectWallets([], [walletWithWc, walletWithoutWc])
+
+      expect(result.map(w => w.id)).toEqual(['wc-wallet'])
+    })
+
+    it('should include all search results on desktop regardless of wc support', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+
+      const walletWithWc = createMockWcWallet({
+        id: 'wc-wallet',
+        name: 'WC Wallet',
+        supports_wc: true
+      })
+      const walletWithoutWc = createMockWcWallet({
+        id: 'no-wc-wallet',
+        name: 'No WC Wallet',
+        supports_wc: false
+      })
+
+      const result = ConnectUtil.getWalletConnectWallets([], [walletWithWc, walletWithoutWc])
+
+      expect(result.map(w => w.id)).toEqual(['wc-wallet', 'no-wc-wallet'])
+    })
+
+    it('should preserve order of search results', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+
+      const wallets = [
+        createMockWcWallet({ id: 'wallet-0', name: 'Wallet 0' }),
+        createMockWcWallet({ id: 'wallet-1', name: 'Wallet 1' }),
+        createMockWcWallet({ id: 'wallet-2', name: 'Wallet 2' })
+      ]
+
+      const result = ConnectUtil.getWalletConnectWallets([], wallets)
+
+      expect(result).toHaveLength(3)
+      expect(result[0]?.id).toBe('wallet-0')
+      expect(result[1]?.id).toBe('wallet-1')
+      expect(result[2]?.id).toBe('wallet-2')
+    })
+  })
+})

--- a/packages/controllers/tests/utils/WalletUtil.test.ts
+++ b/packages/controllers/tests/utils/WalletUtil.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ConnectionController,
+  ConnectorController,
+  OptionsController
+} from '../../exports/index.js'
+import { CoreHelperUtil } from '../../src/utils/CoreHelperUtil.js'
+import type { WcWallet } from '../../src/utils/TypeUtil.js'
+import { WalletUtil } from '../../src/utils/WalletUtil.js'
+
+// -- Helpers ------------------------------------------------------------------
+function createMockWcWallet(overrides: Partial<WcWallet> = {}): WcWallet {
+  return {
+    id: 'wallet-id',
+    name: 'Test Wallet',
+    supports_wc: true,
+    mobile_link: 'testwalletapp://',
+    ...overrides
+  }
+}
+
+// -- Tests --------------------------------------------------------------------
+describe('WalletUtil', () => {
+  describe('filterAndFlagWallets', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks()
+      ConnectorController.state.connectors = []
+      OptionsController.state.featuredWalletIds = undefined
+      ConnectionController.state.wcBasic = false
+    })
+
+    it('should filter out wallets without wc support on mobile', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+
+      const wallets = [
+        createMockWcWallet({ id: 'wc-wallet', supports_wc: true }),
+        createMockWcWallet({ id: 'no-wc-wallet', supports_wc: false })
+      ]
+
+      const result = WalletUtil.filterAndFlagWallets(wallets)
+
+      expect(result.map(w => w.id)).toEqual(['wc-wallet'])
+    })
+
+    it('should pass through all wallets on desktop', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+
+      const wallets = [
+        createMockWcWallet({ id: 'wc-wallet', supports_wc: true }),
+        createMockWcWallet({ id: 'no-wc-wallet', supports_wc: false })
+      ]
+
+      const result = WalletUtil.filterAndFlagWallets(wallets)
+
+      expect(result.map(w => w.id)).toEqual(['wc-wallet', 'no-wc-wallet'])
+    })
+
+    it('should assign display_index to each wallet', () => {
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(false)
+
+      const wallets = [
+        createMockWcWallet({ id: 'wallet-0' }),
+        createMockWcWallet({ id: 'wallet-1' }),
+        createMockWcWallet({ id: 'wallet-2' })
+      ]
+
+      const result = WalletUtil.filterAndFlagWallets(wallets)
+
+      expect(result[0]?.display_index).toBe(0)
+      expect(result[1]?.display_index).toBe(1)
+      expect(result[2]?.display_index).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
## Problem

When searching wallets in the `useAppKitWallets` hook on mobile, wallets without `supports_wc` (e.g. Rabby) could appear in results. This happened because the search path in `ConnectUtil.getWalletConnectWallets` returned results directly without applying `filterWalletsByWcSupport`, unlike the browse path and the scaffold-ui `w3m-all-wallets-search` component which both apply this filter.

Wallets like Rabby pass the API-level `_filterWalletsByPlatform` check because they have a `webapp_link` (even without `mobile_link`), but should still be excluded by the WC support filter on mobile.

## Fix

Apply the full filtering pipeline to search results in `ConnectUtil.getWalletConnectWallets`:
`markWalletsAsInstalled` → `filterWalletsByWcSupport` → `markWalletsWithDisplayIndex`

This aligns the search path with both:
- The browse path via `WalletUtil.getWalletConnectWallets`
- The scaffold-ui `w3m-all-wallets-search` component

## Changes

- `packages/controllers/src/utils/ConnectUtil.ts` — apply filtering pipeline to search results
- `packages/controllers/tests/utils/ConnectUtil.test.ts` — new tests covering mobile filtering, desktop passthrough, and result ordering