### PR TITLE
fix: ensure allAccounts is populated after reload

### DIFF
--- a/.changeset/fix-allaccounts-empty-on-reload.md
+++ b/.changeset/fix-allaccounts-empty-on-reload.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit': patch
+---
+
+Fix `useAppKitAccount().allAccounts` being empty after page reload when a reconnected connection's `caipNetwork` had not yet resolved. Falls back to the active network for the namespace so accounts always surface.

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2411,18 +2411,22 @@ export abstract class AppKitBaseClient {
       throw new Error('AppKit:getAccount - namespace is required')
     }
 
-    const allAccounts = connections.flatMap(connection => {
-      const { caipNetwork } = connection
+    const fallbackCaipNetwork = ChainController.getActiveCaipNetwork(namespace)
 
-      return caipNetwork
-        ? connection.accounts.map(({ address, type, publicKey }) =>
-            CoreHelperUtil.createAccount({
-              caipAddress: `${caipNetwork.caipNetworkId}:${address}`,
-              type: type || 'eoa',
-              publicKey
-            })
-          )
-        : []
+    const allAccounts = connections.flatMap(connection => {
+      const caipNetwork = connection.caipNetwork ?? fallbackCaipNetwork
+
+      if (!caipNetwork) {
+        return []
+      }
+
+      return connection.accounts.map(({ address, type, publicKey }) =>
+        CoreHelperUtil.createAccount({
+          caipAddress: `${caipNetwork.caipNetworkId}:${address}`,
+          type: type || 'eoa',
+          publicKey
+        })
+      )
     })
 
     if (!accountState) {

--- a/packages/appkit/tests/client/public-methods.test.ts
+++ b/packages/appkit/tests/client/public-methods.test.ts
@@ -1155,6 +1155,39 @@ describe('Base Public methods', () => {
     })
   })
 
+  it('returns allAccounts even when connection.caipNetwork is undefined, falling back to active network', () => {
+    vi.spyOn(ChainController, 'getAccountData').mockReturnValue({
+      caipAddress: 'eip155:1:0xabc',
+      status: 'connected',
+      currentTab: 0,
+      addressLabels: new Map(),
+      preferredAccountType: 'eoa'
+    })
+    vi.spyOn(ChainController, 'getActiveCaipNetwork').mockReturnValue(mainnet)
+    vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([
+      {
+        connectorId: 'metamask',
+        accounts: [{ address: '0xabc' }],
+        caipNetwork: undefined
+      }
+    ])
+
+    const appKit = new AppKit(mockOptions)
+    const account = appKit.getAccount('eip155')
+
+    expect(account?.allAccounts).toEqual([
+      {
+        namespace: 'eip155',
+        address: '0xabc',
+        chainId: String(mainnet.id),
+        caipAddress: `${mainnet.caipNetworkId}:0xabc`,
+        type: 'eoa',
+        publicKey: undefined,
+        path: undefined
+      }
+    ])
+  })
+
   it('should handle network switcher UI when enableNetworkSwitch is true', async () => {
     vi.spyOn(ChainController, 'getNetworkData').mockReturnValue(
       mainnet as unknown as AdapterNetworkState


### PR DESCRIPTION
Ensure allAccounts is populated after reload by falling back to active network when caipNetwork is undefined

# Description

Please include a brief summary of the change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues


For GH issues: 
closes #5622
closes #5600 

# Showcase (Optional)

If there is a UI change include the screenshots with before and after state.
If new feature is being introduced, include the link to demo recording.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
