### PR TITLE
fix(tests): drop racy disabled-state precondition in mobile open button test

### DIFF
--- a/apps/laboratory/tests/mobile-wallet-features.spec.ts
+++ b/apps/laboratory/tests/mobile-wallet-features.spec.ts
@@ -82,7 +82,13 @@ mobileWalletFeaturesTest('it should show open button', async ({ library }) => {
   }
 
   await modalPage.clickAllWalletsListSearchItem(walletConfig.walletId)
-  await modalValidator.expectOpenButton({ disabled: true })
-  await modalPage.page.waitForTimeout(2000)
+  /*
+   * Skip the transient `disabled: true` precondition: the connecting widget
+   * sets isLoading = !this.uri synchronously in its constructor, so when the
+   * WC URI is already cached (which depends on relay timing and prior tests),
+   * the loading state is invisible to the test. The user-meaningful behavior
+   * is that the Open button ends up enabled — which the assertion below
+   * verifies (with a 60s default timeout).
+   */
   await modalValidator.expectOpenButton({ disabled: false })
 })


### PR DESCRIPTION
## Summary

Fixes the flaky `mobile-wallet-features.spec.ts:73 › it should show open button` test that has been failing intermittently across shards (e.g. on PR #5655 April 30 — Galaxy S5 × ethers/solana/bitcoin — and on this PR's #5638 follow-up).

## Root Cause

The test asserts the secondary button transitions from disabled → enabled:

```typescript
await modalPage.clickAllWalletsListSearchItem(walletConfig.walletId)
await modalValidator.expectOpenButton({ disabled: true })   // ← racy
await modalPage.page.waitForTimeout(2000)
await modalValidator.expectOpenButton({ disabled: false })
```

But `w3m-connecting-wc-mobile/index.ts:31-77` sets `isLoading = !this.uri` **synchronously in the constructor**:

```typescript
@state() protected override isLoading = true

constructor() {
  super()
  // ...
  this.onHandleURI()   // sets isLoading = !this.uri before first paint
  // ...
}
```

The parent reads `ConnectionController.state.wcUri` at instantiation. When `wcUri` is already cached (from `beforeAll`'s `openConnectModal()` or from prior tests in the serial suite), the widget mounts with `isLoading = false` immediately — the loading state is **invisible to the test**.

The same widget pattern exists in `w3m-connecting-wc-web` for desktop, but the desktop equivalent test never asserts on loading state, so only the mobile test is affected.

## Fix

Drop the `disabled: true` precondition (and the 2s sleep). The remaining `expectOpenButton({ disabled: false })` (with 60s default timeout) still verifies what users care about — the Open button works after picking a wallet.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [ ] Verify on CI that `mobile-wallet-features.spec.ts:73` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)