### PR TITLE
fix(wallet): bundle @walletconnect/logger to fix SSR named export error

### DIFF
--- a/.changeset/fix-wallet-esm-ssr-bundle.md
+++ b/.changeset/fix-wallet-esm-ssr-bundle.md
@@ -1,0 +1,5 @@
+---
+"@reown/appkit-wallet": patch
+---
+
+Bundle @walletconnect/logger into the wallet package dist to fix SSR environments (SvelteKit, Next.js on Vercel) where Vite externalizes the dependency and Node.js resolves it as CJS, causing a "Named export not found" error at runtime.

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "build:clean": "rm -rf dist",
-    "build": "tsc --build",
+    "build": "tsc --build && vite build",
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "2.1.9",
     "jsdom": "24.1.0",
+    "vite": "5.4.20",
     "vitest": "3.1.3"
   },
   "keywords": [

--- a/packages/wallet/vite.config.ts
+++ b/packages/wallet/vite.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        'exports/index': resolve(__dirname, 'exports/index.ts'),
+        'exports/utils': resolve(__dirname, 'exports/utils.ts')
+      },
+      formats: ['es'],
+      fileName: (_format, entryName) => `${entryName}.js`
+    },
+    outDir: 'dist/esm',
+    emptyOutDir: true,
+    rollupOptions: {
+      external: ['@reown/appkit-common', '@reown/appkit-polyfills', 'zod']
+    }
+  }
+})


### PR DESCRIPTION
## Summary

- `@reown/appkit-wallet` previously used `tsc --build` only, which left `@walletconnect/logger` as a raw runtime import in `dist/esm/`
- Vite SSR (SvelteKit, Next.js) externalizes the dependency; Node.js then resolves the CJS version, causing `SyntaxError: Named export 'generateChildLogger' not found` on Vercel and similar SSR environments
- This was a regression introduced in **1.8.10** when `@walletconnect/logger` was bumped from `2.1.2` → `3.0.0` (which added an `exports` map that changed how Vite handles SSR bundling)
- Fix adds a Vite library build step that inlines `@walletconnect/logger` into the dist output — same pattern as `@reown/appkit-cdn`

## Test plan

- [x] `@walletconnect/logger` import no longer present anywhere in `dist/esm/` after build
- [x] Node.js ESM direct import of `dist/esm/exports/index.js` succeeds without CJS/ESM error (simulates Vercel SSR runtime)
- [x] All 27 existing unit tests pass
- [x] Changeset included

Closes REOWN-4396

🤖 Generated with [Claude Code](https://claude.com/claude-code)