### PR TITLE
fix(headless): use Universal Link for custom-deeplink wallets on mobile

### DIFF
--- a/.changeset/fix-headless-solflare-mobile-deeplink.md
+++ b/.changeset/fix-headless-solflare-mobile-deeplink.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fix Solflare and other custom-deeplink wallets failing to open on mobile in headless mode. The headless `connect()` now routes Phantom, Solflare, Coinbase, and Binance through `MobileWalletUtil.handleMobileDeeplinkRedirect` (their Universal Link `…/ul/v1/browse/…` format) instead of building a `<mobile_link>wc?uri=…` URL that Solflare's app does not handle. Matches the existing headful `selectWalletConnector` behavior.

--- a/.changeset/fix-solflare-evm-universal-link.md
+++ b/.changeset/fix-solflare-evm-universal-link.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Allow Solflare's Universal Link to also open when the active namespace is EVM, not only Solana. Solflare's in-app browser exposes both `window.solflare` (Solana) and `window.ethereum` (EVM), so the same `https://solflare.com/ul/v1/browse/<dapp_url>` deeplink is the correct entry point for EVM dApps too. Without this, EVM-only consumers (no Solana adapter registered) fell through to `solflare://wc?uri=…`, which Solflare's app does not handle.

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -555,13 +555,24 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
         await ConnectorControllerUtil.connectExternal(fallbackConnector)
       } else if (isMobileDevice) {
         const wcWallet = ConnectUtil.mapWalletItemToWcWallet(_wallet)
+        const isCustomDeeplinkWallet = MobileWalletUtil.isCustomDeeplinkWallet(
+          _wallet.id,
+          activeNamespace
+        )
 
-        if (wcWallet.mobile_link) {
-          ConnectionControllerUtil.onConnectMobile(wcWallet, options?.wcPayUrl)
-        } else {
+        /*
+         * Custom-deeplink wallets (Phantom, Solflare, Coinbase, Binance) either
+         * don't support WalletConnect or expect a specific browse-URL format
+         * (`https://<wallet>/ul/v1/browse/<dapp_url>`). Building
+         * `<mobile_link>wc?uri=<wc_uri>` here would silently fail for Solflare.
+         * Matches headful selectWalletConnector behavior.
+         */
+        if (isCustomDeeplinkWallet || !wcWallet.mobile_link) {
           MobileWalletUtil.handleMobileDeeplinkRedirect(_wallet.id, activeNamespace, {
             isCoinbaseDisabled: OptionsController.state.enableCoinbase === false
           })
+        } else {
+          ConnectionControllerUtil.onConnectMobile(wcWallet, options?.wcPayUrl)
         }
       } else {
         await ConnectionController.connectWalletConnect({ cache: 'never' })

--- a/packages/controllers/src/utils/MobileWallet.ts
+++ b/packages/controllers/src/utils/MobileWallet.ts
@@ -63,7 +63,14 @@ export const MobileWalletUtil = {
     }
 
     if (id === CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id) {
-      return namespace === ConstantsUtil.CHAIN.SOLANA
+      /*
+       * Solflare's in-app browser exposes both `window.solflare` (Solana) and
+       * `window.ethereum` (EVM), so the same `…/ul/v1/browse/<dapp_url>`
+       * Universal Link is the correct entry point for either chain.
+       * The `solflare://wc?uri=…` deeplink that the WC fallback would build
+       * is not handled by Solflare's app.
+       */
+      return namespace === ConstantsUtil.CHAIN.SOLANA || namespace === ConstantsUtil.CHAIN.EVM
     }
 
     if (id === CUSTOM_DEEPLINK_WALLETS.COINBASE.id) {
@@ -121,10 +128,10 @@ export const MobileWalletUtil = {
       }
     }
 
-    // Solflare only supports Solana
+    // Solflare's in-app browser supports both Solana and EVM dApps
     if (
       id === CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id &&
-      namespace === ConstantsUtil.CHAIN.SOLANA &&
+      (namespace === ConstantsUtil.CHAIN.SOLANA || namespace === ConstantsUtil.CHAIN.EVM) &&
       !('solflare' in window)
     ) {
       window.location.href = `${CUSTOM_DEEPLINK_WALLETS.SOLFLARE.url}/ul/v1/browse/${encodedHref}?ref=${encodedHref}`

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -1740,34 +1740,37 @@ describe('useAppKitWallets', () => {
       }
     }
 
-    it('uses handleMobileDeeplinkRedirect for Solflare on Solana even when mobile_link is set', async () => {
-      mockHeadlessSnapshots()
-      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
-      vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('solana')
+    it.each([['solana' as const], ['eip155' as const]])(
+      'uses handleMobileDeeplinkRedirect for Solflare on %s even when mobile_link is set',
+      async namespace => {
+        mockHeadlessSnapshots()
+        vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+        vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue(namespace)
 
-      const handleRedirectSpy = vi
-        .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
-        .mockImplementation(() => undefined)
-      const onConnectMobileSpy = vi
-        .spyOn(ConnectionControllerUtil, 'onConnectMobile')
-        .mockImplementation(() => undefined)
+        const handleRedirectSpy = vi
+          .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
+          .mockImplementation(() => undefined)
+        const onConnectMobileSpy = vi
+          .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+          .mockImplementation(() => undefined)
 
-      const solflare = makeMobileWallet({
-        id: CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
-        name: 'Solflare',
-        walletInfo: { deepLink: 'solflare://' }
-      })
+        const solflare = makeMobileWallet({
+          id: CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
+          name: 'Solflare',
+          walletInfo: { deepLink: 'solflare://' }
+        })
 
-      const result = useAppKitWallets()
-      await result.connect(solflare, 'solana')
+        const result = useAppKitWallets()
+        await result.connect(solflare, namespace)
 
-      expect(handleRedirectSpy).toHaveBeenCalledWith(
-        CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
-        'solana',
-        expect.objectContaining({ isCoinbaseDisabled: expect.any(Boolean) })
-      )
-      expect(onConnectMobileSpy).not.toHaveBeenCalled()
-    })
+        expect(handleRedirectSpy).toHaveBeenCalledWith(
+          CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
+          namespace,
+          expect.objectContaining({ isCoinbaseDisabled: expect.any(Boolean) })
+        )
+        expect(onConnectMobileSpy).not.toHaveBeenCalled()
+      }
+    )
 
     it.each([['solana' as const], ['eip155' as const], ['bip122' as const]])(
       'uses handleMobileDeeplinkRedirect for Phantom on %s even when mobile_link is set',

--- a/packages/controllers/tests/hooks/react.test.ts
+++ b/packages/controllers/tests/hooks/react.test.ts
@@ -27,6 +27,8 @@ import { ConnectUtil } from '../../src/utils/ConnectUtil.js'
 import type { WalletItem } from '../../src/utils/ConnectUtil.js'
 import { ConnectionControllerUtil } from '../../src/utils/ConnectionControllerUtil.js'
 import { ConnectorControllerUtil } from '../../src/utils/ConnectorControllerUtil.js'
+import { CoreHelperUtil } from '../../src/utils/CoreHelperUtil.js'
+import { CUSTOM_DEEPLINK_WALLETS, MobileWalletUtil } from '../../src/utils/MobileWallet.js'
 
 vi.mock('valtio', () => ({
   useSnapshot: vi.fn()
@@ -1694,5 +1696,165 @@ describe('useAppKitWallets', () => {
 
     expect(resetUriSpy).toHaveBeenCalled()
     expect(setWcLinkingSpy).toHaveBeenCalledWith(undefined)
+  })
+
+  describe('connect() mobile deeplink routing', () => {
+    function mockHeadlessSnapshots() {
+      useSnapshot
+        .mockReturnValueOnce({
+          features: { headless: true },
+          remoteFeatures: { headless: true }
+        })
+        .mockReturnValueOnce({
+          wcUri: undefined,
+          wcFetchingUri: false
+        })
+        .mockReturnValueOnce({
+          wallets: [],
+          search: [],
+          page: 1,
+          count: 0
+        })
+        .mockReturnValueOnce({
+          initialized: true,
+          connectingWallet: undefined
+        })
+        .mockReturnValueOnce({
+          clientId: null
+        })
+
+      vi.spyOn(ConnectUtil, 'getInitialWallets').mockReturnValue([])
+      vi.spyOn(ConnectUtil, 'getWalletConnectWallets').mockReturnValue([])
+    }
+
+    function makeMobileWallet(overrides: Partial<WalletItem>): WalletItem {
+      return {
+        id: 'wallet-id',
+        name: 'Wallet',
+        imageUrl: '',
+        connectors: [],
+        isInjected: false,
+        isRecent: false,
+        walletInfo: {},
+        ...overrides
+      }
+    }
+
+    it('uses handleMobileDeeplinkRedirect for Solflare on Solana even when mobile_link is set', async () => {
+      mockHeadlessSnapshots()
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+      vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('solana')
+
+      const handleRedirectSpy = vi
+        .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
+        .mockImplementation(() => undefined)
+      const onConnectMobileSpy = vi
+        .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+        .mockImplementation(() => undefined)
+
+      const solflare = makeMobileWallet({
+        id: CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
+        name: 'Solflare',
+        walletInfo: { deepLink: 'solflare://' }
+      })
+
+      const result = useAppKitWallets()
+      await result.connect(solflare, 'solana')
+
+      expect(handleRedirectSpy).toHaveBeenCalledWith(
+        CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
+        'solana',
+        expect.objectContaining({ isCoinbaseDisabled: expect.any(Boolean) })
+      )
+      expect(onConnectMobileSpy).not.toHaveBeenCalled()
+    })
+
+    it.each([['solana' as const], ['eip155' as const], ['bip122' as const]])(
+      'uses handleMobileDeeplinkRedirect for Phantom on %s even when mobile_link is set',
+      async namespace => {
+        mockHeadlessSnapshots()
+        vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+        vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue(namespace)
+
+        const handleRedirectSpy = vi
+          .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
+          .mockImplementation(() => undefined)
+        const onConnectMobileSpy = vi
+          .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+          .mockImplementation(() => undefined)
+
+        const phantom = makeMobileWallet({
+          id: CUSTOM_DEEPLINK_WALLETS.PHANTOM.id,
+          name: 'Phantom',
+          walletInfo: { deepLink: 'https://phantom.app/ul/v1/' }
+        })
+
+        const result = useAppKitWallets()
+        await result.connect(phantom, namespace)
+
+        expect(handleRedirectSpy).toHaveBeenCalledWith(
+          CUSTOM_DEEPLINK_WALLETS.PHANTOM.id,
+          namespace,
+          expect.objectContaining({ isCoinbaseDisabled: expect.any(Boolean) })
+        )
+        expect(onConnectMobileSpy).not.toHaveBeenCalled()
+      }
+    )
+
+    it('uses onConnectMobile for a regular WC wallet that has mobile_link', async () => {
+      mockHeadlessSnapshots()
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+      vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('eip155')
+
+      const handleRedirectSpy = vi
+        .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
+        .mockImplementation(() => undefined)
+      const onConnectMobileSpy = vi
+        .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+        .mockImplementation(() => undefined)
+
+      const trust = makeMobileWallet({
+        id: 'trust-wallet-id',
+        name: 'Trust',
+        walletInfo: { deepLink: 'trust://' }
+      })
+
+      const result = useAppKitWallets()
+      await result.connect(trust, 'eip155')
+
+      expect(onConnectMobileSpy).toHaveBeenCalledTimes(1)
+      const [walletArg] = onConnectMobileSpy.mock.calls[0] ?? []
+      expect(walletArg).toMatchObject({ id: 'trust-wallet-id', mobile_link: 'trust://' })
+      expect(handleRedirectSpy).not.toHaveBeenCalled()
+    })
+
+    it('falls back to handleMobileDeeplinkRedirect when wallet has no mobile_link', async () => {
+      mockHeadlessSnapshots()
+      vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+      vi.spyOn(ChainController.state, 'activeChain', 'get').mockReturnValue('eip155')
+
+      const handleRedirectSpy = vi
+        .spyOn(MobileWalletUtil, 'handleMobileDeeplinkRedirect')
+        .mockImplementation(() => undefined)
+      const onConnectMobileSpy = vi
+        .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+        .mockImplementation(() => undefined)
+
+      const unknown = makeMobileWallet({
+        id: 'unknown-wallet-id',
+        name: 'Unknown',
+        walletInfo: {}
+      })
+
+      const result = useAppKitWallets()
+      await result.connect(unknown, 'eip155')
+
+      expect(handleRedirectSpy).toHaveBeenCalledWith(
+        'unknown-wallet-id',
+        'eip155',
+        expect.objectContaining({ isCoinbaseDisabled: expect.any(Boolean) })
+      )
+      expect(onConnectMobileSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/controllers/tests/utils/MobileWallet.test.ts
+++ b/packages/controllers/tests/utils/MobileWallet.test.ts
@@ -193,11 +193,23 @@ describe('MobileWalletUtil', () => {
     expect(window.location.href).toBe(expectedUrl)
   })
 
-  it('should not redirect to Solflare on non-Solana namespaces', () => {
-    const originalHref = window.location.href
+  it('should redirect to Solflare correctly on EVM (in-app browser supports EVM dApps)', () => {
     MobileWalletUtil.handleMobileDeeplinkRedirect(
       CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
       ConstantsUtil.CHAIN.EVM
+    )
+
+    const encodedHref = encodeURIComponent(ORIGINAL_HREF)
+    const expectedUrl = `${CUSTOM_DEEPLINK_WALLETS.SOLFLARE.url}/ul/v1/browse/${encodedHref}?ref=${encodedHref}`
+
+    expect(window.location.href).toBe(expectedUrl)
+  })
+
+  it('should not redirect to Solflare on unsupported namespaces (bitcoin)', () => {
+    const originalHref = window.location.href
+    MobileWalletUtil.handleMobileDeeplinkRedirect(
+      CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id,
+      ConstantsUtil.CHAIN.BITCOIN
     )
 
     expect(window.location.href).toBe(originalHref)
@@ -246,9 +258,15 @@ describe('MobileWalletUtil', () => {
       ).toBe(true)
     })
 
-    it('should return false for Solflare wallet on EVM', () => {
+    it('should return true for Solflare wallet on EVM', () => {
       expect(
         MobileWalletUtil.isCustomDeeplinkWallet(CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id, 'eip155')
+      ).toBe(true)
+    })
+
+    it('should return false for Solflare wallet on Bitcoin', () => {
+      expect(
+        MobileWalletUtil.isCustomDeeplinkWallet(CUSTOM_DEEPLINK_WALLETS.SOLFLARE.id, 'bip122')
       ).toBe(false)
     })
 


### PR DESCRIPTION
## Summary

In headless mode (`useAppKitWallets().connect`), tapping Solflare on mobile produced `solflare://wc?uri=…`, which Solflare's app does not handle — nothing opened. Phantom worked only by accident because its `mobile_link` happens to be a valid Universal Link base.

Two fixes:
1. **`0daaed468`** — headless `connect()` now mirrors the headful `selectWalletConnector` behavior: for any wallet flagged by `MobileWalletUtil.isCustomDeeplinkWallet`, fire the Universal Link via `handleMobileDeeplinkRedirect` instead of building `<mobile_link>wc?uri=…`.
2. **`4c9ec0a2e`** — `isCustomDeeplinkWallet` and the matching branch in `handleMobileDeeplinkRedirect` were Solana-only for Solflare. They now also cover `eip155`. Solflare's in-app browser exposes both `window.solflare` (Solana) and `window.ethereum` (EVM), so the same `https://solflare.com/ul/v1/browse/<dapp_url>` URL is the right entry point either way.

## How the bug happens (before fix)

```mermaid
flowchart TD
  A[user taps Solflare on mobile] --> B{isInjected && connector?}
  B -- yes --> X1[connectExternal]
  B -- no --> C{fallback connector?}
  C -- yes --> X2[connectExternal fallback]
  C -- no --> D{isMobile?}
  D -- yes --> E{wcWallet.mobile_link set?}
  E -- yes --> F["onConnectMobile<br/>builds solflare://wc?uri=..."]
  E -- no --> G[handleMobileDeeplinkRedirect<br/>Universal Link]
  F --> H["⛔ Solflare ignores<br/>solflare://wc?uri=..."]
  G --> I[✅ Solflare opens]

  style F fill:#ffd5d5,stroke:#c00
  style H fill:#ffd5d5,stroke:#c00
```

Solflare's WC-registry `mobile_link` is `solflare://`, so the headless flow always took the left branch and produced `solflare://wc?uri=…`. Solflare's app does not register a handler for that URL, so the redirect was a no-op.

Phantom's `mobile_link` is `https://phantom.app/ul/v1/`, so `<mobile_link>wc?uri=…` was *coincidentally* a valid Phantom Universal Link. That's why Phantom worked while Solflare didn't.

## Headful vs. headless before any fix

```mermaid
sequenceDiagram
  autonumber
  participant U as User
  participant V as View / hook
  participant M as MobileWalletUtil
  participant C as ConnectionControllerUtil

  rect rgb(220,245,220)
  Note over U,C: Headful (worked)
  U->>V: tap Solflare
  V->>M: handleMobileDeeplinkRedirect(id, ns)
  M-->>U: window.location = https://solflare.com/ul/v1/browse/...
  Note over V: then RouterController.push(...)
  end

  rect rgb(255,220,220)
  Note over U,C: Headless (broken)
  U->>V: tap Solflare
  V->>C: onConnectMobile(wcWallet)
  C-->>U: window.location = solflare://wc?uri=...
  Note over U: ⛔ Solflare app ignores it
  end
```

The headful path *always* called `handleMobileDeeplinkRedirect` first (Universal Link). The headless path skipped that whenever `mobile_link` was set.

## Fix #1 — mirror the headful behavior in headless `connect()`

```mermaid
flowchart TD
  A[user taps Solflare on mobile] --> B{isInjected && connector?}
  B -- yes --> X1[connectExternal]
  B -- no --> C{fallback connector?}
  C -- yes --> X2[connectExternal fallback]
  C -- no --> D{isMobile?}
  D -- yes --> NEW{{"isCustomDeeplinkWallet(id, ns)?<br/>NEW CHECK"}}
  NEW -- yes --> G[handleMobileDeeplinkRedirect<br/>Universal Link]
  NEW -- no --> E{wcWallet.mobile_link?}
  E -- yes --> F[onConnectMobile<br/>WC URI deeplink]
  E -- no --> G

  style NEW fill:#d5e6ff,stroke:#06c
  style G fill:#d5f5d5,stroke:#0a0
```

Custom-deeplink wallets (Phantom, Solflare, Coinbase, Binance) now skip the WC URI deeplink entirely and go straight to the Universal Link, matching headful.

## Fix #2 — Solflare on EVM also needs the Universal Link

Before Fix #2, the allow-list inside `MobileWalletUtil.isCustomDeeplinkWallet` was:

| Wallet | Allowed namespaces (before) |
|--------|-----------------------------|
| Phantom | `solana` `eip155` `bip122` |
| Solflare | `solana` |
| Coinbase | `solana` `eip155` |
| Binance | `bip122` |

When BX has both the wagmi adapter and the Solana adapter, and the user taps Solflare while the active chain is `eip155`:

```mermaid
flowchart TD
  A[Solflare clicked<br/>activeChain = eip155] --> B{"isCustomDeeplinkWallet(SOLFLARE_ID, 'eip155')?"}
  B -- "false (before Fix #2)" --> C["onConnectMobile<br/>solflare://wc?uri=..."]
  C --> D[⛔ silently fails]

  B -- "true (after Fix #2)" --> E["handleMobileDeeplinkRedirect('eip155')"]
  E --> F[Universal Link<br/>https://solflare.com/ul/v1/browse/...]
  F --> G[✅ Solflare opens dApp<br/>in in-app browser]

  style C fill:#ffd5d5,stroke:#c00
  style D fill:#ffd5d5,stroke:#c00
  style E fill:#d5e6ff,stroke:#06c
  style F fill:#d5f5d5,stroke:#0a0
  style G fill:#d5f5d5,stroke:#0a0
```

The same Solana-only gate existed inside `handleMobileDeeplinkRedirect` itself, so it was double-locked. Both checks now allow `solana | eip155`.

## Final allow-list

| Wallet | Allowed namespaces (after) |
|--------|----------------------------|
| Phantom | `solana` `eip155` `bip122` |
| Solflare | `solana` **`eip155`** ← changed |
| Coinbase | `solana` `eip155` |
| Binance | `bip122` |

## End-to-end fixed flow

```mermaid
sequenceDiagram
  autonumber
  participant U as User (mobile)
  participant H as useAppKitWallets connect()
  participant M as MobileWalletUtil
  participant S as Solflare app

  U->>H: tap Solflare (activeChain = eip155 OR solana)
  H->>M: isCustomDeeplinkWallet(SOLFLARE_ID, ns) → true
  H->>M: handleMobileDeeplinkRedirect(SOLFLARE_ID, ns)
  M-->>U: window.location = https://solflare.com/ul/v1/browse/<dapp_url>?ref=<dapp_url>
  U->>S: iOS / Android opens Solflare via Universal Link
  S->>S: load dApp in in-app browser
  Note over S: window.solflare (Solana)<br/>+ window.ethereum (EVM) injected
  S-->>U: dApp connects via wagmi or wallet-standard
```

## Test plan

- [x] `pnpm --filter @reown/appkit-controllers test` — full suite passing, including new cases for Solflare/Phantom on mobile across `solana`, `eip155`, and `bip122` namespaces in `tests/hooks/react.test.ts` and `tests/utils/MobileWallet.test.ts`.
- [x] `pnpm --filter @reown/appkit-controllers typecheck` — clean.
- [x] Real-device check with canary `1.8.21-solflare-headless-deeplink-evm.0` in WalletConnect Pay buyer-experience — Solflare now opens on EVM-active and Solana-active flows; Phantom still opens; regular WC wallets still use the WC URI deeplink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
