### PR TITLE
feat: enable SIWX sign-in for the TRON adapter

### DIFF
--- a/.changeset/tron-siwx-sign-message.md
+++ b/.changeset/tron-siwx-sign-message.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-adapter-tron': patch
+---
+
+Implement message signing in the TRON adapter. `TronAdapter.signMessage` previously returned an empty signature, which broke SIWX / Reown Authentication (the empty signature was rejected by the server). It now delegates to the active connector's `signMessage`, producing a real signature.

--- a/apps/laboratory/src/components/DemoContent.tsx
+++ b/apps/laboratory/src/components/DemoContent.tsx
@@ -88,6 +88,14 @@ export default function DemoContent({
           showActions={false}
         />
       ) : null}
+      {tronAdapter ? (
+        <AppKitWalletButtons
+          title="TRON Wallet Buttons"
+          namespace={isMultiChain ? 'tron' : undefined}
+          wallets={ConstantsUtil.TronWalletButtons}
+          showActions={false}
+        />
+      ) : null}
     </>
   )
 }

--- a/apps/laboratory/src/constants/appKitConfigs.ts
+++ b/apps/laboratory/src/constants/appKitConfigs.ts
@@ -391,7 +391,7 @@ export const appKitConfigs = {
   },
   'reown-authentication': {
     ...commonAppKitConfig,
-    adapters: ['ethers', 'solana', 'bitcoin'],
+    adapters: ['ethers', 'solana', 'bitcoin', 'tron'],
     networks: ConstantsUtil.AllNetworks,
     siwx: new ReownAuthentication(),
     siwxReown: true

--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -212,6 +212,7 @@ export const ConstantsUtil = {
     'frontier'
   ] as Wallet[],
   BitcoinWalletButtons: ['walletConnect', 'xverse', 'leather', 'okx', 'phantom'] as Wallet[],
+  TronWalletButtons: ['walletConnect'] as Wallet[],
   Socials: [
     'google',
     'github',

--- a/packages/adapters/tron/src/adapter.ts
+++ b/packages/adapters/tron/src/adapter.ts
@@ -143,8 +143,21 @@ export class TronAdapter extends AdapterBlueprint<TronConnector> {
     })
   }
 
-  override async signMessage(): Promise<AdapterBlueprint.SignMessageResult> {
-    return Promise.resolve({ signature: '' })
+  override async signMessage(
+    params: AdapterBlueprint.SignMessageParams
+  ): Promise<AdapterBlueprint.SignMessageResult> {
+    const connector = (params.provider as TronConnector | undefined) ?? this.getActiveConnector()
+
+    if (!connector) {
+      throw new Error('TronAdapter:signMessage - connector is undefined')
+    }
+
+    const signature = await connector.signMessage({
+      message: params.message,
+      from: params.address
+    })
+
+    return { signature }
   }
 
   override async sendTransaction(): Promise<AdapterBlueprint.SendTransactionResult> {


### PR DESCRIPTION
# Description

Enable SIWX / Reown Authentication sign-in for the TRON adapter: `TronAdapter.signMessage` now delegates to the active connector's `signMessage` (TronLink `signMessageV2` / WalletConnect `tron_signMessage`) instead of returning an empty signature, which the auth server rejected. The laboratory `reown-authentication` config gains the `tron` adapter plus a TRON wallet-buttons section so the flow is testable end to end.

This PR must be merged first: https://github.com/reown-com/web-monorepo/pull/2864 

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

N/A

# Showcase (Optional)

N/A

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
