### PR TITLE
fix(swap): auto-focus input field when swap view opens

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
@@ -45,6 +45,16 @@ export class W3mSwapInput extends LitElement {
     | ((target: SwapInputTarget, balance: string | undefined) => void)
     | null = null
 
+  @property({ type: Boolean }) public autoFocus = false
+
+  // -- Lifecycle ----------------------------------------- //
+  public override firstUpdated() {
+    if (this.autoFocus) {
+      const input = this.shadowRoot?.querySelector('input')
+      input?.focus()
+    }
+  }
+
   // -- Render -------------------------------------------- //
   public override render() {
     const marketValue = this.marketValue || '0'

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -299,6 +299,7 @@ export class W3mSwapView extends LitElement {
       .price=${myToken?.price}
       .marketValue=${marketValue}
       .onSetMaxValue=${this.onSetMaxValue.bind(this)}
+      ?autoFocus=${target === 'sourceToken'}
     ></w3m-swap-input>`
   }
 


### PR DESCRIPTION
## Summary

Auto-focuses the source token input field when the swap view opens so users can immediately start typing (REOWN-3541).

## Technical Report

### Problem
When the user opens the swap page, the input field is not active — they have to manually click on it before typing an amount. This adds an unnecessary interaction step.

### Root Cause Analysis
The w3m-swap-input component had no mechanism to auto-focus the input element on mount. The swap view renders two instances of w3m-swap-input (source token and destination token), and neither received focus automatically.

### Approach & Reasoning

**Added autoFocus boolean property to w3m-swap-input:**
- New @property({ type: Boolean }) public autoFocus = false — defaults to false so existing usages are unaffected
- New firstUpdated() lifecycle hook that queries the shadow DOM for the input element and calls .focus() when autoFocus is true

**Why firstUpdated() and not connectedCallback():**
firstUpdated() runs after the first render when the shadow DOM is fully constructed. connectedCallback() fires before the first render — the input element doesn't exist yet. firstUpdated() is the correct Lit lifecycle for DOM-dependent initialization.

**Why firstUpdated() and not updated():**
Focus should only be set once on initial mount, not on every re-render. firstUpdated() runs exactly once per element lifecycle. If the swap view re-renders without destroying the component, focus won't be re-stolen.

**Only source token gets focus:**
In w3m-swap-view, the attribute is set as ?autoFocus=\${target === 'sourceToken'}. The destination token input is disabled/read-only (shows calculated output), so focusing it would be useless.

**Optional chaining on querySelector result:**
input?.focus() safely handles the (unlikely) case where the input element isn't found in the shadow DOM.

### Files Changed
- packages/scaffold-ui/src/partials/w3m-swap-input/index.ts — added autoFocus property + firstUpdated()
- packages/scaffold-ui/src/views/w3m-swap-view/index.ts — passes autoFocus to source token input

### Verification
- 15/15 w3m-swap-input tests pass
- 14/14 w3m-swap-view tests pass
- Type check clean
- Existing test fixtures don't pass autoFocus, so they default to false — no behavior change for existing consumers
- No accessibility concern — auto-focusing a primary input on a dedicated page is standard UX

## Test plan

- [ ] Open swap view — source token input should be focused automatically
- [ ] Verify destination token input is NOT focused
- [ ] Verify typing works immediately without clicking first

🤖 Generated with [Claude Code](https://claude.com/claude-code)