### PR TITLE
fix: pass required account param in Bitcoin getAccountAddresses

### DIFF
--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -77,10 +77,11 @@ export class BitcoinWalletConnectConnector
 
   public async getAccountAddresses(): Promise<BitcoinConnector.AccountAddress[]> {
     this.checkIfMethodIsSupported('getAccountAddresses')
+    const account = this.getAccount(true)
 
     const addresses = await this.internalRequest({
       method: 'getAccountAddresses',
-      params: undefined
+      params: { account }
     })
 
     return addresses.map(address => ({ address, purpose: AddressPurpose.Payment }))
@@ -210,6 +211,11 @@ export namespace WalletConnectProvider {
     memo?: string
   }
 
+  export type WCGetAccountAddressesParams = {
+    account: string
+    intentions?: string[]
+  }
+
   export type WCGetAccountAddressesResponse = {
     address: string
     publicKey: Uint8Array
@@ -240,7 +246,7 @@ export namespace WalletConnectProvider {
   export type RequestMethods = {
     signMessage: Request<WCSignMessageParams, WCSignMessageResponse>
     sendTransfer: Request<WCSendTransferParams, WCSendTransferResponse>
-    getAccountAddresses: Request<undefined, string[]>
+    getAccountAddresses: Request<WCGetAccountAddressesParams, string[]>
     signPsbt: Request<WCSignPSBTParams, WCSignPSBTResponse>
   }
 

--- a/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
+++ b/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
@@ -197,6 +197,10 @@ describe('LeatherConnector', () => {
   describe('getAccountAddresses', () => {
     beforeEach(() => {
       universalProvider.session = mockUniversalProvider.mockSession()
+      vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
+        caipAddress: `${bitcoin.caipNetworkId}:address`,
+        address: 'address'
+      } as unknown as AccountState)
     })
 
     it('should get the account addresses and parse response', async () => {
@@ -208,7 +212,7 @@ describe('LeatherConnector', () => {
       expect(requestSpy).toHaveBeenCalledWith(
         {
           method: 'getAccountAddresses',
-          params: undefined
+          params: { account: 'address' }
         },
         bitcoin.caipNetworkId
       )


### PR DESCRIPTION
## Summary

Fixes BitcoinWalletConnectConnector.getAccountAddresses() sending params: undefined instead of the required account field per the BIP122 RPC spec (REOWN-4541).

## Technical Report

### Problem
The BIP122 getAccountAddresses RPC spec requires an account field in params, but the connector was sending params: undefined, causing wallets that strictly validate the spec to reject the request.

### Root Cause Analysis
In BitcoinWalletConnectConnector.ts, the getAccountAddresses method hardcoded params: undefined. Other methods in the same file (sendTransfer, signPsbt) correctly call this.getAccount(true) and pass the result — this method was simply missed.

The RequestMethods type also mapped getAccountAddresses to Request<undefined, string[]>, reinforcing the incorrect implementation.

### Approach & Reasoning

**Added WCGetAccountAddressesParams type** with required account and optional intentions fields, matching the BIP122 spec.

**Fixed the method** to call this.getAccount(true) before the request, matching the sendTransfer/signPsbt pattern. this.getAccount(true) resolves the connected account address from the WC session namespaces and throws if not found.

**Kept response type as string[]** — initially changed to WCGetAccountAddressesResponse (object array), but sanity check revealed the WC provider actually returns plain string arrays. The existing test mocked ['mock_address'] and the mapping code treated elements as strings. Changing the response type would have caused runtime errors (addr.address on a string is undefined).

**Updated the test** to mock ChainController.getAccountData (needed for getAccount()) and expect params: { account: 'address' } instead of params: undefined.

### Verification
- 22/22 WalletConnectProvider tests pass
- Type check clean on bitcoin adapter
- Response type kept as string[] to match actual wallet behavior

## Test plan

- [ ] Connect a Bitcoin wallet via WalletConnect
- [ ] Call getAccountAddresses() — verify request includes params: { account: "..." }
- [ ] Verify wallet returns addresses without rejecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)