### PR TITLE
fix: handle undefined address in wagmi toChecksummedAddress

### DIFF
--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -1079,6 +1079,14 @@ export class WagmiAdapter extends AdapterBlueprint {
   }
 
   private toChecksummedAddress(address: string) {
-    return checksumAddress(address.toLowerCase() as `0x${string}`)
+    if (!address) {
+      return address as `0x${string}`
+    }
+
+    try {
+      return checksumAddress(address.toLowerCase() as `0x${string}`)
+    } catch {
+      return address as `0x${string}`
+    }
   }
 }


### PR DESCRIPTION
## Summary

Prevents crash when a wallet emits undefined/empty address during account-change or reconnect in the wagmi adapter (REOWN-4447).

## Technical Report

### Problem
When a wallet connector emits an account-change event with address as undefined (observed on mobile webviews and reconnect edge cases), toChecksummedAddress crashes on address.toLowerCase() with TypeError: Cannot read properties of undefined.

### Root Cause Analysis
toChecksummedAddress(address: string) assumes address is always a valid string. It calls address.toLowerCase() without checking. This method is called from 9 different places in the wagmi adapter (connection flows, account change handlers, disconnect callbacks), so the crash can occur in multiple scenarios.

The TypeScript types don't prevent this because several call sites cast potentially-undefined values: res.accounts[0] as string, connection?.accounts[0] as string.

### Approach & Reasoning

**Added guard + try-catch in toChecksummedAddress** — returns the original address as-is for falsy input, and catches any checksumAddress errors:

```typescript
private toChecksummedAddress(address: string) {
  if (!address) {
    return address as \`0x\${string}\`
  }
  try {
    return checksumAddress(address.toLowerCase() as \`0x\${string}\`)
  } catch {
    return address as \`0x\${string}\`
  }
}
```

**Why return original instead of empty string:** Initial implementation returned '' as \`0x\${string}\`, but sanity check revealed this creates silent data corruption — downstream code (Connection objects, CAIP address construction, balance lookups) would receive an empty string that passes TypeScript checks but is meaningless. Returning the original input propagates the invalid value upstream where it can be caught by other guards (e.g., REOWN-4448's setCaipAddress validation).

**Why try-catch:** viem's checksumAddress throws on malformed input (not just undefined). The try-catch handles any unexpected address format gracefully.

**Matches ethers adapter pattern:** The ethers and ethers5 adapters already use try-catch in their checksum methods, returning the original address on failure. This change makes the wagmi adapter consistent.

**Works with REOWN-4448:** If an undefined/empty address passes through toChecksummedAddress, it will be caught by the setCaipAddress CAIP-10 validation guard before entering AppKit state.

### Verification
- 76/76 wagmi adapter tests pass (2 skipped — pre-existing)
- Type check clean
- Covers all 9 call sites through the single method fix

## Test plan

- [ ] Trigger account-change with undefined address — no crash
- [ ] Normal wallet connection/switching still works
- [ ] Verify checksummed addresses are still correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)