### PR TITLE
fix: reject malformed CAIP-10 addresses in setCaipAddress

### DIFF
--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2131,6 +2131,13 @@ export abstract class AppKitBaseClient {
     chain: ChainNamespace,
     shouldRefresh = false
   ) => {
+    if (caipAddress !== null) {
+      const parts = caipAddress.split(':')
+      if (parts.length !== 3 || parts.some(p => !p)) {
+        return
+      }
+    }
+
     ChainController.setAccountProp('caipAddress', caipAddress, chain, shouldRefresh)
     ChainController.setAccountProp(
       'address',

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2134,6 +2134,8 @@ export abstract class AppKitBaseClient {
     if (caipAddress !== null) {
       const parts = caipAddress.split(':')
       if (parts.length !== 3 || parts.some(p => !p)) {
+        console.warn(`[AppKit] setCaipAddress: invalid CAIP-10 address rejected: "${caipAddress}"`)
+
         return
       }
     }


### PR DESCRIPTION
## Summary

Prevents malformed CAIP-10 addresses from entering AppKit state when a wallet emits an empty address string (REOWN-4448).

## Technical Report

### Problem
When a wallet connector emits an empty string "" as the account address (observed sporadically with injected wallets and WalletConnect during reconnection/network switching), AppKit stores a malformed CAIP-10 address like "eip155:42161:" in state. This propagates through balance fetching, identity sync, and SIWE — all operating on an empty address.

### Root Cause Analysis
syncAccountInfo in appkit-base-client.ts constructs the CAIP-10 address via string interpolation: \`\${chainNamespace}:\${newChainId}:\${address}\`. With an empty address, this produces "eip155:42161:" — technically a string but invalid CAIP-10. setCaipAddress stored this directly without validation. Downstream, getPlainAddress() returns "", and consumers operate on a garbage address.

ParseUtil.parseCaipAddress already validates CAIP-10 format, but setCaipAddress bypassed it entirely — doing raw interpolation and direct state assignment.

### Approach & Reasoning

**Added validation guard in setCaipAddress** — the single convergence point before any CAIP-10 value enters state. The guard splits on ":" and checks for exactly 3 non-empty parts (namespace:chainId:address). Malformed values are rejected with a console.warn for debuggability.

**Why setCaipAddress and not the callers:** There are multiple code paths that call setCaipAddress (syncAccountInfo, onAuthProviderConnected, adapter callbacks). Guarding at the convergence point covers all of them with one check.

**Why silent reject with warning (not throw):** The wallet is the source of the bad data, not the app. Throwing would crash the connection flow. Silently rejecting keeps the app functional with whatever address was previously in state. The console.warn ensures the issue is visible for debugging.

**Format validation:** Splits on ":" and checks parts.length === 3 && !parts.some(p => !p). This correctly handles:
- EVM: "eip155:1:0xABC..." → passes (3 non-empty parts)
- Solana: "solana:5eykt4...:SoLAddr..." → passes
- Bitcoin: "bip122:000000...:bc1q..." → passes
- Malformed: "eip155:42161:" → rejected (empty 3rd part)
- Null: allowed through (used for disconnect)

**Works with REOWN-4447 fix:** Even if toChecksummedAddress returns an empty/undefined address, this guard catches it before it enters state.

### Verification
- 75/75 appkit public-methods tests pass
- Type check clean
- No addresses with colons in any supported blockchain format (EVM hex, Solana base58, Bitcoin bech32)

## Test plan

- [ ] Connect wallet — verify address correctly stored in state
- [ ] Simulate empty address emission — verify console.warn and no malformed CAIP-10 in state
- [ ] Disconnect wallet — verify null caipAddress still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)