### PR TITLE
fix: resolve Lit dev warnings from AppKit web components

### DIFF
--- a/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
@@ -43,6 +43,9 @@ export class W3mAllWalletsList extends LitElement {
   }
 
   public override firstUpdated() {
+    if (this.mobileFullScreen) {
+      this.setAttribute('data-mobile-fullscreen', 'true')
+    }
     this.initialFetch()
     this.createPaginationObserver()
   }
@@ -54,10 +57,6 @@ export class W3mAllWalletsList extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    if (this.mobileFullScreen) {
-      this.setAttribute('data-mobile-fullscreen', 'true')
-    }
-
     return html`
       <wui-grid
         data-scroll=${!this.loading}

--- a/packages/scaffold-ui/src/partials/w3m-input-address/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-address/index.ts
@@ -56,9 +56,7 @@ export class W3mInputAddress extends LitElement {
           ?disabled=${true}
           autocomplete="off"
           .value=${this.value ?? ''}
-        >
-           ${this.value ?? ''}</textarea
-        >
+        ></textarea>
       </wui-flex>`
     }
 
@@ -96,9 +94,7 @@ export class W3mInputAddress extends LitElement {
         @blur=${this.onBlur.bind(this)}
         .value=${this.value ?? ''}
         autocomplete="off"
-      >
-${this.value ?? ''}</textarea
-      >
+      ></textarea>
     </wui-flex>`
   }
 

--- a/packages/scaffold-ui/src/partials/w3m-router-container/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-router-container/index.ts
@@ -150,7 +150,9 @@ export class W3mRouterContainer extends LitElement {
       direction = 'next'
     }
 
-    this.viewDirection = `${direction}-${newView}`
+    queueMicrotask(() => {
+      this.viewDirection = `${direction}-${newView}`
+    })
 
     setTimeout(() => {
       this.historyState = history

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -61,8 +61,6 @@ export class W3mWalletSendView extends LitElement {
 
   @state() private caipAddress = ChainController.getAccountData()?.caipAddress
 
-  @state() private message: SendButtonMessage = SEND_BUTTON_MESSAGE.PREVIEW_SEND
-
   @state() private disconnecting = false
 
   public constructor() {
@@ -112,8 +110,7 @@ export class W3mWalletSendView extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    this.getMessage()
-
+    const message = this.getMessage()
     const isReadOnly = Boolean(this.params)
 
     return html` <wui-flex flexDirection="column" .padding=${['0', '4', '4', '4'] as const}>
@@ -122,7 +119,7 @@ export class W3mWalletSendView extends LitElement {
           .token=${this.token}
           .sendTokenAmount=${this.sendTokenAmount}
           ?readOnly=${isReadOnly}
-          ?isInsufficientBalance=${this.message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS}
+          ?isInsufficientBalance=${message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS}
         ></w3m-input-token>
         <wui-icon-box size="md" variant="secondary" icon="arrowBottom"></wui-icon-box>
         <w3m-input-address
@@ -130,7 +127,7 @@ export class W3mWalletSendView extends LitElement {
           .value=${this.receiverProfileName ? this.receiverProfileName : this.receiverAddress}
         ></w3m-input-address>
       </wui-flex>
-      ${this.buttonTemplate()}
+      ${this.buttonTemplate(message)}
     </wui-flex>`
   }
 
@@ -166,47 +163,40 @@ export class W3mWalletSendView extends LitElement {
     }
   }
 
-  private getMessage() {
-    this.message = SEND_BUTTON_MESSAGE.PREVIEW_SEND
-
-    if (
-      this.receiverAddress &&
-      !CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)
-    ) {
-      this.message = SEND_BUTTON_MESSAGE.INVALID_ADDRESS
+  private getMessage(): SendButtonMessage {
+    if (!this.token) {
+      return SEND_BUTTON_MESSAGE.SELECT_TOKEN
     }
 
-    if (!this.receiverAddress) {
-      this.message = SEND_BUTTON_MESSAGE.ADD_ADDRESS
-    }
-
-    if (
-      this.sendTokenAmount &&
-      this.token &&
-      this.sendTokenAmount > Number(this.token.quantity.numeric)
-    ) {
-      this.message = SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
-    }
-
-    if (!this.sendTokenAmount) {
-      this.message = SEND_BUTTON_MESSAGE.ADD_AMOUNT
-    }
-
-    if (this.sendTokenAmount && this.token?.price) {
+    if (this.sendTokenAmount && this.token.price) {
       const value = this.sendTokenAmount * this.token.price
       if (!value) {
-        this.message = SEND_BUTTON_MESSAGE.INCORRECT_VALUE
+        return SEND_BUTTON_MESSAGE.INCORRECT_VALUE
       }
     }
 
-    if (!this.token) {
-      this.message = SEND_BUTTON_MESSAGE.SELECT_TOKEN
+    if (!this.sendTokenAmount) {
+      return SEND_BUTTON_MESSAGE.ADD_AMOUNT
     }
+
+    if (this.sendTokenAmount > Number(this.token.quantity.numeric)) {
+      return SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
+    }
+
+    if (!this.receiverAddress) {
+      return SEND_BUTTON_MESSAGE.ADD_ADDRESS
+    }
+
+    if (!CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)) {
+      return SEND_BUTTON_MESSAGE.INVALID_ADDRESS
+    }
+
+    return SEND_BUTTON_MESSAGE.PREVIEW_SEND
   }
 
-  private buttonTemplate() {
-    const isDisabled = !this.message.startsWith(SEND_BUTTON_MESSAGE.PREVIEW_SEND)
-    const isInsufficientBalance = this.message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
+  private buttonTemplate(message: SendButtonMessage) {
+    const isDisabled = !message.startsWith(SEND_BUTTON_MESSAGE.PREVIEW_SEND)
+    const isInsufficientBalance = message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     const isReadOnly = Boolean(this.params)
 
     if (isInsufficientBalance && !isReadOnly) {
@@ -245,7 +235,7 @@ export class W3mWalletSendView extends LitElement {
         ?loading=${this.loading}
         fullWidth
       >
-        ${this.message}
+        ${message}
       </wui-button>
     </wui-flex>`
   }


### PR DESCRIPTION
## Summary

Fixes 4 Lit development warnings emitted by AppKit internal web components during normal modal usage (REOWN-4559).

## Technical Report

### Problem
Four Lit dev warnings were firing in the browser console during normal AppKit modal usage, creating noise for developers integrating AppKit.

### Root Cause Analysis
Each warning had a distinct cause in a different component:

1. **w3m-wallet-send-view** (`change-in-update`): `render()` called `getMessage()` which mutated `this.message` — a `@state()` reactive property. Setting reactive state during render triggers a new update cycle.
2. **w3m-input-address** (`expression-in-textarea`): Two `<textarea>` elements had both `.value=\${...}` binding AND child expression `\${this.value ?? ''}`. Lit doesn't support expressions inside `<textarea>`.
3. **w3m-router-container** (`change-in-update`): `updated()` lifecycle called `onViewChange()` which synchronously set `this.viewDirection` (reactive state), triggering another update during the current cycle.
4. **w3m-all-wallets-list** (`change-in-update`): `render()` called `this.setAttribute('data-mobile-fullscreen', 'true')` — DOM mutation during render.

### Approach & Reasoning

**Fix 1 — Pure function (chosen over computed property):**
Converted `getMessage()` from a state-mutating method to a pure function that returns the message. The return value is passed as a local variable through `render()` and `buttonTemplate(message)`. Removed the `@state() private message` property entirely since it was only set and consumed within the same render cycle. The early-return priority order was carefully reversed to match the original last-assignment-wins semantics: `SELECT_TOKEN > INCORRECT_VALUE > ADD_AMOUNT > INSUFFICIENT_FUNDS > ADD_ADDRESS > INVALID_ADDRESS > PREVIEW_SEND`.

**Fix 2 — Remove child expressions (only option):**
Removed `\${this.value ?? ''}` child text from both textarea elements. The `.value` property binding is the correct and sufficient mechanism for controlling textarea content in Lit. The child text was redundant — it sets `defaultValue` while `.value` sets the current value.

**Fix 3 — queueMicrotask (chosen over setTimeout/requestAnimationFrame):**
Wrapped `this.viewDirection = ...` in `queueMicrotask()`. This defers the state mutation past the current Lit update cycle but runs before the next browser paint, so there's no visual gap in the CSS transition animation. `setTimeout(0)` would run after paint (causing a flash), and `requestAnimationFrame` could miss the current frame.

**Fix 4 — Move to firstUpdated (chosen over willUpdate/updated):**
Moved `setAttribute` to `firstUpdated()` since `mobileFullScreen` is initialized from `OptionsController.state.enableMobileFullScreen` with no subscription — it never changes after init. If it could change dynamically, `updated()` with a `changedProperties` check would be needed instead.

### Verification
- 761 scaffold-ui tests pass (1 skipped)
- All pre-existing type errors only — zero new errors introduced
- getMessage() priority order verified to match original exactly

## Test plan

- [ ] Open AppKit modal in dev mode — no Lit warnings in console
- [ ] Navigate wallet list, send flow, modal views
- [ ] Verify wallet send flow works (address input, amount, preview)
- [ ] Verify modal view transitions animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)