### PR TITLE
fix(tests): capture window.open URL before redirects in clickOpenWebApp

### DIFF
--- a/apps/laboratory/tests/shared/pages/ModalPage.ts
+++ b/apps/laboratory/tests/shared/pages/ModalPage.ts
@@ -924,30 +924,38 @@ export class ModalPage {
   }
 
   async clickOpenWebApp() {
-    let url = ''
-
     const openButton = this.page.getByTestId('w3m-connecting-widget-secondary-button')
     await expect(openButton).toBeVisible()
     await expect(openButton).toHaveText('Open')
 
-    while (!url) {
-      await openButton.click()
-      await this.page.waitForTimeout(500)
+    /*
+     * Patch window.open to capture the URL synchronously at the moment AppKit
+     * calls it. Reading lastTab.url() after the click races against external
+     * redirects (e.g. some wallets' webapp_link points to chromewebstore.google.com
+     * which immediately redirects to a Google consent page, dropping the ?uri= param).
+     */
+    await this.page.evaluate(() => {
+      const original = window.open
+      ;(window as unknown as { __capturedOpenUrl: string }).__capturedOpenUrl = ''
+      window.open = function open(...args: Parameters<typeof window.open>) {
+        ;(window as unknown as { __capturedOpenUrl: string }).__capturedOpenUrl = String(
+          args[0] ?? ''
+        )
 
-      const pages = this.page.context().pages()
-
-      // Check if more than 1 tab is open
-      if (pages.length > 1) {
-        const lastTab = pages[pages.length - 1]
-
-        if (lastTab) {
-          url = lastTab.url()
-          break
-        }
+        return original.apply(this, args)
       }
-    }
+    })
 
-    return url
+    await openButton.click()
+    await this.page.waitForFunction(
+      () => (window as unknown as { __capturedOpenUrl: string }).__capturedOpenUrl !== '',
+      undefined,
+      { timeout: 10_000 }
+    )
+
+    return this.page.evaluate(
+      () => (window as unknown as { __capturedOpenUrl: string }).__capturedOpenUrl
+    )
   }
 
   async search(value: string) {


### PR DESCRIPTION
## Summary

Fixes the flaky `wallet-features.spec.ts:131:1 › it should open web app wallet` test that has been failing across multiple CI shards on unrelated PRs (#5638, #5651).

## Root Cause

The test clicks "Open" which calls `window.open(<webapp_link>/wc?uri=<wc-uri>, '_blank')` and reads the new tab's URL after a 500ms timeout to assert that `?uri=<wc URI>` was passed.

**MathWallet's `webapp_link` in the WC explorer points to `https://chromewebstore.google.com/detail/math-wallet/...`** — the Chrome Web Store extension page (since MathWallet doesn't have a real web wallet). Google's Chrome Web Store **immediately redirects** to `https://consent.google.com/m?continue=<original-url>&...` (cookie consent gate). By the time `lastTab.url()` is read, the URL no longer has the `uri` param at the top level — it's nested inside `continue=`.

Confirmed via the playwright trace from a failing CI run:
```
https://consent.google.com/m?continue=https%3A%2F%2Fchromewebstore.google.com%2F.../wc%3Furi%3Dwc%3A...&gl=DE&...
```

## Fix

Patch `window.open` in the page context to capture the URL synchronously at the moment AppKit calls it, before any navigation or redirect happens. This is what the test actually wants to assert on anyway (the URL AppKit attempted to open), independent of whatever the destination wallet does after navigation.

This is more robust than relying on a specific wallet's `webapp_link` not redirecting — any wallet that redirects (intentionally or via geo-based consent gates) would otherwise re-introduce the flake.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [ ] Verify on CI that `wallet-features.spec.ts:131` passes consistently across all shards
