### PR TITLE
feat(appkit): expose headless resetWalletConnectUri + resetConnectingWallet

### DIFF
--- a/.changeset/headless-reset-wcuri.md
+++ b/.changeset/headless-reset-wcuri.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Add headless reset methods for the WalletConnect URI + connecting-wallet state.
+
+The AppKit instance now exposes `resetWalletConnectUri()` and `resetConnectingWallet()` — thin passthroughs to `HeadlessWalletUtil.resetWcUri()` / `resetConnectingWallet()`. A headless host that reads the URI via `getWalletConnectUri()` can now clear it (e.g. when a QR is dismissed or a connection is cancelled) through the instance, without importing `@reown/appkit-controllers`. This completes the headless WalletConnect-URI surface alongside `getWalletConnectUri` / `subscribeWalletConnectUri` / `prefetchWalletConnectUri`.

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -2372,6 +2372,20 @@ export abstract class AppKitBaseClient {
   }
 
   /**
+   * Clear the WalletConnect URI + linking state (e.g. when a headless host dismisses or
+   * cancels the QR). Resets the connection layer directly, so a host can clear the URI it
+   * read via {@link getWalletConnectUri} without touching controllers.
+   */
+  public resetWalletConnectUri() {
+    HeadlessWalletUtil.resetWcUri()
+  }
+
+  /** Clear the `connectingWallet` state (e.g. when a headless host cancels a connection). */
+  public resetConnectingWallet() {
+    HeadlessWalletUtil.resetConnectingWallet()
+  }
+
+  /**
    * Connect a chosen wallet programmatically (headless — no modal). Handles injected,
    * API ("all wallets"), and mobile-deeplink wallets.
    */


### PR DESCRIPTION
Follow-up to #5697.

## What

#5697 exposed the headless **read** side of the WalletConnect URI on the AppKit instance (`getWalletConnectUri()` / `subscribeWalletConnectUri()` / `prefetchWalletConnectUri()`) but not the resets. This adds the missing two, as thin client passthroughs to the existing `HeadlessWalletUtil` impls:

```ts
public resetWalletConnectUri() { HeadlessWalletUtil.resetWcUri() }
public resetConnectingWallet() { HeadlessWalletUtil.resetConnectingWallet() }
```

## Why

A headless host that reads the URI via `getWalletConnectUri()` needs an **ungated** way to clear it — e.g. when the QR is dismissed or a connection is cancelled. Since #5697 moved `wcUri` off public state (it now lives in `ConnectionController`), the old host-side workaround (mutating `getState().wcUri`) is dead. Without `resetWalletConnectUri()` a dismissed QR keeps a stale URI. `resetConnectingWallet()` is added for symmetry (clears `connectingWallet`).

This completes the headless WalletConnect-URI surface so a headless host (the WC Pay `@walletconnect/pay-appkit` adapter) can read, subscribe, prefetch **and** reset entirely through the instance — no `@reown/appkit-controllers` import, no duplicate-valtio-singleton footgun.

## Notes

- Delegations only — the impls (`resetWcUri` / `resetConnectingWallet`) and their unit tests already exist in `HeadlessWalletUtil` (`packages/controllers`).
- `pnpm --filter @reown/appkit typecheck` clean; `HeadlessWalletUtil` tests pass (17).
- Changeset: patch across the appkit packages (matches #5697).