### PR TITLE
fix(ui): add --apkt-font-family-mono so custom fonts don't break mono text

### DIFF
--- a/.changeset/mono-font-family-variable.md
+++ b/.changeset/mono-font-family-variable.md
@@ -1,0 +1,7 @@
+---
+'@reown/appkit-ui': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+---
+
+Fix monospace text (WalletConnect "Copy link", wallet addresses, amount inputs) rendering in the browser default font when a custom `--apkt-font-family` is set. Added a `--apkt-font-family-mono` theme variable that falls back to `--apkt-font-family` when not provided, so a single custom font now styles monospace text too.

--- a/packages/common/src/utils/ThemeUtil.ts
+++ b/packages/common/src/utils/ThemeUtil.ts
@@ -3,6 +3,7 @@ export type ThemeType = 'dark' | 'light'
 
 export interface ThemeVariables {
   '--w3m-font-family'?: string
+  '--w3m-font-family-mono'?: string
   '--w3m-accent'?: string
   '--w3m-color-mix'?: string
   '--w3m-color-mix-strength'?: number
@@ -11,6 +12,7 @@ export interface ThemeVariables {
   '--w3m-z-index'?: number
   '--w3m-qr-color'?: string
   '--apkt-font-family'?: string
+  '--apkt-font-family-mono'?: string
   '--apkt-accent'?: string
   '--apkt-color-mix'?: string
   '--apkt-color-mix-strength'?: number

--- a/packages/controllers/src/utils/TypeUtil.ts
+++ b/packages/controllers/src/utils/TypeUtil.ts
@@ -211,6 +211,7 @@ export type ThemeMode = 'dark' | 'light'
 
 export interface ThemeVariables {
   '--w3m-font-family'?: string
+  '--w3m-font-family-mono'?: string
   '--w3m-accent'?: string
   '--w3m-color-mix'?: string
   '--w3m-color-mix-strength'?: number
@@ -219,6 +220,7 @@ export interface ThemeVariables {
   '--w3m-z-index'?: number
   '--w3m-qr-color'?: string
   '--apkt-font-family'?: string
+  '--apkt-font-family-mono'?: string
   '--apkt-accent'?: string
   '--apkt-color-mix'?: string
   '--apkt-color-mix-strength'?: number

--- a/packages/ui/src/utils/ThemeHelperUtil.ts
+++ b/packages/ui/src/utils/ThemeHelperUtil.ts
@@ -17,6 +17,14 @@ function normalizeThemeVariables(themeVariables?: ThemeVariables): Record<string
   normalized['font-family'] =
     themeVariables['--apkt-font-family'] ?? themeVariables['--w3m-font-family'] ?? 'KHTeka'
 
+  // Fall back to the base font (so one --apkt-font-family styles mono too), then the mono default.
+  normalized['font-family-mono'] =
+    themeVariables['--apkt-font-family-mono'] ??
+    themeVariables['--w3m-font-family-mono'] ??
+    themeVariables['--apkt-font-family'] ??
+    themeVariables['--w3m-font-family'] ??
+    'KHTekaMono'
+
   normalized['accent'] =
     themeVariables['--apkt-accent'] ?? themeVariables['--w3m-accent'] ?? '#0988F0'
 
@@ -183,6 +191,7 @@ export const ThemeHelperUtil = {
 
     // Set default values and user overrides (keep --w3m-* names for backwards compatibility)
     variables['--w3m-font-family'] = normalized['font-family'] as string
+    variables['--w3m-font-family-mono'] = normalized['font-family-mono'] as string
     variables['--w3m-accent'] = normalized['accent'] as string
     variables['--w3m-color-mix'] = normalized['color-mix'] as string
     variables['--w3m-color-mix-strength'] = `${normalized['color-mix-strength']}%`
@@ -214,6 +223,15 @@ export const ThemeHelperUtil = {
 
     if (themeVariables['--apkt-font-family'] || themeVariables['--w3m-font-family']) {
       overrides['--apkt-fontFamily-regular'] = normalized['font-family'] as string
+    }
+
+    if (
+      themeVariables['--apkt-font-family-mono'] ||
+      themeVariables['--w3m-font-family-mono'] ||
+      themeVariables['--apkt-font-family'] ||
+      themeVariables['--w3m-font-family']
+    ) {
+      overrides['--apkt-fontFamily-mono'] = normalized['font-family-mono'] as string
     }
 
     if (normalized['z-index'] !== undefined) {

--- a/packages/ui/src/utils/TypeUtil.ts
+++ b/packages/ui/src/utils/TypeUtil.ts
@@ -376,6 +376,7 @@ export type InputType =
 
 export interface ThemeVariables {
   '--w3m-font-family'?: string
+  '--w3m-font-family-mono'?: string
   '--w3m-accent'?: string
   '--w3m-color-mix'?: string
   '--w3m-color-mix-strength'?: number
@@ -384,6 +385,7 @@ export interface ThemeVariables {
   '--w3m-z-index'?: number
   '--w3m-qr-color'?: string
   '--apkt-font-family'?: string
+  '--apkt-font-family-mono'?: string
   '--apkt-accent'?: string
   '--apkt-color-mix'?: string
   '--apkt-color-mix-strength'?: number

--- a/packages/ui/tests/ThemeUtil.test.ts
+++ b/packages/ui/tests/ThemeUtil.test.ts
@@ -52,6 +52,31 @@ describe('ThemeUtil', () => {
       expect(rootStyles).toContain('--apkt-fontFamily-regular:New Font')
     })
 
+    it('should drive the monospace font from --apkt-font-family when no mono font is set', () => {
+      const themeVariables: ThemeVariables = {
+        '--apkt-font-family': 'New Font'
+      }
+      const rootStyles = ThemeHelperUtil.createRootStyles('dark', themeVariables)
+
+      expect(rootStyles).toContain('--apkt-fontFamily-mono:New Font')
+    })
+
+    it('should prioritize --apkt-font-family-mono over --apkt-font-family for monospace text', () => {
+      const themeVariables: ThemeVariables = {
+        '--apkt-font-family': 'New Font',
+        '--apkt-font-family-mono': 'New Mono'
+      }
+      const rootStyles = ThemeHelperUtil.createRootStyles('dark', themeVariables)
+
+      expect(rootStyles).toContain('--apkt-fontFamily-mono:New Mono')
+    })
+
+    it('should default the monospace font to KHTekaMono when no font is provided', () => {
+      const rootStyles = ThemeHelperUtil.createRootStyles('dark', { '--w3m-accent': '#ff0000' })
+
+      expect(rootStyles).toContain('--w3m-font-family-mono:KHTekaMono')
+    })
+
     it('should always include keyframe animations regardless of font family setting', () => {
       const withCustomFont: ThemeVariables = { '--w3m-font-family': 'Custom Font' }
       const withoutCustomFont: ThemeVariables = {}


### PR DESCRIPTION
# Description

Setting a custom base font via `--apkt-font-family` (or the legacy `--w3m-font-family`) previously broke every monospace piece of UI text (the WalletConnect "Copy link" button, wallet addresses, and amount inputs): they fell back to the browser default font instead of following the custom font.

Root cause: the regular font is themeable through the `--apkt-fontFamily-regular` CSS variable, which `ThemeHelperUtil.generateW3MOverrides` overrides with the custom font. The mono font (`--apkt-fontFamily-mono`, default `KHTekaMono`) had no equivalent override, so it kept resolving to `KHTekaMono`, whose `@font-face` is dropped once a custom font is set (see #4542). The result was an unloaded family with no fallback.

This adds a `--apkt-font-family-mono` theme variable that mirrors the regular one and falls back to `--apkt-font-family` when not provided. So a single `--apkt-font-family` now also styles monospace text (nothing breaks), while an explicit `--apkt-font-family-mono` is still respected. Default behavior (no custom font) is unchanged.

Changes (all in `packages/ui`):

- `utils/ThemeHelperUtil.ts`: resolve `font-family-mono` in `normalizeThemeVariables` (falls back to the base font), override `--apkt-fontFamily-mono` in `generateW3MOverrides`, and publish `--w3m-font-family-mono` in `generateW3MVariables` for parity.
- `utils/TypeUtil.ts`: add `--apkt-font-family-mono` and `--w3m-font-family-mono` to `ThemeVariables`.
- `tests/ThemeHelperUtils.test.ts`: cover the new override (base font only, explicit mono, mono only, no font).

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5681

# Showcase (Optional)

Reproduction (set a custom `--apkt-font-family`, then open the WalletConnect QR view and note "Copy link" does not follow it): https://stackblitz.com/edit/github-e1adycfs?file=src%2FApp.tsx

Toggling the `--apkt-font-family` line in that StackBlitz shows the before/after. With this branch, the mono text follows the custom font.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
