### PR TITLE
fix: sync approved CAIP networks before connection status transition

### DIFF
--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1266,6 +1266,14 @@ export abstract class AppKitBaseClient {
           chainNamespace
         })
         this.syncConnectedWalletInfo(chainNamespace)
+
+        if (connector.type === UtilConstantsUtil.CONNECTOR_TYPE_WALLET_CONNECT) {
+          const approvedData = this.getApprovedCaipNetworksData()
+          ChainController.setApprovedCaipNetworksData(chainNamespace, {
+            approvedCaipNetworkIds: approvedData.approvedCaipNetworkIds,
+            supportsAllNetworks: approvedData.supportsAllNetworks
+          })
+        }
       }
 
       const namespaceNetworkId = ChainController.getNetworkData(chainNamespace)?.caipNetwork?.id
@@ -1543,6 +1551,12 @@ export abstract class AppKitBaseClient {
         )
         StorageUtil.addConnectedNamespace(chainNamespace)
 
+        const data = this.getApprovedCaipNetworksData()
+        ChainController.setApprovedCaipNetworksData(chainNamespace, {
+          approvedCaipNetworkIds: data.approvedCaipNetworkIds,
+          supportsAllNetworks: data.supportsAllNetworks
+        })
+
         await this.syncAccount({
           address,
           chainId,
@@ -1552,12 +1566,7 @@ export abstract class AppKitBaseClient {
         this.setStatus('disconnected', chainNamespace)
       }
 
-      const data = this.getApprovedCaipNetworksData()
       this.syncConnectedWalletInfo(chainNamespace)
-      ChainController.setApprovedCaipNetworksData(chainNamespace, {
-        approvedCaipNetworkIds: data.approvedCaipNetworkIds,
-        supportsAllNetworks: data.supportsAllNetworks
-      })
     })
 
     await Promise.all(syncTasks)


### PR DESCRIPTION
## Summary
- Moved `getApprovedCaipNetworksData` + `setApprovedCaipNetworksData` to run **before** `syncAccount()` in `syncWalletConnectAccount()`, so `approvedCaipNetworkIds` and `supportsAllNetworks` are available in `useAppKitNetwork` at the moment the connection status transitions to `connected`
- Scoped approved network sync to the `if (sessionAddress)` guard — namespaces without session data no longer overwrite with defaults
- Added approved network sync in the `accountChanged` handler as a safety net for the wagmi reconnect path

## Test plan
- [ ] Connect via WalletConnect — verify `approvedCaipNetworkIds` and `supportsAllNetworks` are correct immediately on connected status
- [ ] Refresh the page (reconnect) — verify values are still correct after reconnection
- [ ] Verify non-WC connections (injected, coinbase) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)