### PR TITLE
fix(tron): respect wallet tron_method_version for tron_signTransaction payload

### DIFF
--- a/.changeset/tron-signtransaction-method-version.md
+++ b/.changeset/tron-signtransaction-method-version.md
@@ -1,0 +1,30 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Fixed TRON `tron_signTransaction` payload shape to respect the wallet's `tron_method_version` session property. The connector now sends the spec-mandated legacy nested `transaction.transaction` shape by default, and the simplified flat shape only when the wallet advertises `tron_method_version: "v1"` in `sessionProperties`.

--- a/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
+++ b/packages/adapters/tron/src/connectors/TronWalletConnectConnector.ts
@@ -110,12 +110,17 @@ export class TronWalletConnectConnector
       throw new Error(unsignedTx?.Error || 'Failed to create transaction')
     }
 
-    // Step 2: Send full transaction to wallet for signing via WalletConnect
+    // Step 2: Send full transaction to wallet for signing via WalletConnect.
+    // Wallets opt into the simplified (v1) payload shape by advertising
+    // `tron_method_version: "v1"` in sessionProperties during the handshake.
+    // Otherwise the spec mandates the legacy nested `transaction.transaction` shape.
+    // See https://docs.reown.com/advanced/multichain/rpc-reference/tron-rpc
+    const usesV1Format = this.provider.session?.sessionProperties?.['tron_method_version'] === 'v1'
     const signRequest = {
       method: 'tron_signTransaction',
       params: {
         address: params.from,
-        transaction: unsignedTx
+        transaction: usesV1Format ? unsignedTx : { transaction: unsignedTx }
       }
     }
     const signedTx:

--- a/packages/adapters/tron/src/tests/TronWalletConnectConnector.test.ts
+++ b/packages/adapters/tron/src/tests/TronWalletConnectConnector.test.ts
@@ -146,13 +146,14 @@ describe('TronWalletConnectConnector', () => {
       expect(createBody.method).toBe('tron_createTransaction')
       expect(createBody.params).toEqual([MOCK_OWNER_ADDRESS, MOCK_TO_ADDRESS, 1000000, true])
 
-      // Verify WC sign call with full transaction object
+      // Verify WC sign call uses the legacy nested shape by default (wallet did not
+      // advertise tron_method_version: "v1" in sessionProperties)
       expect(mockProviderRequest).toHaveBeenCalledWith(
         {
           method: 'tron_signTransaction',
           params: {
             address: MOCK_OWNER_ADDRESS,
-            transaction: MOCK_UNSIGNED_TX
+            transaction: { transaction: MOCK_UNSIGNED_TX }
           }
         },
         MOCK_CHAIN_ID
@@ -165,6 +166,46 @@ describe('TronWalletConnectConnector', () => {
       expect(broadcastBody.method).toBe('tron_broadcastTransaction')
       expect(broadcastBody.params[0]).toBe(MOCK_SIGNED_TX.txID)
       expect(broadcastBody.params[4]).toEqual(MOCK_SIGNED_TX.signature)
+    })
+
+    it('should send the flat (v1) transaction shape when wallet advertises tron_method_version v1', async () => {
+      const v1Provider = {
+        ...mockProvider,
+        session: {
+          ...mockProvider.session,
+          sessionProperties: { tron_method_version: 'v1' }
+        }
+      }
+      const v1Connector = new TronWalletConnectConnector({
+        provider: v1Provider as any,
+        chains: [MOCK_CAIP_NETWORK as any]
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ result: MOCK_UNSIGNED_TX })
+      })
+      mockProviderRequest.mockResolvedValueOnce(MOCK_SIGNED_TX)
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ result: { result: true } })
+      })
+
+      await v1Connector.sendTransaction({
+        from: MOCK_OWNER_ADDRESS,
+        to: MOCK_TO_ADDRESS,
+        value: '1000000'
+      })
+
+      // v1 wallets receive the flat transaction object (no nested wrapper)
+      expect(mockProviderRequest).toHaveBeenCalledWith(
+        {
+          method: 'tron_signTransaction',
+          params: {
+            address: MOCK_OWNER_ADDRESS,
+            transaction: MOCK_UNSIGNED_TX
+          }
+        },
+        MOCK_CHAIN_ID
+      )
     })
 
     it('should throw when createTransaction fails', async () => {


### PR DESCRIPTION
## What

`TronWalletConnectConnector.sendTransaction` now selects the `tron_signTransaction` payload shape based on the wallet's `tron_method_version` session property.

## Why

Per the [Tron RPC reference](https://docs.reown.com/advanced/multichain/rpc-reference/tron-rpc), `tron_signTransaction` has two payload shapes gated by the `tron_method_version` a **wallet** advertises in `sessionProperties` at handshake:

- **Legacy (default, when not `"v1"`):** nested — `params.transaction.transaction`
- **v1 (`tron_method_version: "v1"`):** flat — `params.transaction`

The connector previously **always** sent the flat (v1) shape, regardless of negotiation. A spec-compliant wallet that did not advertise v1 (the default) expects the nested shape and cannot parse what AppKit sent → "Failed to create transaction" / signing failures. Reported by DFNS.

## How

```ts
const usesV1Format =
  this.provider.session?.sessionProperties?.['tron_method_version'] === 'v1'
// ...
transaction: usesV1Format ? unsignedTx : { transaction: unsignedTx }
```

Defaults to the spec-mandated legacy nested shape; sends the flat shape only when the wallet opts into v1.

> Scope: only the WalletConnect connector. The injected connector (`TronConnectConnector.ts`) does not use WC sessions, so `sessionProperties` (a WalletConnect-protocol concept) does not apply.

## ⚠️ Behavior change

This flips the default payload shape from flat → nested. This is the spec-correct behavior, but any wallet that currently accepts the flat shape **without** advertising `tron_method_version: "v1"` will need to advertise it.

## Tests

- Updated the existing test to assert the legacy nested default.
- Added a test asserting the flat shape when `sessionProperties.tron_method_version === 'v1'`.
- `pnpm --filter @reown/appkit-adapter-tron test` — 6/6 pass. tsc + prettier clean.

Closes #5693. Related: REOWN-4662, companion blockchain-api fix reown-com/blockchain-api#1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
