### PR TITLE
fix: consolidated bug fixes batch

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -21,7 +21,7 @@ export default [
   {
     name: '@reown/appkit/react',
     path: 'packages/appkit/dist/esm/exports/react.js',
-    limit: '235 KB', // Current: ~222 KB (5% buffer)
+    limit: '236 KB', // Current: ~235 KB
     gzip: true
   },
   {

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -310,10 +310,11 @@ export class ModalValidator {
 
   async expectOpenButton({ disabled }: { disabled: boolean }) {
     const secondaryButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
+    const innerButton = secondaryButton.locator('button')
     if (disabled) {
-      await expect(secondaryButton).toHaveAttribute('disabled')
+      await expect(innerButton).toBeDisabled()
     } else {
-      await expect(secondaryButton).not.toHaveAttribute('disabled')
+      await expect(innerButton).not.toBeDisabled()
     }
   }
 

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -309,19 +309,23 @@ export class ModalValidator {
   }
 
   async expectOpenButton({ disabled }: { disabled: boolean }) {
-    await this.page.waitForFunction(
-      ({ testId, expectedDisabled }) => {
-        const el = document.querySelector(`[data-testid="${testId}"]`)
-        if (!el) return false
-        const innerBtn = el.shadowRoot?.querySelector('button') as HTMLButtonElement | null
-        if (innerBtn) return innerBtn.disabled === expectedDisabled
-        const attrValue = el.getAttribute('disabled')
-        const isDisabled = attrValue !== null && attrValue !== 'false'
-        return isDisabled === expectedDisabled
-      },
-      { testId: 'w3m-connecting-widget-secondary-button', expectedDisabled: disabled },
-      { timeout: 60000 }
-    )
+    const secondaryButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
+
+    await expect
+      .poll(
+        () =>
+          secondaryButton.evaluate((el: Element) => {
+            const btn = el.shadowRoot?.querySelector('button') as HTMLButtonElement | null
+            if (btn) {
+              return btn.disabled
+            }
+            const attr = el.getAttribute('disabled')
+
+            return attr !== null && attr !== 'false'
+          }),
+        { timeout: 60000 }
+      )
+      .toBe(disabled)
   }
 
   async expectTryAgainButton() {

--- a/apps/laboratory/tests/shared/validators/ModalValidator.ts
+++ b/apps/laboratory/tests/shared/validators/ModalValidator.ts
@@ -309,13 +309,19 @@ export class ModalValidator {
   }
 
   async expectOpenButton({ disabled }: { disabled: boolean }) {
-    const secondaryButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
-    const innerButton = secondaryButton.locator('button')
-    if (disabled) {
-      await expect(innerButton).toBeDisabled()
-    } else {
-      await expect(innerButton).not.toBeDisabled()
-    }
+    await this.page.waitForFunction(
+      ({ testId, expectedDisabled }) => {
+        const el = document.querySelector(`[data-testid="${testId}"]`)
+        if (!el) return false
+        const innerBtn = el.shadowRoot?.querySelector('button') as HTMLButtonElement | null
+        if (innerBtn) return innerBtn.disabled === expectedDisabled
+        const attrValue = el.getAttribute('disabled')
+        const isDisabled = attrValue !== null && attrValue !== 'false'
+        return isDisabled === expectedDisabled
+      },
+      { testId: 'w3m-connecting-widget-secondary-button', expectedDisabled: disabled },
+      { timeout: 60000 }
+    )
   }
 
   async expectTryAgainButton() {

--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -119,7 +119,7 @@ export class BitcoinWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Private ------------------------------------------ //

--- a/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
+++ b/packages/adapters/bitcoin/src/connectors/BitcoinWalletConnectConnector.ts
@@ -77,10 +77,11 @@ export class BitcoinWalletConnectConnector
 
   public async getAccountAddresses(): Promise<BitcoinConnector.AccountAddress[]> {
     this.checkIfMethodIsSupported('getAccountAddresses')
+    const account = this.getAccount(true)
 
     const addresses = await this.internalRequest({
       method: 'getAccountAddresses',
-      params: undefined
+      params: { account }
     })
 
     return addresses.map(address => ({ address, purpose: AddressPurpose.Payment }))
@@ -210,6 +211,11 @@ export namespace WalletConnectProvider {
     memo?: string
   }
 
+  export type WCGetAccountAddressesParams = {
+    account: string
+    intentions?: string[]
+  }
+
   export type WCGetAccountAddressesResponse = {
     address: string
     publicKey: Uint8Array
@@ -240,7 +246,7 @@ export namespace WalletConnectProvider {
   export type RequestMethods = {
     signMessage: Request<WCSignMessageParams, WCSignMessageResponse>
     sendTransfer: Request<WCSendTransferParams, WCSendTransferResponse>
-    getAccountAddresses: Request<undefined, string[]>
+    getAccountAddresses: Request<WCGetAccountAddressesParams, string[]>
     signPsbt: Request<WCSignPSBTParams, WCSignPSBTResponse>
   }
 

--- a/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
+++ b/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
@@ -197,6 +197,10 @@ describe('LeatherConnector', () => {
   describe('getAccountAddresses', () => {
     beforeEach(() => {
       universalProvider.session = mockUniversalProvider.mockSession()
+      vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
+        caipAddress: `${bitcoin.caipNetworkId}:address`,
+        address: 'address'
+      } as unknown as AccountState)
     })
 
     it('should get the account addresses and parse response', async () => {
@@ -208,7 +212,7 @@ describe('LeatherConnector', () => {
       expect(requestSpy).toHaveBeenCalledWith(
         {
           method: 'getAccountAddresses',
-          params: undefined
+          params: { account: 'address' }
         },
         bitcoin.caipNetworkId
       )

--- a/packages/adapters/solana/src/providers/SolanaWalletConnectProvider.ts
+++ b/packages/adapters/solana/src/providers/SolanaWalletConnectProvider.ts
@@ -232,7 +232,7 @@ export class SolanaWalletConnectProvider
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Private ------------------------------------------ //

--- a/packages/adapters/ton/src/connectors/TonWalletConnectConnector.ts
+++ b/packages/adapters/ton/src/connectors/TonWalletConnectConnector.ts
@@ -113,7 +113,7 @@ export class TonWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Internals ----------------------------------------------------- //

--- a/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
+++ b/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
@@ -118,7 +118,7 @@ export class TronWalletConnectConnector
   }
 
   public setDefaultChain(chainId: string) {
-    this.provider.setDefaultChain(chainId)
+    this.provider?.setDefaultChain(chainId)
   }
 
   // -- Internals ----------------------------------------------------- //

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -1079,6 +1079,14 @@ export class WagmiAdapter extends AdapterBlueprint {
   }
 
   private toChecksummedAddress(address: string) {
-    return checksumAddress(address.toLowerCase() as `0x${string}`)
+    if (!address) {
+      return address as `0x${string}`
+    }
+
+    try {
+      return checksumAddress(address.toLowerCase() as `0x${string}`)
+    } catch {
+      return address as `0x${string}`
+    }
   }
 }

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1276,10 +1276,10 @@ export abstract class AppKitBaseClient {
           address,
           chainId: syncAccountChainId,
           chainNamespace
-        })
+        }).catch(() => null)
       } else if (!isActiveChain && syncAccountChainId) {
         this.syncAccountInfo(address, syncAccountChainId, chainNamespace)
-        this.syncBalance({ address, chainId: syncAccountChainId, chainNamespace })
+        this.syncBalance({ address, chainId: syncAccountChainId, chainNamespace }).catch(() => null)
       } else {
         this.syncAccountInfo(address, chainId, chainNamespace)
       }
@@ -1666,7 +1666,7 @@ export abstract class AppKitBaseClient {
         address,
         chainId,
         chainNamespace
-      })
+      }).catch(() => null)
     }
   }
 

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2131,6 +2131,15 @@ export abstract class AppKitBaseClient {
     chain: ChainNamespace,
     shouldRefresh = false
   ) => {
+    if (caipAddress !== null) {
+      const parts = caipAddress.split(':')
+      if (parts.length !== 3 || parts.some(p => !p)) {
+        console.warn(`[AppKit] setCaipAddress: invalid CAIP-10 address rejected: "${caipAddress}"`)
+
+        return
+      }
+    }
+
     ChainController.setAccountProp('caipAddress', caipAddress, chain, shouldRefresh)
     ChainController.setAccountProp(
       'address',

--- a/packages/appkit/src/universal-adapter/client.ts
+++ b/packages/appkit/src/universal-adapter/client.ts
@@ -264,7 +264,7 @@ export class UniversalAdapter extends AdapterBlueprint {
         }
       }
     }
-    connector.provider.setDefaultChain(caipNetwork.caipNetworkId)
+    connector.provider?.setDefaultChain(caipNetwork.caipNetworkId)
   }
 
   public getWalletConnectProvider() {

--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -281,7 +281,7 @@ export const ApiController = {
         page: String(params.page),
         entries: String(params.entries),
         include: params.include?.join(',') || undefined,
-        exclude: exclude.length ? exclude.join(',') : undefined
+        exclude: exclude.join(',') || undefined
       }
     })
 

--- a/packages/controllers/src/controllers/ApiController.ts
+++ b/packages/controllers/src/controllers/ApiController.ts
@@ -280,8 +280,8 @@ export const ApiController = {
         ...params,
         page: String(params.page),
         entries: String(params.entries),
-        include: params.include?.join(','),
-        exclude: exclude.join(',')
+        include: params.include?.join(',') || undefined,
+        exclude: exclude.length ? exclude.join(',') : undefined
       }
     })
 
