### PR TITLE
fix: improve isMobile() to exclude touchscreen desktops/laptops

### DIFF
--- a/.changeset/empty-bugs-end.md
+++ b/.changeset/empty-bugs-end.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+fix: improve isMobile() to exclude touchscreen desktops using any-pointer:fine media query

--- a/packages/controllers/src/utils/CoreHelperUtil.ts
+++ b/packages/controllers/src/utils/CoreHelperUtil.ts
@@ -27,12 +27,25 @@ export const CoreHelperUtil = {
 
   isMobile() {
     if (this.isClient()) {
-      return Boolean(
-        (window?.matchMedia &&
-          typeof window.matchMedia === 'function' &&
-          window.matchMedia('(pointer:coarse)')?.matches) ||
-          /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)
-      )
+      // Known mobile UA strings - definitive match, check first
+      if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent)) {
+        return true
+      }
+
+      /*
+       * Pointer:coarse matches touchscreens, but also touchscreen desktops/laptops.
+       * If a fine pointer (trackpad/mouse) is also available via any-pointer:fine,
+       * this is a multi-input desktop device - not mobile.
+       * Ref: https://css-tricks.com/interaction-media-features-and-their-potential-for-incorrect-assumptions/
+       */
+      const isCoarsePointer = window.matchMedia?.('(pointer:coarse)')?.matches ?? false
+      const hasAnyFinePointer = window.matchMedia?.('(any-pointer:fine)')?.matches ?? false
+
+      if (isCoarsePointer && hasAnyFinePointer) {
+        return false
+      }
+
+      return isCoarsePointer
     }
 
     return false

--- a/packages/controllers/tests/utils/CoreHelperUtil.test.ts
+++ b/packages/controllers/tests/utils/CoreHelperUtil.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { CoreHelperUtil } from '../../src/utils/CoreHelperUtil.js'
 
@@ -122,6 +122,80 @@ describe('CoreHelperUtil', () => {
     ['bip122:mock_chain_id:mock_address', true]
   ])('should validate the value $s is valid caip address $b', (caipAddress, expected) => {
     expect(CoreHelperUtil.isCaipAddress(caipAddress)).toEqual(expected)
+  })
+
+  describe('isMobile', () => {
+    function mockMatchMedia(results: Record<string, boolean>) {
+      vi.spyOn(window, 'matchMedia').mockImplementation(
+        (query: string) =>
+          ({
+            matches: results[query] ?? false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn()
+          }) as MediaQueryList
+      )
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return true for iPhone user agent', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      )
+
+      expect(CoreHelperUtil.isMobile()).toBe(true)
+    })
+
+    it('should return true for Android user agent', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36'
+      )
+
+      expect(CoreHelperUtil.isMobile()).toBe(true)
+    })
+
+    it('should return false for non-touch desktop', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      )
+      mockMatchMedia({
+        '(pointer:coarse)': false,
+        '(any-pointer:fine)': true
+      })
+
+      expect(CoreHelperUtil.isMobile()).toBe(false)
+    })
+
+    it('should return false for touchscreen desktop/laptop', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      )
+      mockMatchMedia({
+        '(pointer:coarse)': true,
+        '(any-pointer:fine)': true
+      })
+
+      expect(CoreHelperUtil.isMobile()).toBe(false)
+    })
+
+    it('should return true for coarse-only device without mobile UA', () => {
+      vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+        'Mozilla/5.0 (X11; CrOS armv7l 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36'
+      )
+      mockMatchMedia({
+        '(pointer:coarse)': true,
+        '(any-pointer:fine)': false
+      })
+
+      expect(CoreHelperUtil.isMobile()).toBe(true)
+    })
   })
 
   describe('formatNativeUrl', () => {


### PR DESCRIPTION
# fix: improve `isMobile()` detection to exclude touchscreen desktops/laptops

Fixes #5648

## Problem

`CoreHelperUtil.isMobile()` uses `(pointer:coarse)` as a mobile detection signal. This misclassifies touchscreen desktops and laptops (Surface Pro, Dell XPS 2-in-1, Lenovo Yoga, etc.) as mobile devices.

The downstream impact: `ConnectorUtil.getConnectViewItems()` completely excludes the WalletConnect QR connector when `isMobile` returns `true`, so users on touchscreen laptops cannot connect via QR code scan.

## Solution

Check whether a **fine pointer is also available** using `(any-pointer:fine)`. On a touchscreen laptop, `(pointer:coarse)` is `true` (touchscreen is primary) but `(any-pointer:fine)` is also `true` (trackpad/mouse exists). On actual mobile devices, only `(pointer:coarse)` matches.

This approach is recommended by **Patrick H. Lauke**, co-editor of the W3C Pointer Events spec:

> *`@media (pointer: coarse) and (any-pointer: fine)` suggests the primary input is touchscreen, but that there is a mouse or stylus present.*
> — [Interaction Media Features and Their Potential (for Incorrect Assumptions)](https://css-tricks.com/interaction-media-features-and-their-potential-for-incorrect-assumptions/)

## Changes

- **`CoreHelperUtil.isMobile()`**: UA regex check first (definitive), then media query check with `any-pointer:fine` exclusion for multi-input devices
- **Tests**: Added test cases for mobile phone, non-touch desktop, and touchscreen laptop scenarios

## Detection matrix

| Device | `pointer:coarse` | `any-pointer:fine` | UA match | `isMobile()` |
|---|---|---|---|---|
| iPhone / Android phone | ✅ | ❌ | ✅ | `true` ✅ |
| iPad | ✅ | ❌ | ✅ | `true` ✅ |
| Desktop (no touch) | ❌ | ✅ | ❌ | `false` ✅ |
| Surface / touch laptop | ✅ | ✅ | ❌ | `false` ✅ (fixed) |
| Phone + bluetooth mouse | ✅ | ✅ | ✅ | `true` ✅ (UA takes priority) |

## Testing

- Verified on Windows 11 touchscreen laptop (Chrome, Edge, Firefox)
- Verified on Ubuntu 24 desktop (no regression)
- Verified on Android / iOS (no regression)
- Unit tests pass: `pnpm test`

## References

- [W3C F98 — Failure due to interactions limited to touch-only](https://www.w3.org/WAI/WCAG21/Techniques/failures/F98)
- [Patrick H. Lauke — Touchscreen detection](https://patrickhlauke.github.io/touch/touchscreen-detection/)
- [Smashing Magazine — Guide to hover and pointer media queries](https://www.smashingmagazine.com/2022/03/guide-hover-pointer-media-queries/)