### PR TITLE
fix(send): use string type for sendTokenAmount to preserve precision

### DIFF
--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -33,7 +33,7 @@ import { SnackController } from './SnackController.js'
 
 export interface TxParams {
   receiverAddress: string
-  sendTokenAmount: number
+  sendTokenAmount: string
   decimals: string
 }
 export interface SendInputArguments {
@@ -47,14 +47,14 @@ export interface SendInputArguments {
 export interface ContractWriteParams {
   receiverAddress: string
   tokenAddress: string
-  sendTokenAmount: number
+  sendTokenAmount: string
   decimals: string
 }
 export interface SendControllerState {
   tokenBalances: Balance[]
   token?: Balance
   hash?: string
-  sendTokenAmount?: number
+  sendTokenAmount?: string
   receiverAddress?: string
   receiverProfileName?: string
   receiverProfileImageUrl?: string
@@ -122,7 +122,7 @@ const controller = {
         getPreferredAccountType(ChainController.state.activeChain) ===
         W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
       token: state.token?.symbol || '',
-      amount: state.sendTokenAmount ?? 0,
+      amount: Number(state.sendTokenAmount ?? '0'),
       network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
     }
   },
@@ -177,7 +177,7 @@ const controller = {
         properties: {
           isSmartAccount: activeAccountType === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token.address,
-          amount: SendController.state.sendTokenAmount,
+          amount: Number(SendController.state.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
         }
       })
@@ -198,7 +198,7 @@ const controller = {
         properties: {
           isSmartAccount: activeAccountType === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token.symbol || '',
-          amount: SendController.state.sendTokenAmount,
+          amount: Number(SendController.state.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
         }
       })
@@ -302,7 +302,7 @@ const controller = {
         isSmartAccount:
           getPreferredAccountType('eip155') === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
         token: SendController.state.token?.symbol || '',
-        amount: params.sendTokenAmount,
+        amount: Number(params.sendTokenAmount),
         network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
         hash: hash || ''
       }
@@ -350,7 +350,7 @@ const controller = {
           isSmartAccount:
             getPreferredAccountType('eip155') === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token?.symbol || '',
-          amount: params.sendTokenAmount,
+          amount: Number(params.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
           hash: hash || ''
         }
@@ -392,7 +392,7 @@ const controller = {
       chainNamespace: 'solana',
       tokenMint,
       to: SendController.state.receiverAddress,
-      value: SendController.state.sendTokenAmount
+      value: Number(SendController.state.sendTokenAmount)
     })
 
     if (hash) {
@@ -407,7 +407,7 @@ const controller = {
       properties: {
         isSmartAccount: false,
         token: SendController.state.token?.symbol || '',
-        amount: SendController.state.sendTokenAmount,
+        amount: Number(SendController.state.sendTokenAmount),
         network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
         hash: hash || ''
       }

--- a/packages/controllers/tests/controllers/SendController.test.ts
+++ b/packages/controllers/tests/controllers/SendController.test.ts
@@ -34,7 +34,7 @@ const token = {
   },
   iconUrl: 'https://token-icons.s3.amazonaws.com/0x4200000000000000000000000000000000000042.png'
 }
-const sendTokenAmount = 0.1
+const sendTokenAmount = '0.1'
 const receiverAddress = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 const receiverProfileName = 'john.eth'
 const receiverProfileImageUrl = 'https://ipfs.com/0x123.png'
@@ -238,7 +238,7 @@ describe('SendController', () => {
     })
 
     it('should call sendTransaction without tokenMint', async () => {
-      SendController.setTokenAmount(0.1)
+      SendController.setTokenAmount('0.1')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()
@@ -273,7 +273,7 @@ describe('SendController', () => {
       }
 
       SendController.setToken(solanaToken as SendControllerState['token'])
-      SendController.setTokenAmount(50)
+      SendController.setTokenAmount('50')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()
@@ -310,7 +310,7 @@ describe('SendController', () => {
       }
 
       SendController.setToken(solanaToken as SendControllerState['token'])
-      SendController.setTokenAmount(50)
+      SendController.setTokenAmount('50')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -23,7 +23,7 @@ export class W3mInputToken extends LitElement {
 
   @property({ type: Boolean }) public readOnly = false
 
-  @property({ type: Number }) public sendTokenAmount?: number
+  @property({ type: String }) public sendTokenAmount?: string
 
   @property({ type: Boolean }) public isInsufficientBalance = false
 
@@ -40,7 +40,7 @@ export class W3mInputToken extends LitElement {
         <wui-input-amount
           @inputChange=${this.onInputChange.bind(this)}
           ?disabled=${isDisabled}
-          .value=${this.sendTokenAmount ? String(this.sendTokenAmount) : ''}
+          .value=${this.sendTokenAmount ?? ''}
           ?error=${Boolean(this.isInsufficientBalance)}
         ></wui-input-amount>
         ${this.buttonTemplate()}
@@ -77,7 +77,7 @@ export class W3mInputToken extends LitElement {
   private sendValueTemplate() {
     if (!this.readOnly && this.token && this.sendTokenAmount) {
       const price = this.token.price
-      const totalValue = price * this.sendTokenAmount
+      const totalValue = price * Number(this.sendTokenAmount)
 
       return html`<wui-text class="totalValue" variant="sm-regular" color="secondary"
         >${totalValue
@@ -121,14 +121,14 @@ export class W3mInputToken extends LitElement {
   }
 
   private onInputChange(event: InputEvent) {
-    SendController.setTokenAmount(event.detail)
+    SendController.setTokenAmount(String(event.detail))
   }
 
   private onMaxClick() {
     if (this.token) {
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      SendController.setTokenAmount(Number(maxValue.toFixed(20)))
+      SendController.setTokenAmount(maxValue.toFixed(20))
     }
   }
 }

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-preview-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-preview-view/index.ts
@@ -76,7 +76,7 @@ export class W3mWalletSendPreviewView extends LitElement {
           </wui-flex>
           <wui-preview-item
             text="${this.sendTokenAmount
-              ? UiHelperUtil.roundNumber(this.sendTokenAmount, 6, 5)
+              ? UiHelperUtil.roundNumber(Number(this.sendTokenAmount), 6, 5)
               : 'unknown'} ${this.token?.symbol}"
             .imageSrc=${this.token?.iconUrl}
           ></wui-preview-item>
@@ -142,7 +142,7 @@ export class W3mWalletSendPreviewView extends LitElement {
   private sendValueTemplate() {
     if (!this.params && this.token && this.sendTokenAmount) {
       const price = this.token.price
-      const totalValue = price * this.sendTokenAmount
+      const totalValue = price * Number(this.sendTokenAmount)
 
       return html`<wui-text variant="md-regular" color="primary"
         >$${totalValue.toFixed(2)}</wui-text

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 
-import { type CaipAddress } from '@reown/appkit-common'
+import { type CaipAddress, NumberUtil } from '@reown/appkit-common'
 import {
   AssetUtil,
   ChainController,
@@ -183,7 +183,7 @@ export class W3mWalletSendView extends LitElement {
     if (
       this.sendTokenAmount &&
       this.token &&
-      this.sendTokenAmount > Number(this.token.quantity.numeric)
+      NumberUtil.bigNumber(this.sendTokenAmount).gt(this.token.quantity.numeric)
     ) {
       this.message = SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     }
@@ -193,7 +193,7 @@ export class W3mWalletSendView extends LitElement {
     }
 
     if (this.sendTokenAmount && this.token?.price) {
-      const value = this.sendTokenAmount * this.token.price
+      const value = Number(this.sendTokenAmount) * this.token.price
       if (!value) {
         this.message = SEND_BUTTON_MESSAGE.INCORRECT_VALUE
       }
@@ -312,7 +312,7 @@ export class W3mWalletSendView extends LitElement {
         },
         iconUrl: AssetUtil.getTokenImage(symbol) ?? ''
       })
-      SendController.setTokenAmount(amount)
+      SendController.setTokenAmount(String(amount))
       SendController.setReceiverAddress(this.params.to)
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
@@ -78,7 +78,7 @@ describe('W3mInputToken', () => {
 
   it('should display total value when token amount is set', async () => {
     const element: W3mInputToken = await fixture(
-      html`<w3m-input-token .token=${MOCK_TOKEN} .sendTokenAmount=${50}></w3m-input-token>`
+      html`<w3m-input-token .token=${MOCK_TOKEN} .sendTokenAmount=${'50'}></w3m-input-token>`
     )
 
     const totalValue = element.shadowRoot?.querySelector('.totalValue')
@@ -94,7 +94,7 @@ describe('W3mInputToken', () => {
     const maxLink = element.shadowRoot?.querySelector('wui-link')
     maxLink?.click()
 
-    expect(setTokenAmountSpy).toHaveBeenCalledWith(100)
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('100.00000000000000000000')
   })
 
   it('should handle max amount click for native token', async () => {
@@ -119,6 +119,6 @@ describe('W3mInputToken', () => {
     const input = element.shadowRoot?.querySelector('wui-input-amount')
     input?.dispatchEvent(new CustomEvent('inputChange', { detail: 75 }))
 
-    expect(setTokenAmountSpy).toHaveBeenCalledWith(75)
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('75')
   })
 })

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
@@ -54,7 +54,7 @@ const mockNetwork: CaipNetwork = {
 
 const mockSendControllerState = {
   token: mockToken,
-  sendTokenAmount: 5,
+  sendTokenAmount: '5',
   receiverAddress: '0x456',
   loading: false,
   tokenBalances: [mockToken]

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-view-params.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-view-params.test.ts
@@ -102,7 +102,7 @@ describe('W3mWalletSendView - parameters handling', () => {
       iconUrl: ''
     })
 
-    expect(SendController.setTokenAmount).toHaveBeenCalledWith(10.5)
+    expect(SendController.setTokenAmount).toHaveBeenCalledWith('10.5')
     expect(SendController.setReceiverAddress).toHaveBeenCalledWith(mockValidParams.to)
   })
 

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-view.test.ts
@@ -88,7 +88,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     await element.updateComplete
@@ -105,7 +105,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(150)
+    SendController.setTokenAmount('150')
     SendController.setReceiverAddress('0x456')
     await element.updateComplete
     await element.render()
@@ -123,7 +123,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     SendController.setReceiverAddress('invalid-address')
@@ -152,7 +152,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     const addressInput = element.shadowRoot?.querySelector('w3m-input-address') as HTMLElement
@@ -175,7 +175,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     const addressInput = element.shadowRoot?.querySelector('w3m-input-address') as HTMLElement
@@ -198,7 +198,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setReceiverAddress('0x123456789abcdef123456789abcdef123456789a')
     await element.updateComplete
     await element.render()
@@ -215,7 +215,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setReceiverAddress('0x123456789abcdef123456789abcdef123456789a')
     await element.updateComplete
     await element.render()


### PR DESCRIPTION
## Summary

Fixes Send/Swap max amount of token throwing transaction errors due to JavaScript floating-point precision loss (REOWN-3617).

## Technical Report

### Problem
When sending the max amount of a token with 18 decimals, the transaction fails because the amount exceeds the actual on-chain balance. The sent amount differs from the intended amount due to JS number precision limits.

### Root Cause Analysis
sendTokenAmount was typed as number throughout the send flow (SendController, UI components, event tracking). JavaScript numbers (IEEE 754 double-precision) can only represent ~15-16 significant digits accurately. Tokens with 18 decimals can require up to 18+ significant digits. For example, a balance of 1.123456789012345678 ETH would be truncated/rounded by JS number arithmetic, and the resulting amount could exceed the actual balance by a tiny margin — causing the transaction to revert.

The critical point was w3m-input-token's onMaxClick handler: maxValue.toFixed(20) produced the correct string, but wrapping it in Number(...) immediately lost precision before it reached SendController.

### Approach & Reasoning

**Changed sendTokenAmount from number to string** across the entire flow:

1. **Types** — TxParams, ContractWriteParams, SendControllerState interfaces updated
2. **SendController** — setTokenAmount accepts string, state stores string
3. **w3m-input-token** — @property changed to { type: String }. onMaxClick now passes maxValue.toFixed(20) directly as string (the key fix — no more Number() roundtrip). Input changes wrapped with String(event.detail)
4. **w3m-wallet-send-view** — Balance comparison changed from this.sendTokenAmount > Number(quantity) to NumberUtil.bigNumber(this.sendTokenAmount).gt(quantity) — uses Big.js arbitrary-precision math instead of lossy JS number comparison
5. **w3m-wallet-send-preview-view** — Display values use Number() only for UiHelperUtil.roundNumber (display-only, precision loss acceptable)

**Number() conversion only at boundaries where it's safe:**
- Event tracking amount properties (analytics only — precision loss acceptable)
- Display values via UiHelperUtil.roundNumber (human-readable rounding)
- Solana sendTransaction value (SOL has 9 decimals, fits within JS number safely)

**Critical EVM path preserved full precision:**
- ConnectionController.parseUnits(params.sendTokenAmount.toString(), decimals) — parseUnits takes a string and converts to BigInt, so full precision flows to the contract

**Why string and not BigInt:** The value needs to flow through UI input fields, Lit property bindings, and valtio state — all of which handle strings naturally. BigInt would require constant conversion at every UI boundary.

### Files Changed
- packages/controllers/src/controllers/SendController.ts — types + state
- packages/scaffold-ui/src/partials/w3m-input-token/index.ts — input handling
- packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts — balance comparison
- packages/scaffold-ui/src/views/w3m-wallet-send-preview-view/index.ts — display
- 5 test files updated to use string literals

### Verification
- 60/60 tests pass across 5 test files (SendController, input-token, send-view, send-preview-view, send-view-params)
- Type check clean on controllers and scaffold-ui packages
- TxParams and ContractWriteParams are internal to SendController — no external consumers affected

## Test plan

- [ ] Send max amount of a token with 18 decimals — transaction should succeed
- [ ] Send partial amounts — verify correct precision
- [ ] Verify balance comparison works (insufficient funds warning)
- [ ] Verify Solana send still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)