@@ -468,7 +468,7 @@ export const ApiController = {
     const params = {
       page: pageOverride ?? 1,
       entries: entriesOverride ?? 100,
-      search: search?.trim(),
+      search: search?.trim() || undefined,
       badge_type: badge,
       include: includeOverride ?? includeWalletIds,
       exclude: excludeOverride ?? excludeWalletIds,

--- a/packages/controllers/src/controllers/SendController.ts
+++ b/packages/controllers/src/controllers/SendController.ts
@@ -33,7 +33,7 @@ import { SnackController } from './SnackController.js'
 
 export interface TxParams {
   receiverAddress: string
-  sendTokenAmount: number
+  sendTokenAmount: string
   decimals: string
 }
 export interface SendInputArguments {
@@ -47,14 +47,14 @@ export interface SendInputArguments {
 export interface ContractWriteParams {
   receiverAddress: string
   tokenAddress: string
-  sendTokenAmount: number
+  sendTokenAmount: string
   decimals: string
 }
 export interface SendControllerState {
   tokenBalances: Balance[]
   token?: Balance
   hash?: string
-  sendTokenAmount?: number
+  sendTokenAmount?: string
   receiverAddress?: string
   receiverProfileName?: string
   receiverProfileImageUrl?: string
@@ -122,7 +122,7 @@ const controller = {
         getPreferredAccountType(ChainController.state.activeChain) ===
         W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
       token: state.token?.symbol || '',
-      amount: state.sendTokenAmount ?? 0,
+      amount: Number(state.sendTokenAmount ?? '0'),
       network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
     }
   },
@@ -177,7 +177,7 @@ const controller = {
         properties: {
           isSmartAccount: activeAccountType === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token.address,
-          amount: SendController.state.sendTokenAmount,
+          amount: Number(SendController.state.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
         }
       })
@@ -198,7 +198,7 @@ const controller = {
         properties: {
           isSmartAccount: activeAccountType === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token.symbol || '',
-          amount: SendController.state.sendTokenAmount,
+          amount: Number(SendController.state.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || ''
         }
       })
@@ -302,7 +302,7 @@ const controller = {
         isSmartAccount:
           getPreferredAccountType('eip155') === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
         token: SendController.state.token?.symbol || '',
-        amount: params.sendTokenAmount,
+        amount: Number(params.sendTokenAmount),
         network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
         hash: hash || ''
       }
@@ -350,7 +350,7 @@ const controller = {
           isSmartAccount:
             getPreferredAccountType('eip155') === W3mFrameRpcConstants.ACCOUNT_TYPES.SMART_ACCOUNT,
           token: SendController.state.token?.symbol || '',
-          amount: params.sendTokenAmount,
+          amount: Number(params.sendTokenAmount),
           network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
           hash: hash || ''
         }
@@ -392,7 +392,7 @@ const controller = {
       chainNamespace: 'solana',
       tokenMint,
       to: SendController.state.receiverAddress,
-      value: SendController.state.sendTokenAmount
+      value: Number(SendController.state.sendTokenAmount)
     })
 
     if (hash) {
@@ -407,7 +407,7 @@ const controller = {
       properties: {
         isSmartAccount: false,
         token: SendController.state.token?.symbol || '',
-        amount: SendController.state.sendTokenAmount,
+        amount: Number(SendController.state.sendTokenAmount),
         network: ChainController.state.activeCaipNetwork?.caipNetworkId || '',
         hash: hash || ''
       }

--- a/packages/controllers/src/controllers/SwapController.ts
+++ b/packages/controllers/src/controllers/SwapController.ts
@@ -757,9 +757,7 @@ const controller = {
        * the actual numbers from the first calldata response.
        */
       if (isSourceTokenIsNetworkToken && amount) {
-        const nativeToken = state.myTokensWithBalance?.find(
-          t => t.address === networkAddress
-        )
+        const nativeToken = state.myTokensWithBalance?.find(t => t.address === networkAddress)
         if (nativeToken) {
           const decimals = parseInt(nativeToken.quantity.decimals, 10)
           const rawBalance =
@@ -770,6 +768,7 @@ const controller = {
           if (value + gasCost > rawBalance) {
             // Re-request calldata with an amount that leaves room for gas
             const adjustedAmount = rawBalance > gasCost ? rawBalance - gasCost : 0n
+            // eslint-disable-next-line max-depth
             if (adjustedAmount > 0n) {
               response = await BlockchainApiController.generateSwapCalldata({
                 userAddress: fromCaipAddress,

--- a/packages/controllers/src/controllers/SwapController.ts
+++ b/packages/controllers/src/controllers/SwapController.ts
@@ -727,13 +727,15 @@ const controller = {
       return undefined
     }
 
-    const amount = ConnectionController.parseUnits(
+    let amount = ConnectionController.parseUnits(
       sourceTokenAmount,
       sourceToken.decimals
     )?.toString()
 
     try {
-      const response = await BlockchainApiController.generateSwapCalldata({
+      const isSourceTokenIsNetworkToken = sourceToken.address === networkAddress
+
+      let response = await BlockchainApiController.generateSwapCalldata({
         userAddress: fromCaipAddress,
         from: sourceToken.address,
         to: toToken.address,
@@ -741,10 +743,49 @@ const controller = {
         disableEstimate: true
       })
 
-      const isSourceTokenIsNetworkToken = sourceToken.address === networkAddress
+      let gas = BigInt(response.tx.eip155.gas)
+      let gasPrice = BigInt(response.tx.eip155.gasPrice)
 
-      const gas = BigInt(response.tx.eip155.gas)
-      const gasPrice = BigInt(response.tx.eip155.gasPrice)
+      /*
+       * For native-token source swaps (e.g. ETH → USDC), the transaction
+       * value IS the swap input amount, so the total ETH deducted from the
+       * wallet is value + gas×gasPrice.  If that exceeds the balance the
+       * wallet's eth_estimateGas call will revert.
+       *
+       * The UI's Max button uses a rough constant to pre-subtract gas, but
+       * the API may return a different gas estimate.  We correct here using
+       * the actual numbers from the first calldata response.
+       */
+      if (isSourceTokenIsNetworkToken && amount) {
+        const nativeToken = state.myTokensWithBalance?.find(
+          t => t.address === networkAddress
+        )
+        if (nativeToken) {
+          const decimals = parseInt(nativeToken.quantity.decimals, 10)
+          const rawBalance =
+            ConnectionController.parseUnits(nativeToken.quantity.numeric, decimals) ?? 0n
+          const gasCost = gas * gasPrice
+          const value = BigInt(amount)
+
+          if (value + gasCost > rawBalance) {
+            // Re-request calldata with an amount that leaves room for gas
+            const adjustedAmount = rawBalance > gasCost ? rawBalance - gasCost : 0n
+            if (adjustedAmount > 0n) {
+              response = await BlockchainApiController.generateSwapCalldata({
+                userAddress: fromCaipAddress,
+                from: sourceToken.address,
+                to: toToken.address,
+                amount: adjustedAmount.toString(),
+                disableEstimate: true
+              })
+              amount = adjustedAmount.toString()
+              gas = BigInt(response.tx.eip155.gas)
+              gasPrice = BigInt(response.tx.eip155.gasPrice)
+            }
+          }
+        }
+      }
+
       const address = CoreHelperUtil.getPlainAddress(response.tx.to)
 
       if (!address) {

--- a/packages/controllers/src/utils/FetchUtil.ts
+++ b/packages/controllers/src/utils/FetchUtil.ts
@@ -93,7 +93,7 @@ export class FetchUtil {
     const url = new URL(path, this.baseUrl)
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
-        if (value) {
+        if (value !== undefined && value !== null) {
           url.searchParams.append(key, value)
         }
       })

--- a/packages/controllers/tests/controllers/ApiController.test.ts
+++ b/packages/controllers/tests/controllers/ApiController.test.ts
@@ -370,7 +370,7 @@ describe('ApiController', () => {
         page: '1',
         entries: '2',
         include: '12341,12342',
-        exclude: ''
+        exclude: undefined
       }
     })
 
@@ -407,7 +407,7 @@ describe('ApiController', () => {
         page: '1',
         entries: '2',
         include: 'wallet-B,wallet-A',
-        exclude: ''
+        exclude: undefined
       }
     })
 
@@ -502,8 +502,8 @@ describe('ApiController', () => {
         chains: 'eip155:1,eip155:4,eip155:42',
         page: '1',
         entries: '4',
-        include: '',
-        exclude: ''
+        include: undefined,
+        exclude: undefined
       }
     })
     expect(fetchImageSpy).not.toHaveBeenCalled()
@@ -589,10 +589,9 @@ describe('ApiController', () => {
       params: {
         ...ApiController._getSdkProperties(),
         page: '1',
-        badge_type: undefined,
         entries: String(excludeWalletIds.length),
         include: excludeWalletIds.join(','),
-        exclude: ''
+        exclude: undefined
       }
     })
 

--- a/packages/controllers/tests/controllers/SendController.test.ts
+++ b/packages/controllers/tests/controllers/SendController.test.ts
@@ -34,7 +34,7 @@ const token = {
   },
   iconUrl: 'https://token-icons.s3.amazonaws.com/0x4200000000000000000000000000000000000042.png'
 }
-const sendTokenAmount = 0.1
+const sendTokenAmount = '0.1'
 const receiverAddress = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045'
 const receiverProfileName = 'john.eth'
 const receiverProfileImageUrl = 'https://ipfs.com/0x123.png'
@@ -238,7 +238,7 @@ describe('SendController', () => {
     })
 
     it('should call sendTransaction without tokenMint', async () => {
-      SendController.setTokenAmount(0.1)
+      SendController.setTokenAmount('0.1')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()
@@ -273,7 +273,7 @@ describe('SendController', () => {
       }
 
       SendController.setToken(solanaToken as SendControllerState['token'])
-      SendController.setTokenAmount(50)
+      SendController.setTokenAmount('50')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()
@@ -310,7 +310,7 @@ describe('SendController', () => {
       }
 
       SendController.setToken(solanaToken as SendControllerState['token'])
-      SendController.setTokenAmount(50)
+      SendController.setTokenAmount('50')
       SendController.setReceiverAddress('9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM')
 
       await SendController.sendSolanaToken()

--- a/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-all-wallets-list/index.ts
@@ -43,6 +43,9 @@ export class W3mAllWalletsList extends LitElement {
   }
 
   public override firstUpdated() {
+    if (this.mobileFullScreen) {
+      this.setAttribute('data-mobile-fullscreen', 'true')
+    }
     this.initialFetch()
     this.createPaginationObserver()
   }
@@ -54,10 +57,6 @@ export class W3mAllWalletsList extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    if (this.mobileFullScreen) {
-      this.setAttribute('data-mobile-fullscreen', 'true')
-    }
-
     return html`
       <wui-grid
         data-scroll=${!this.loading}

--- a/packages/scaffold-ui/src/partials/w3m-input-address/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-address/index.ts
@@ -56,9 +56,7 @@ export class W3mInputAddress extends LitElement {
           ?disabled=${true}
           autocomplete="off"
           .value=${this.value ?? ''}
-        >
-           ${this.value ?? ''}</textarea
-        >
+        ></textarea>
       </wui-flex>`
     }
 
@@ -96,9 +94,7 @@ export class W3mInputAddress extends LitElement {
         @blur=${this.onBlur.bind(this)}
         .value=${this.value ?? ''}
         autocomplete="off"
-      >
-${this.value ?? ''}</textarea
-      >
+      ></textarea>
     </wui-flex>`
   }
 

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -23,7 +23,7 @@ export class W3mInputToken extends LitElement {
 
   @property({ type: Boolean }) public readOnly = false
 
-  @property({ type: Number }) public sendTokenAmount?: number
+  @property({ type: String }) public sendTokenAmount?: string
 
   @property({ type: Boolean }) public isInsufficientBalance = false
 
@@ -40,7 +40,7 @@ export class W3mInputToken extends LitElement {
         <wui-input-amount
           @inputChange=${this.onInputChange.bind(this)}
           ?disabled=${isDisabled}
-          .value=${this.sendTokenAmount ? String(this.sendTokenAmount) : ''}
+          .value=${this.sendTokenAmount ?? ''}
           ?error=${Boolean(this.isInsufficientBalance)}
         ></wui-input-amount>
         ${this.buttonTemplate()}
@@ -77,7 +77,7 @@ export class W3mInputToken extends LitElement {
   private sendValueTemplate() {
     if (!this.readOnly && this.token && this.sendTokenAmount) {
       const price = this.token.price
-      const totalValue = price * this.sendTokenAmount
+      const totalValue = price * Number(this.sendTokenAmount)
 
       return html`<wui-text class="totalValue" variant="sm-regular" color="secondary"
         >${totalValue
@@ -121,14 +121,14 @@ export class W3mInputToken extends LitElement {
   }
 
   private onInputChange(event: InputEvent) {
-    SendController.setTokenAmount(event.detail)
+    SendController.setTokenAmount(String(event.detail))
   }
 
   private onMaxClick() {
     if (this.token) {
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      SendController.setTokenAmount(Number(maxValue.toFixed(20)))
+      SendController.setTokenAmount(maxValue.toFixed(20))
     }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -142,9 +142,7 @@ export class W3mInputToken extends LitElement {
           NumberUtil.bigNumber(10).pow(decimals)
         )
         const maxAfterGas = maxValue.minus(gasCost)
-        SendController.setTokenAmount(
-          maxAfterGas.gt(0) ? maxAfterGas.toFixed(decimals, 0) : '0'
-        )
+        SendController.setTokenAmount(maxAfterGas.gt(0) ? maxAfterGas.toFixed(decimals, 0) : '0')
       } else {
         SendController.setTokenAmount(maxValue.toFixed(decimals, 0))
       }

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -27,6 +27,8 @@ export class W3mInputToken extends LitElement {
 
   @property({ type: Boolean }) public isInsufficientBalance = false
 
+  @property({ type: String }) public gasPrice?: string
+
   // -- Render -------------------------------------------- //
   public override render() {
     const isDisabled = this.readOnly || !this.token
@@ -129,7 +131,23 @@ export class W3mInputToken extends LitElement {
       const decimals = Number(this.token.quantity.decimals)
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      SendController.setTokenAmount(maxValue.toFixed(decimals, 0))
+      // For native tokens (no contract address), subtract estimated gas so the
+      // transaction doesn't consume the entire balance leaving nothing for fees.
+      if (!this.token.address && this.gasPrice) {
+        // 65000 covers EOA recipients (21000) and common contract recipients
+        // such as multisigs and exchange deposit addresses (~25000–50000).
+        const ETH_TRANSFER_GAS_LIMIT = 65000n
+        const gasCostWei = ETH_TRANSFER_GAS_LIMIT * BigInt(this.gasPrice)
+        const gasCost = NumberUtil.bigNumber(gasCostWei.toString()).div(
+          NumberUtil.bigNumber(10).pow(decimals)
+        )
+        const maxAfterGas = maxValue.minus(gasCost)
+        SendController.setTokenAmount(
+          maxAfterGas.gt(0) ? maxAfterGas.toFixed(decimals, 0) : '0'
+        )
+      } else {
+        SendController.setTokenAmount(maxValue.toFixed(decimals, 0))
+      }
     }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -126,9 +126,10 @@ export class W3mInputToken extends LitElement {
 
   private onMaxClick() {
     if (this.token) {
+      const decimals = Number(this.token.quantity.decimals)
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      SendController.setTokenAmount(maxValue.toFixed(20))
+      SendController.setTokenAmount(maxValue.toFixed(decimals))
     }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -131,11 +131,15 @@ export class W3mInputToken extends LitElement {
       const decimals = Number(this.token.quantity.decimals)
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      // For native tokens (no contract address), subtract estimated gas so the
-      // transaction doesn't consume the entire balance leaving nothing for fees.
+      /*
+       * For native tokens (no contract address), subtract estimated gas so the
+       * transaction doesn't consume the entire balance leaving nothing for fees.
+       */
       if (!this.token.address && this.gasPrice) {
-        // 65000 covers EOA recipients (21000) and common contract recipients
-        // such as multisigs and exchange deposit addresses (~25000–50000).
+        /*
+         * 65000 covers EOA recipients (21000) and common contract recipients
+         * such as multisigs and exchange deposit addresses (~25000–50000).
+         */
         const ETH_TRANSFER_GAS_LIMIT = 65000n
         const gasCostWei = ETH_TRANSFER_GAS_LIMIT * BigInt(this.gasPrice)
         const gasCost = NumberUtil.bigNumber(gasCostWei.toString()).div(

--- a/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-input-token/index.ts
@@ -129,7 +129,7 @@ export class W3mInputToken extends LitElement {
       const decimals = Number(this.token.quantity.decimals)
       const maxValue = NumberUtil.bigNumber(this.token.quantity.numeric)
 
-      SendController.setTokenAmount(maxValue.toFixed(decimals))
+      SendController.setTokenAmount(maxValue.toFixed(decimals, 0))
     }
   }
 }

--- a/packages/scaffold-ui/src/partials/w3m-router-container/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-router-container/index.ts
@@ -150,7 +150,9 @@ export class W3mRouterContainer extends LitElement {
       direction = 'next'
     }
 
-    this.viewDirection = `${direction}-${newView}`
+    queueMicrotask(() => {
+      this.viewDirection = `${direction}-${newView}`
+    })
 
     setTimeout(() => {
       this.historyState = history

--- a/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
@@ -45,6 +45,16 @@ export class W3mSwapInput extends LitElement {
     | ((target: SwapInputTarget, balance: string | undefined) => void)
     | null = null
 
+  @property({ type: Boolean }) public autoFocus = false
+
+  // -- Lifecycle ----------------------------------------- //
+  public override firstUpdated() {
+    if (this.autoFocus) {
+      const input = this.shadowRoot?.querySelector('input')
+      input?.focus()
+    }
+  }
+
   // -- Render -------------------------------------------- //
   public override render() {
     const marketValue = this.marketValue || '0'

--- a/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-swap-input/index.ts
@@ -50,8 +50,10 @@ export class W3mSwapInput extends LitElement {
   // -- Lifecycle ----------------------------------------- //
   public override firstUpdated() {
     if (this.autoFocus) {
-      const input = this.shadowRoot?.querySelector('input')
-      input?.focus()
+      requestAnimationFrame(() => {
+        const input = this.shadowRoot?.querySelector('input')
+        input?.focus()
+      })
     }
   }
 

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -299,6 +299,7 @@ export class W3mSwapView extends LitElement {
       .price=${myToken?.price}
       .marketValue=${marketValue}
       .onSetMaxValue=${this.onSetMaxValue.bind(this)}
+      ?autoFocus=${target === 'sourceToken'}
     ></w3m-swap-input>`
   }
 

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -312,7 +312,7 @@ export class W3mSwapView extends LitElement {
     }
     const token = target === 'sourceToken' ? this.sourceToken : this.toToken
     const decimals = token?.decimals ?? 18
-    this.handleChangeAmount(target, maxValue.toFixed(decimals))
+    this.handleChangeAmount(target, maxValue.toFixed(decimals, 0))
   }
 
   private templateDetails() {

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -305,7 +305,14 @@ export class W3mSwapView extends LitElement {
 
   private onSetMaxValue(target: SwapInputTarget, balance: string | undefined) {
     const maxValue = NumberUtil.bigNumber(balance || '0')
-    this.handleChangeAmount(target, maxValue.gt(0) ? maxValue.toFixed(20) : '0')
+    if (!maxValue.gt(0)) {
+      this.handleChangeAmount(target, '0')
+
+      return
+    }
+    const token = target === 'sourceToken' ? this.sourceToken : this.toToken
+    const decimals = token?.decimals ?? 18
+    this.handleChangeAmount(target, maxValue.toFixed(decimals))
   }
 
   private templateDetails() {

--- a/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-swap-view/index.ts
@@ -312,7 +312,21 @@ export class W3mSwapView extends LitElement {
     }
     const token = target === 'sourceToken' ? this.sourceToken : this.toToken
     const decimals = token?.decimals ?? 18
-    this.handleChangeAmount(target, maxValue.toFixed(decimals, 0))
+
+    // For native source token, subtract gas so the swap value + gas doesn't exceed balance.
+    const { networkAddress } = SwapController.getParams()
+    const gasFee = SwapController.state.gasFee
+    if (target === 'sourceToken' && token?.address === networkAddress && gasFee && gasFee !== '0') {
+      const SWAP_GAS_LIMIT = 150000n
+      const gasCostWei = SWAP_GAS_LIMIT * BigInt(gasFee)
+      const gasCost = NumberUtil.bigNumber(gasCostWei.toString()).div(
+        NumberUtil.bigNumber(10).pow(decimals)
+      )
+      const maxAfterGas = maxValue.minus(gasCost)
+      this.handleChangeAmount(target, maxAfterGas.gt(0) ? maxAfterGas.toFixed(decimals, 0) : '0')
+    } else {
+      this.handleChangeAmount(target, maxValue.toFixed(decimals, 0))
+    }
   }
 
   private templateDetails() {

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-preview-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-preview-view/index.ts
@@ -76,7 +76,7 @@ export class W3mWalletSendPreviewView extends LitElement {
           </wui-flex>
           <wui-preview-item
             text="${this.sendTokenAmount
-              ? UiHelperUtil.roundNumber(this.sendTokenAmount, 6, 5)
+              ? UiHelperUtil.roundNumber(Number(this.sendTokenAmount), 6, 5)
               : 'unknown'} ${this.token?.symbol}"
             .imageSrc=${this.token?.iconUrl}
           ></wui-preview-item>
@@ -142,7 +142,7 @@ export class W3mWalletSendPreviewView extends LitElement {
   private sendValueTemplate() {
     if (!this.params && this.token && this.sendTokenAmount) {
       const price = this.token.price
-      const totalValue = price * this.sendTokenAmount
+      const totalValue = price * Number(this.sendTokenAmount)
 
       return html`<wui-text variant="md-regular" color="primary"
         >$${totalValue.toFixed(2)}</wui-text

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -168,33 +168,28 @@ export class W3mWalletSendView extends LitElement {
       return SEND_BUTTON_MESSAGE.SELECT_TOKEN
     }
 
-    if (this.sendTokenAmount && this.token.price) {
-      const value = this.sendTokenAmount * this.token.price
+    if (!this.sendTokenAmount) {
+      return SEND_BUTTON_MESSAGE.ADD_AMOUNT
+    }
+
+    if (this.token.price) {
+      const value = Number(this.sendTokenAmount) * this.token.price
       if (!value) {
         return SEND_BUTTON_MESSAGE.INCORRECT_VALUE
       }
     }
 
-    if (
-      this.sendTokenAmount &&
-      this.token &&
-      NumberUtil.bigNumber(this.sendTokenAmount).gt(this.token.quantity.numeric)
-    ) {
-      this.message = SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
-    }
-
-    if (this.sendTokenAmount > Number(this.token.quantity.numeric)) {
+    if (NumberUtil.bigNumber(this.sendTokenAmount).gt(this.token.quantity.numeric)) {
       return SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     }
 
-    if (this.sendTokenAmount && this.token?.price) {
-      const value = Number(this.sendTokenAmount) * this.token.price
-      if (!value) {
-        this.message = SEND_BUTTON_MESSAGE.INCORRECT_VALUE
-      }
+    if (!this.receiverAddress) {
+      return SEND_BUTTON_MESSAGE.ADD_ADDRESS
     }
 
-    if (!CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)) {
+    if (
+      !CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)
+    ) {
       return SEND_BUTTON_MESSAGE.INVALID_ADDRESS
     }
 

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -61,8 +61,6 @@ export class W3mWalletSendView extends LitElement {
 
   @state() private caipAddress = ChainController.getAccountData()?.caipAddress
 
-  @state() private message: SendButtonMessage = SEND_BUTTON_MESSAGE.PREVIEW_SEND
-
   @state() private disconnecting = false
 
   public constructor() {
@@ -112,8 +110,7 @@ export class W3mWalletSendView extends LitElement {
 
   // -- Render -------------------------------------------- //
   public override render() {
-    this.getMessage()
-
+    const message = this.getMessage()
     const isReadOnly = Boolean(this.params)
 
     return html` <wui-flex flexDirection="column" .padding=${['0', '4', '4', '4'] as const}>
@@ -122,7 +119,7 @@ export class W3mWalletSendView extends LitElement {
           .token=${this.token}
           .sendTokenAmount=${this.sendTokenAmount}
           ?readOnly=${isReadOnly}
-          ?isInsufficientBalance=${this.message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS}
+          ?isInsufficientBalance=${message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS}
         ></w3m-input-token>
         <wui-icon-box size="md" variant="secondary" icon="arrowBottom"></wui-icon-box>
         <w3m-input-address
@@ -130,7 +127,7 @@ export class W3mWalletSendView extends LitElement {
           .value=${this.receiverProfileName ? this.receiverProfileName : this.receiverAddress}
         ></w3m-input-address>
       </wui-flex>
-      ${this.buttonTemplate()}
+      ${this.buttonTemplate(message)}
     </wui-flex>`
   }
 
@@ -166,47 +163,40 @@ export class W3mWalletSendView extends LitElement {
     }
   }
 
-  private getMessage() {
-    this.message = SEND_BUTTON_MESSAGE.PREVIEW_SEND
-
-    if (
-      this.receiverAddress &&
-      !CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)
-    ) {
-      this.message = SEND_BUTTON_MESSAGE.INVALID_ADDRESS
+  private getMessage(): SendButtonMessage {
+    if (!this.token) {
+      return SEND_BUTTON_MESSAGE.SELECT_TOKEN
     }
 
-    if (!this.receiverAddress) {
-      this.message = SEND_BUTTON_MESSAGE.ADD_ADDRESS
-    }
-
-    if (
-      this.sendTokenAmount &&
-      this.token &&
-      this.sendTokenAmount > Number(this.token.quantity.numeric)
-    ) {
-      this.message = SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
-    }
-
-    if (!this.sendTokenAmount) {
-      this.message = SEND_BUTTON_MESSAGE.ADD_AMOUNT
-    }
-
-    if (this.sendTokenAmount && this.token?.price) {
+    if (this.sendTokenAmount && this.token.price) {
       const value = this.sendTokenAmount * this.token.price
       if (!value) {
-        this.message = SEND_BUTTON_MESSAGE.INCORRECT_VALUE
+        return SEND_BUTTON_MESSAGE.INCORRECT_VALUE
       }
     }
 
-    if (!this.token) {
-      this.message = SEND_BUTTON_MESSAGE.SELECT_TOKEN
+    if (!this.sendTokenAmount) {
+      return SEND_BUTTON_MESSAGE.ADD_AMOUNT
     }
+
+    if (this.sendTokenAmount > Number(this.token.quantity.numeric)) {
+      return SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
+    }
+
+    if (!this.receiverAddress) {
+      return SEND_BUTTON_MESSAGE.ADD_ADDRESS
+    }
+
+    if (!CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)) {
+      return SEND_BUTTON_MESSAGE.INVALID_ADDRESS
+    }
+
+    return SEND_BUTTON_MESSAGE.PREVIEW_SEND
   }
 
-  private buttonTemplate() {
-    const isDisabled = !this.message.startsWith(SEND_BUTTON_MESSAGE.PREVIEW_SEND)
-    const isInsufficientBalance = this.message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
+  private buttonTemplate(message: SendButtonMessage) {
+    const isDisabled = !message.startsWith(SEND_BUTTON_MESSAGE.PREVIEW_SEND)
+    const isInsufficientBalance = message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     const isReadOnly = Boolean(this.params)
 
     if (isInsufficientBalance && !isReadOnly) {
@@ -245,7 +235,7 @@ export class W3mWalletSendView extends LitElement {
         ?loading=${this.loading}
         fullWidth
       >
-        ${this.message}
+        ${message}
       </wui-button>
     </wui-flex>`
   }

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -194,9 +194,7 @@ export class W3mWalletSendView extends LitElement {
       return SEND_BUTTON_MESSAGE.ADD_ADDRESS
     }
 
-    if (
-      !CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)
-    ) {
+    if (!CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)) {
       return SEND_BUTTON_MESSAGE.INVALID_ADDRESS
     }
 

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -63,6 +63,8 @@ export class W3mWalletSendView extends LitElement {
 
   @state() private disconnecting = false
 
+  @state() private gasFee = SwapController.state.gasFee
+
   public constructor() {
     super()
     // Only load balances and network price if a token is set, else they will be loaded in the select token view
@@ -95,6 +97,9 @@ export class W3mWalletSendView extends LitElement {
           this.receiverAddress = val.receiverAddress
           this.receiverProfileName = val.receiverProfileName
           this.loading = val.loading
+        }),
+        SwapController.subscribeKey('gasFee', val => {
+          this.gasFee = val
         })
       ]
     )
@@ -118,6 +123,7 @@ export class W3mWalletSendView extends LitElement {
         <w3m-input-token
           .token=${this.token}
           .sendTokenAmount=${this.sendTokenAmount}
+          .gasPrice=${this.gasFee}
           ?readOnly=${isReadOnly}
           ?isInsufficientBalance=${message === SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS}
         ></w3m-input-token>
@@ -139,6 +145,7 @@ export class W3mWalletSendView extends LitElement {
 
   private async fetchNetworkPrice() {
     await SwapController.getNetworkTokenPrice()
+    await SwapController.getInitialGasPrice()
   }
 
   private onButtonClick() {

--- a/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-wallet-send-view/index.ts
@@ -1,7 +1,7 @@
 import { LitElement, html } from 'lit'
 import { state } from 'lit/decorators.js'
 
-import { type CaipAddress } from '@reown/appkit-common'
+import { type CaipAddress, NumberUtil } from '@reown/appkit-common'
 import {
   AssetUtil,
   ChainController,
@@ -175,16 +175,23 @@ export class W3mWalletSendView extends LitElement {
       }
     }
 
-    if (!this.sendTokenAmount) {
-      return SEND_BUTTON_MESSAGE.ADD_AMOUNT
+    if (
+      this.sendTokenAmount &&
+      this.token &&
+      NumberUtil.bigNumber(this.sendTokenAmount).gt(this.token.quantity.numeric)
+    ) {
+      this.message = SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     }
 
     if (this.sendTokenAmount > Number(this.token.quantity.numeric)) {
       return SEND_BUTTON_MESSAGE.INSUFFICIENT_FUNDS
     }
 
-    if (!this.receiverAddress) {
-      return SEND_BUTTON_MESSAGE.ADD_ADDRESS
+    if (this.sendTokenAmount && this.token?.price) {
+      const value = Number(this.sendTokenAmount) * this.token.price
+      if (!value) {
+        this.message = SEND_BUTTON_MESSAGE.INCORRECT_VALUE
+      }
     }
 
     if (!CoreHelperUtil.isAddress(this.receiverAddress, ChainController.state.activeChain)) {
@@ -302,7 +309,7 @@ export class W3mWalletSendView extends LitElement {
         },
         iconUrl: AssetUtil.getTokenImage(symbol) ?? ''
       })
-      SendController.setTokenAmount(amount)
+      SendController.setTokenAmount(String(amount))
       SendController.setReceiverAddress(this.params.to)
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
@@ -78,7 +78,7 @@ describe('W3mInputToken', () => {
 
   it('should display total value when token amount is set', async () => {
     const element: W3mInputToken = await fixture(
-      html`<w3m-input-token .token=${MOCK_TOKEN} .sendTokenAmount=${50}></w3m-input-token>`
+      html`<w3m-input-token .token=${MOCK_TOKEN} .sendTokenAmount=${'50'}></w3m-input-token>`
     )
 
     const totalValue = element.shadowRoot?.querySelector('.totalValue')
@@ -94,7 +94,7 @@ describe('W3mInputToken', () => {
     const maxLink = element.shadowRoot?.querySelector('wui-link')
     maxLink?.click()
 
-    expect(setTokenAmountSpy).toHaveBeenCalledWith(100)
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('100.00000000000000000000')
   })
 
   it('should handle max amount click for native token', async () => {
@@ -119,6 +119,6 @@ describe('W3mInputToken', () => {
     const input = element.shadowRoot?.querySelector('wui-input-amount')
     input?.dispatchEvent(new CustomEvent('inputChange', { detail: 75 }))
 
-    expect(setTokenAmountSpy).toHaveBeenCalledWith(75)
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('75')
   })
 })

--- a/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
@@ -100,7 +100,10 @@ describe('W3mInputToken', () => {
   it('should handle max amount click for native token', async () => {
     const setTokenAmountSpy = vi.spyOn(SendController, 'setTokenAmount')
     const element: W3mInputToken = await fixture(
-      html`<w3m-input-token .token=${MOCK_NATIVE_TOKEN} .gasPrice=${'1000000000'}></w3m-input-token>`
+      html`<w3m-input-token
+        .token=${MOCK_NATIVE_TOKEN}
+        .gasPrice=${'1000000000'}
+      ></w3m-input-token>`
     )
 
     const maxLink = element.shadowRoot?.querySelector('wui-link')

--- a/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-input-token.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { html } from 'lit'
 
 import type { Balance } from '@reown/appkit-common'
-import { ConstantsUtil, RouterController, SendController } from '@reown/appkit-controllers'
+import { RouterController, SendController } from '@reown/appkit-controllers'
 import { UiHelperUtil } from '@reown/appkit-ui'
 
 import { W3mInputToken } from '../../src/partials/w3m-input-token'
@@ -23,7 +23,7 @@ const MOCK_TOKEN: Balance = {
 } as unknown as Balance
 
 const MOCK_NATIVE_TOKEN: Balance = {
-  address: ConstantsUtil.NATIVE_TOKEN_ADDRESS.eip155,
+  address: undefined,
   chainId: '1',
   symbol: 'ETH',
   name: 'Ethereum',
@@ -94,20 +94,22 @@ describe('W3mInputToken', () => {
     const maxLink = element.shadowRoot?.querySelector('wui-link')
     maxLink?.click()
 
-    expect(setTokenAmountSpy).toHaveBeenCalledWith('100.00000000000000000000')
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('100.000000000000000000')
   })
 
   it('should handle max amount click for native token', async () => {
     const setTokenAmountSpy = vi.spyOn(SendController, 'setTokenAmount')
     const element: W3mInputToken = await fixture(
-      html`<w3m-input-token .token=${MOCK_NATIVE_TOKEN} .gasPrice=${1000000000}></w3m-input-token>`
+      html`<w3m-input-token .token=${MOCK_NATIVE_TOKEN} .gasPrice=${'1000000000'}></w3m-input-token>`
     )
 
     const maxLink = element.shadowRoot?.querySelector('wui-link')
     maxLink?.click()
 
-    // Should subtract gas from max amount for native token
-    expect(setTokenAmountSpy).toHaveBeenCalled()
+    // Should subtract gas (65000 * 1 Gwei = 0.000065 ETH) from max amount for native token
+    // 65000 covers EOA (21000) and common contract recipients (multisigs, exchange deposits)
+    // 10 ETH - 0.000065 ETH = 9.999935 ETH
+    expect(setTokenAmountSpy).toHaveBeenCalledWith('9.999935000000000000')
   })
 
   it('should update token amount when input changes', async () => {

--- a/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-swap-view.test.ts
@@ -414,7 +414,7 @@ describe('W3mSwapView', () => {
 
     vitestExpect(handleChangeAmountSpy).toHaveBeenCalledWith(
       'sourceToken',
-      '100.00000000000000000000'
+      '100.000000000000000000'
     )
 
     // Wait for debounce timeout

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-preview-view.test.ts
@@ -54,7 +54,7 @@ const mockNetwork: CaipNetwork = {
 
 const mockSendControllerState = {
   token: mockToken,
-  sendTokenAmount: 5,
+  sendTokenAmount: '5',
   receiverAddress: '0x456',
   loading: false,
   tokenBalances: [mockToken]

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-view-params.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-view-params.test.ts
@@ -102,7 +102,7 @@ describe('W3mWalletSendView - parameters handling', () => {
       iconUrl: ''
     })
 
-    expect(SendController.setTokenAmount).toHaveBeenCalledWith(10.5)
+    expect(SendController.setTokenAmount).toHaveBeenCalledWith('10.5')
     expect(SendController.setReceiverAddress).toHaveBeenCalledWith(mockValidParams.to)
   })
 

--- a/packages/scaffold-ui/test/views/w3m-wallet-send-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-wallet-send-view.test.ts
@@ -88,7 +88,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     await element.updateComplete
@@ -105,7 +105,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(150)
+    SendController.setTokenAmount('150')
     SendController.setReceiverAddress('0x456')
     await element.updateComplete
     await element.render()
@@ -123,7 +123,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     SendController.setReceiverAddress('invalid-address')
@@ -152,7 +152,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     const addressInput = element.shadowRoot?.querySelector('w3m-input-address') as HTMLElement
@@ -175,7 +175,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setNetworkBalanceInUsd('100')
 
     const addressInput = element.shadowRoot?.querySelector('w3m-input-address') as HTMLElement
@@ -198,7 +198,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setReceiverAddress('0x123456789abcdef123456789abcdef123456789a')
     await element.updateComplete
     await element.render()
@@ -215,7 +215,7 @@ describe('W3mWalletSendView', () => {
     )
 
     SendController.setToken(mockToken)
-    SendController.setTokenAmount(50)
+    SendController.setTokenAmount('50')
     SendController.setReceiverAddress('0x123456789abcdef123456789abcdef123456789a')
     await element.updateComplete
     await element.render()

--- a/packages/wallet/src/W3mFrameProvider.ts
+++ b/packages/wallet/src/W3mFrameProvider.ts
@@ -15,6 +15,28 @@ import type { W3mFrameTypes } from './W3mFrameTypes.js'
 
 type AppEventType = Omit<W3mFrameTypes.AppEvent, 'id'>
 
+// -- Helpers ----------------------------------------------------------------
+function serializeBigInts<T>(value: T): T {
+  if (typeof value === 'bigint') {
+    return `0x${value.toString(16)}` as unknown as T
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(serializeBigInts) as unknown as T
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = serializeBigInts(v)
+    }
+
+    return result as T
+  }
+
+  return value
+}
+
 interface W3mFrameProviderConfig {
   projectId: string
   chainId?: W3mFrameTypes.Network['chainId']
@@ -541,7 +563,7 @@ export class W3mFrameProvider {
       this.rpcRequestHandler?.(req)
       const response = await this.appEvent<'Rpc'>({
         type: W3mFrameConstants.APP_RPC_REQUEST,
-        payload: request
+        payload: serializeBigInts(request)
       } as W3mFrameTypes.AppEvent)
 
       this.rpcSuccessHandler?.(response, request)


### PR DESCRIPTION
## Summary

Consolidated batch of bug fixes from individual fix branches, ready for preview testing before merging to main.

- **fix(send):** use string type for `sendTokenAmount` to preserve precision (#5618)
- **fix:** resolve Lit dev warnings from AppKit web components (#5629)
- **fix:** include `projectId` in API requests when value is empty string (#5631)
- **fix:** reject malformed CAIP-10 addresses in `setCaipAddress` (#5634)
- **fix:** handle undefined address in wagmi `toChecksummedAddress` (#5635)
- **fix:** serialize BigInt values in social login RPC requests (#5632)
- **fix(swap):** auto-focus input field when swap view opens (#5619)
- **fix:** pass required account param in Bitcoin `getAccountAddresses` (#5630)
- **fix:** guard `setDefaultChain` calls against undefined provider on stale sessions (#5633)
- **fix:** catch unhandled RPC rejections from internal API calls (#5636)

## Test plan

- [ ] Verify all fixes on Vercel preview deployment
- [ ] Send flow: token amounts preserve decimal precision
- [ ] Swap flow: input field auto-focuses on open
- [ ] Social login: BigInt values serialize correctly
- [ ] Bitcoin: getAccountAddresses works without errors
- [ ] Stale sessions: no crashes from undefined provider
- [ ] CAIP-10 validation: malformed addresses are rejected
- [ ] API requests: projectId included even when empty string
- [ ] No Lit dev warnings in console