### PR TITLE
feat(laboratory): add TON and TRON account info sections in multichain view

### DIFF
--- a/apps/laboratory/src/components/AppKitInfoMultiChain.tsx
+++ b/apps/laboratory/src/components/AppKitInfoMultiChain.tsx
@@ -18,11 +18,15 @@ export function AppKitInfoMultiChain({
   )
   const solanaAdapter = config?.adapters?.find(adapter => adapter === 'solana')
   const bitcoinAdapter = config?.adapters?.find(adapter => adapter === 'bitcoin')
+  const tonAdapter = config?.adapters?.find(adapter => adapter === 'ton')
+  const tronAdapter = config?.adapters?.find(adapter => adapter === 'tron')
 
   const currentAccount = useAppKitAccount()
   const evmAccount = useAppKitAccount({ namespace: 'eip155' })
   const solanaAccount = useAppKitAccount({ namespace: 'solana' })
   const bitcoinAccount = useAppKitAccount({ namespace: 'bip122' })
+  const tonAccount = useAppKitAccount({ namespace: 'ton' })
+  const tronAccount = useAppKitAccount({ namespace: 'tron' })
 
   return (
     <>
@@ -35,6 +39,8 @@ export function AppKitInfoMultiChain({
         {evmAdapter && <AccountCard account={evmAccount} namespace="eip155" />}
         {solanaAdapter && <AccountCard account={solanaAccount} namespace="solana" />}
         {bitcoinAdapter && <AccountCard account={bitcoinAccount} namespace="bip122" />}
+        {tonAdapter && <AccountCard account={tonAccount} namespace="ton" />}
+        {tronAdapter && <AccountCard account={tronAccount} namespace="tron" />}
       </Grid>
       <Grid templateColumns={{ base: 'repeat(1, 1fr)', md: 'repeat(2, 1fr)' }} gap={4}>
         <AccountCard account={currentAccount} />


### PR DESCRIPTION
## Summary
- Added dedicated account info sections for TON and TRON wallets in the multichain laboratory view
- Follows the same pattern as existing EVM, Solana, and Bitcoin sections
- Sections only appear when the respective adapter is configured

## Test plan
- [ ] Run laboratory app with multichain config including TON and TRON adapters
- [ ] Verify TON Account Info section appears when TON adapter is configured
- [ ] Verify TRON Account Info section appears when TRON adapter is configured
- [ ] Verify account data displays correctly when connected

Fixes REOWN-4526

🤖 Generated with [Claude Code](https://claude.ai/code)