### PR TITLE
fix: catch unhandled RPC rejections from internal API calls

### DIFF
--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1276,10 +1276,10 @@ export abstract class AppKitBaseClient {
           address,
           chainId: syncAccountChainId,
           chainNamespace
-        })
+        }).catch(() => null)
       } else if (!isActiveChain && syncAccountChainId) {
         this.syncAccountInfo(address, syncAccountChainId, chainNamespace)
-        this.syncBalance({ address, chainId: syncAccountChainId, chainNamespace })
+        this.syncBalance({ address, chainId: syncAccountChainId, chainNamespace }).catch(() => null)
       } else {
         this.syncAccountInfo(address, chainId, chainNamespace)
       }
@@ -1666,7 +1666,7 @@ export abstract class AppKitBaseClient {
         address,
         chainId,
         chainNamespace
-      })
+      }).catch(() => null)
     }
   }
 


### PR DESCRIPTION
## Summary

Prevents Ankr "Unauthorized" and other RPC errors from rpc.walletconnect.org from bubbling up as unhandled promise rejections to consumer apps (REOWN-4446).

## Technical Report

### Problem
Internal RPC calls (balance sync, ENS identity resolution) through rpc.walletconnect.org sometimes fail when the Ankr backend rate-limits or returns "Unauthorized". These errors surface as unhandled promise rejections, polluting consumer apps' Sentry and browser console. Reported as ~15 events over 2 days in production.

### Root Cause Analysis
Three async call sites in appkit-base-client.ts were fire-and-forget — async functions called without `await` or `.catch()`:

1. **`syncAccount()`** (line 1275) — called in `accountChanged` event handler. This method internally awaits `syncBalance()` which makes RPC calls. Since `syncAccount()` itself isn't awaited, any rejection inside it becomes unhandled.

2. **`syncBalance()`** (line 1282) — called in `accountChanged` handler for non-active chain path. Direct fire-and-forget RPC call.

3. **`syncIdentity()`** (line 1665) — called at the end of `syncAccount()`. Makes ENS resolution calls through the blockchain API.

These calls are intentionally not awaited — they're background sync operations that shouldn't block the connection flow. But without `.catch()`, their rejections escape to the global unhandled rejection handler.

### Approach & Reasoning

**Added `.catch(() => null)` on all three fire-and-forget call sites.** This is the minimal fix that:

- Prevents unhandled rejections from reaching the consumer
- Preserves the fire-and-forget behavior (non-blocking)
- Doesn't change any success path logic
- Doesn't hide errors from AppKit's own internal error handling (the methods already have try-catch internally for their own logging)

**Why `.catch(() => null)` and not `.catch(console.warn)`:** These errors are already logged internally where they originate (e.g., syncBalance catches and logs its own failures). Adding another console.warn at the call site would duplicate the log. Silent catch is correct here — it just prevents the rejection from being "unhandled".

**Why not add try-catch inside the methods instead:** The methods are also called with `await` in other paths (e.g., `syncBalance` is awaited on lines 1660-1662). Adding internal catch-all would swallow errors for callers that DO want to handle them. The fix correctly targets only the fire-and-forget call sites.

### Verification
- 204/204 appkit client tests pass
- Type check clean
- Only 3 lines changed (adding `.catch(() => null)`)

## Test plan

- [ ] Connect wallet, switch networks — no unhandled rejections in console
- [ ] Simulate RPC failure (e.g., invalid projectId) — errors caught silently, no Sentry noise
- [ ] Balance and ENS still work on success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)