### PR TITLE
fix: guard setDefaultChain calls against undefined provider on stale sessions

### DIFF
--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -119,7 +119,7 @@ export class BitcoinWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Private ------------------------------------------ //

--- a/packages/adapters/solana/src/providers/SolanaWalletConnectProvider.ts
+++ b/packages/adapters/solana/src/providers/SolanaWalletConnectProvider.ts
@@ -232,7 +232,7 @@ export class SolanaWalletConnectProvider
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Private ------------------------------------------ //

--- a/packages/adapters/ton/src/connectors/TonWalletConnectConnector.ts
+++ b/packages/adapters/ton/src/connectors/TonWalletConnectConnector.ts
@@ -113,7 +113,7 @@ export class TonWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Internals ----------------------------------------------------- //

--- a/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
+++ b/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
@@ -118,7 +118,7 @@ export class TronWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Internals ----------------------------------------------------- //

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -264,7 +264,7 @@ export class UniversalAdapter extends AdapterBlueprint {
         }
       }
     }
-    connector.provider.setDefaultChain(caipNetwork.caipNetworkId)
+    connector.provider?.setDefaultChain(caipNetwork.caipNetworkId)
   }
 
   public getWalletConnectProvider() {


### PR DESCRIPTION
## Summary

Fixes unhandled TypeError: Cannot read properties of undefined (reading 'setDefaultChain') when WalletConnect sessions go stale (REOWN-4467).

## Technical Report

### Problem
Two unhandled errors spam production console/Sentry when WC sessions become stale:
1. "No matching key. session topic doesn't exist" — from WC sign-client (external, not fixable here)
2. "Cannot read properties of undefined (reading 'setDefaultChain')" — from AppKit chain change handling

### Root Cause Analysis
When a WC session is invalidated externally (wallet disconnects, session expires), chainChanged events can still fire. The event handler calls switchNetwork → setDefaultChain on the provider. But by this point, the provider reference may be undefined because the session teardown cleared it.

Five call sites across the codebase called this.provider.setDefaultChain() or connector.provider.setDefaultChain() without null checks.

### Approach & Reasoning

**Added optional chaining (?.)** on all 5 setDefaultChain call sites:
- packages/appkit/src/universal-adapter/client.ts (line 267)
- packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
- packages/adapters/ton/src/connectors/TonWalletConnectConnector.ts
- packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
- packages/adapters/solana/src/providers/SolanaWalletConnectProvider.ts

**Why optional chaining instead of throwing:** The universal adapter's switchNetwork method already uses ?. for connector.provider?.request() on lines 235 and 249. Adding ?. on setDefaultChain is consistent with the existing defensive pattern. When the session is stale, the chain switch is meaningless anyway — there's nothing to switch on a dead session.

**Why not fix the "No matching key" error:** That originates inside @walletconnect/sign-client, not AppKit code. The wagmi adapter already catches it during disconnect (line 220 of WalletConnectConnector.ts) but not in other paths.

**Considered alternatives:**
- Adding try-catch around the entire chainChanged handler — heavier, might swallow legitimate errors
- Checking session validity before calling setDefaultChain — requires accessing WC internals, fragile
- The chosen approach is minimal, safe, and addresses the exact crash point

### Verification
- All tests pass across all 5 affected packages (appkit, bitcoin, ton, tron, solana adapters)
- Type check clean across all packages
- The base WalletConnectConnector type declares provider as non-optional (public provider: UniversalProvider), so ?. only triggers in edge cases

## Test plan

- [ ] Connect wallet via WalletConnect, let session go stale, trigger chain change — no unhandled errors
- [ ] Normal chain switching still works when session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)