### PR TITLE
fix(common): parse numeric string EVM chain IDs

### DIFF
--- a/.changeset/few-plums-sip.md
+++ b/.changeset/few-plums-sip.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-common': patch
+---
+
+Support numeric string inputs in `NetworkUtil.parseEvmChainId`.

--- a/packages/common/src/utils/NetworkUtil.ts
+++ b/packages/common/src/utils/NetworkUtil.ts
@@ -7,9 +7,13 @@ export const NetworkUtil = {
   },
 
   parseEvmChainId(chainId: string | number) {
-    return typeof chainId === 'string'
+    if (typeof chainId === 'number') {
+      return chainId
+    }
+
+    return chainId.includes(':')
       ? this.caipNetworkIdToNumber(chainId as CaipNetworkId)
-      : chainId
+      : Number(chainId)
   },
 
   getNetworksByNamespace(networks: CaipNetwork[] | undefined, namespace: ChainNamespace) {

--- a/packages/common/tests/NetworkUtil.test.ts
+++ b/packages/common/tests/NetworkUtil.test.ts
@@ -76,6 +76,11 @@ describe('NetworkUtil', () => {
       expect(NetworkUtil.parseEvmChainId('eip155:42')).toBe(42)
     })
 
+    test('parses numeric string chain ID', () => {
+      expect(NetworkUtil.parseEvmChainId('1')).toBe(1)
+      expect(NetworkUtil.parseEvmChainId('42')).toBe(42)
+    })
+
     test('returns number input as-is', () => {
       expect(NetworkUtil.parseEvmChainId(1)).toBe(1)
       expect(NetworkUtil.parseEvmChainId(42)).toBe(42)


### PR DESCRIPTION
# Description

This PR updates `NetworkUtil.parseEvmChainId` to support numeric string chain IDs such as `"1"` and `"42"`.

Previously, numeric strings were treated like CAIP network IDs and returned `NaN`. The helper now preserves existing CAIP parsing for values like `eip155:1`, returns numeric inputs as-is, and parses non-CAIP string chain IDs with `Number(...)`.


## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

N/A

# Showcase (Optional)

N/A - utility-only change.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
