### PR TITLE
fix: serialize BigInt values in social login RPC requests

### DIFF
--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -15,6 +15,28 @@ import type { W3mFrameTypes } from './W3mFrameTypes.js'
 
 type AppEventType = Omit<W3mFrameTypes.AppEvent, 'id'>
 
+// -- Helpers ----------------------------------------------------------------
+function serializeBigInts<T>(value: T): T {
+  if (typeof value === 'bigint') {
+    return `0x${value.toString(16)}` as unknown as T
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(serializeBigInts) as unknown as T
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = serializeBigInts(v)
+    }
+
+    return result as T
+  }
+
+  return value
+}
+
 interface W3mFrameProviderConfig {
   projectId: string
   chainId?: W3mFrameTypes.Network['chainId']
@@ -541,7 +563,7 @@ export class W3mFrameProvider {
       this.rpcRequestHandler?.(req)
       const response = await this.appEvent<'Rpc'>({
         type: W3mFrameConstants.APP_RPC_REQUEST,
-        payload: request
+        payload: serializeBigInts(request)
       } as W3mFrameTypes.AppEvent)
 
       this.rpcSuccessHandler?.(response, request)


### PR DESCRIPTION
## Summary

Fixes Magic RPC Error [-32603] Do not know how to serialize a BigInt when sending transactions via social login (REOWN-4455).

## Technical Report

### Problem
When a user connects via social login (Magic) and sends any transaction, it fails with "Do not know how to serialize a BigInt". Only social login is affected — MetaMask, WalletConnect, and injected wallets work fine.

### Root Cause Analysis
W3mFrameProvider.request() passes RPC payloads to the Magic iframe via postMessage(). The browser's structured cloning algorithm (used by postMessage) cannot serialize BigInt values. The wagmi adapter creates transaction params with BigInt values at lines 432-434 of client.ts (BigInt(params.value), BigInt(params.gas), BigInt(params.gasPrice)). These BigInt values flow through to the postMessage call at W3mFrame.ts:242.

Other wallets aren't affected because they use different transport mechanisms that handle BigInt natively (direct provider calls, not iframe postMessage).

### Approach & Reasoning

**Added serializeBigInts() helper** that recursively converts BigInt values to 0x-prefixed hex strings before the payload reaches postMessage. Applied at the single convergence point — W3mFrameProvider.request() — so all RPC methods are covered.

**Why 0x hex strings:** This is the standard Ethereum JSON-RPC encoding for quantities (gas, value, nonce). The Magic iframe expects this format.

**Why recursive:** RPC params can be nested objects/arrays (e.g., sendTransaction params contain objects with gas, value fields). The helper traverses the full structure.

**Immutability:** The helper creates new objects/arrays — the original request is not mutated. This is important because the original request is also passed to rpcSuccessHandler/rpcErrorHandler downstream.

**Considered alternatives:**
- Fixing at the wagmi adapter level (converting BigInt before passing to provider) — would only fix wagmi, not ethers or direct provider.request() calls
- Patching postMessage to add BigInt support — not possible, browser API limitation
- The chosen approach fixes at the single point where all RPC requests converge before hitting the iframe

### Edge Cases
- BigInt(0) → "0x0" (correct)
- Very large BigInts → full hex string (correct)
- Negative BigInts → "0x-1" (invalid but never occurs in Ethereum RPC — gas/value/nonce are unsigned)
- null/undefined/strings/numbers → passed through unchanged

### Verification
- 27/27 wallet package tests pass
- Type check clean
- Only affects W3mFrameProvider (social login) — no impact on other wallet types

## Test plan

- [ ] Connect via social login (Google)
- [ ] Send a transaction (e.g. ERC20 approve) — should succeed
- [ ] Verify MetaMask/WalletConnect transactions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)