### PR TITLE
fix(solana): sync walletProvider after switchNetwork for non-AUTH providers

### DIFF
--- a/.changeset/fix-solana-switch-network-provider.md
+++ b/.changeset/fix-solana-switch-network-provider.md
@@ -1,0 +1,11 @@
+---
+"@reown/appkit-adapter-solana": patch
+"@reown/appkit": patch
+---
+
+fix(solana): sync walletProvider after switchNetwork for non-AUTH providers
+
+`useAppKitProvider` returned a stale provider after calling `switchNetwork` because
+the Solana adapter never emitted a `switchNetwork` event for WalletConnect and
+standard wallet providers, and the base client's `switchNetwork` handler never
+called `syncProvider`. Both are now fixed.

--- a/packages/adapters/solana/src/client.ts
+++ b/packages/adapters/solana/src/client.ts
@@ -19,6 +19,7 @@ import {
   CoreHelperUtil,
   type Provider as CoreProvider,
   OptionsController,
+  ProviderController,
   StorageUtil,
   WcHelpersUtil
 } from '@reown/appkit-controllers'
@@ -507,6 +508,20 @@ export class SolanaAdapter extends AdapterBlueprint<SolanaProvider> {
       SolStoreUtil.setConnection(
         new SolanaConnection(caipNetwork.rpcUrls.default.http[0], this.connectionSettings)
       )
+    }
+
+    /*
+     * super.switchNetwork() only emits 'switchNetwork' for AUTH providers.
+     * For WalletConnect and standard wallet providers we must emit it here so
+     * the base-client can re-sync the provider state via syncProvider().
+     */
+    const providerType = ProviderController.getProviderId(caipNetwork.chainNamespace)
+    if (providerType !== 'AUTH') {
+      const address = ChainController.state.chains.get(caipNetwork.chainNamespace)?.accountState
+        ?.address
+      if (address) {
+        this.emit('switchNetwork', { chainId: caipNetwork.id, address })
+      }
     }
   }
 

--- a/packages/adapters/solana/src/tests/client.test.ts
+++ b/packages/adapters/solana/src/tests/client.test.ts
@@ -651,6 +651,54 @@ describe('SolanaAdapter', () => {
       expect(switchNetworkSpy).toHaveBeenCalled()
       expect(SolStoreUtil.setConnection).toHaveBeenCalled()
     })
+
+    it('should emit switchNetwork event for WalletConnect provider', async () => {
+      const wcProvider = mockUniversalProvider()
+      ProviderController.setProvider(mockCaipNetworks[0].chainNamespace, wcProvider)
+      ProviderController.setProviderId(mockCaipNetworks[0].chainNamespace, 'WALLET_CONNECT')
+
+      ChainController.state.chains.get('solana')!.accountState!.address = '0xTestAddress'
+
+      const emitSpy = vi.spyOn(adapter, 'emit')
+
+      await adapter.switchNetwork({ caipNetwork: mockCaipNetworks[0] })
+
+      expect(SolStoreUtil.setConnection).toHaveBeenCalled()
+      expect(emitSpy).toHaveBeenCalledWith('switchNetwork', {
+        chainId: mockCaipNetworks[0].id,
+        address: '0xTestAddress'
+      })
+    })
+
+    it('should emit switchNetwork event for standard wallet provider', async () => {
+      ProviderController.setProvider(mockCaipNetworks[0].chainNamespace, mockProvider)
+      ProviderController.setProviderId(mockCaipNetworks[0].chainNamespace, 'ANNOUNCED')
+
+      ChainController.state.chains.get('solana')!.accountState!.address = '0xTestAddress'
+
+      const emitSpy = vi.spyOn(adapter, 'emit')
+
+      await adapter.switchNetwork({ caipNetwork: mockCaipNetworks[0] })
+
+      expect(SolStoreUtil.setConnection).toHaveBeenCalled()
+      expect(emitSpy).toHaveBeenCalledWith('switchNetwork', {
+        chainId: mockCaipNetworks[0].id,
+        address: '0xTestAddress'
+      })
+    })
+
+    it('should not emit switchNetwork event when no account address is present', async () => {
+      ProviderController.setProvider(mockCaipNetworks[0].chainNamespace, mockProvider)
+      ProviderController.setProviderId(mockCaipNetworks[0].chainNamespace, 'ANNOUNCED')
+
+      ChainController.state.chains.get('solana')!.accountState!.address = undefined
+
+      const emitSpy = vi.spyOn(adapter, 'emit')
+
+      await adapter.switchNetwork({ caipNetwork: mockCaipNetworks[0] })
+
+      expect(emitSpy).not.toHaveBeenCalledWith('switchNetwork', expect.anything())
+    })
   })
 
   describe('SolanaAdapter - connectWalletConnect', () => {

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -1225,6 +1225,19 @@ export abstract class AppKitBaseClient {
       } else {
         this.setUnsupportedNetwork(chainId)
       }
+
+      const currentProvider = ProviderController.getProvider(chainNamespace)
+      const currentProviderId = ProviderController.getProviderId(chainNamespace)
+      const currentConnectorId = ConnectorController.getConnectorId(chainNamespace)
+
+      if (currentProvider && currentProviderId && currentConnectorId) {
+        this.syncProvider({
+          id: currentConnectorId,
+          type: currentProviderId,
+          provider: currentProvider,
+          chainNamespace
+        })
+      }
     })
 
     adapter.on('disconnect', () => {


### PR DESCRIPTION
## Summary

- Solana adapter now emits `switchNetwork` for WalletConnect and standard wallet providers (previously only AUTH providers triggered this event)
- Base-client `switchNetwork` handler now calls `syncProvider()` after `syncAccount()`, keeping `useAppKitProvider` reactive after network switches

## Root Cause

`useAppKitProvider` reads from `ProviderController.state.providers[namespace]`, which is only updated by `syncProvider()`. The Solana adapter's `switchNetwork` method only emitted the event for AUTH connectors (via `super.switchNetwork()`), leaving WC and standard wallet providers without a re-sync. The base-client handler also never called `syncProvider()` in the `switchNetwork` event path.

## Test plan

- [x] New unit tests: WC provider emits `switchNetwork` event after network change
- [x] New unit tests: Standard wallet provider emits `switchNetwork` event after network change  
- [x] New unit tests: No address → event not emitted
- [x] All 32 Solana adapter tests pass

Fixes: REOWN-4377

🤖 Generated with [Claude Code](https://claude.com/claude-code)