### PR TITLE
fix(tron): use fullnode for testnet balances

### DIFF
--- a/.changeset/tron-testnet-fullnode-balance.md
+++ b/.changeset/tron-testnet-fullnode-balance.md
@@ -1,0 +1,30 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Fixed TRON testnet balance fetching by using the configured TRON fullnode endpoint for testnet accounts instead of routing balance reads through the WalletConnect RPC proxy.

--- a/packages/adapters/tron/src/adapter.ts
+++ b/packages/adapters/tron/src/adapter.ts
@@ -308,6 +308,18 @@ export class TronAdapter extends AdapterBlueprint<TronConnector> {
     }
 
     try {
+      if (params.caipNetwork?.testnet) {
+        const balanceInSun = await this.getFullNodeBalance({
+          address,
+          rpcUrl: params.caipNetwork.rpcUrls?.['chainDefault']?.http?.[0]
+        })
+
+        return {
+          balance: this.formatTrxBalance(balanceInSun),
+          symbol: 'TRX'
+        }
+      }
+
       const response = await BlockchainApiController.getAddressBalance<{
         data: { balance: number }[]
       }>({
@@ -319,17 +331,47 @@ export class TronAdapter extends AdapterBlueprint<TronConnector> {
 
       const balanceInSun = response?.data?.[0]?.balance ?? 0
 
-      const formattedBalance = NumberUtil.bigNumber(balanceInSun)
-        .div(10 ** 6)
-        .toString()
-
-      return { balance: formattedBalance, symbol: 'TRX' }
+      return { balance: this.formatTrxBalance(balanceInSun), symbol: 'TRX' }
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('[TronAdapter] getBalance error:', error)
 
       return { balance: '0', symbol: 'TRX' }
     }
+  }
+
+  private async getFullNodeBalance({
+    address,
+    rpcUrl
+  }: {
+    address: string
+    rpcUrl?: string
+  }): Promise<number> {
+    if (!rpcUrl) {
+      throw new Error('TRON fullnode RPC URL is not configured')
+    }
+
+    const normalizedRpcUrl = rpcUrl.replace(/\/+$/u, '')
+
+    const response = await fetch(`${normalizedRpcUrl}/wallet/getaccount`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address, visible: true })
+    })
+
+    if (!response.ok) {
+      throw new Error(`TRON fullnode balance request failed: ${response.status}`)
+    }
+
+    const result = (await response.json()) as { balance?: number }
+
+    return result.balance ?? 0
+  }
+
+  private formatTrxBalance(balanceInSun: number): string {
+    return NumberUtil.bigNumber(balanceInSun)
+      .div(10 ** 6)
+      .toString()
   }
 
   override parseUnits(): bigint {

--- a/packages/adapters/tron/src/tests/client.test.ts
+++ b/packages/adapters/tron/src/tests/client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BlockchainApiController } from '@reown/appkit-controllers'
+
+import { TronAdapter } from '../adapter'
+
+const MOCK_ADDRESS = 'TQZnRQHi8ioE4rEQHDWsDR9qM1APYUPbJG'
+
+const MOCK_TRON_MAINNET = {
+  id: '0x2b6653dc',
+  name: 'TRON',
+  chainNamespace: 'tron',
+  caipNetworkId: 'tron:0x2b6653dc',
+  rpcUrls: {
+    default: { http: ['https://rpc.walletconnect.org/v1'] },
+    chainDefault: { http: ['https://api.trongrid.io'] }
+  },
+  nativeCurrency: { name: 'TRX', symbol: 'TRX', decimals: 6 },
+  testnet: false
+}
+
+const MOCK_TRON_SHASTA = {
+  id: '0x94a9059e',
+  name: 'TRON Shasta',
+  chainNamespace: 'tron',
+  caipNetworkId: 'tron:0x94a9059e',
+  rpcUrls: {
+    default: { http: ['https://rpc.walletconnect.org/v1'] },
+    chainDefault: { http: ['https://api.shasta.trongrid.io/'] }
+  },
+  nativeCurrency: { name: 'TRX', symbol: 'TRX', decimals: 6 },
+  testnet: true
+}
+
+const mockFetch = vi.fn()
+
+vi.stubGlobal('fetch', mockFetch)
+
+describe('TronAdapter', () => {
+  let adapter: TronAdapter
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    adapter = new TronAdapter()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('getBalance', () => {
+    it('uses the configured TRON fullnode for testnet balances', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ balance: 2500000 })
+      })
+
+      const blockchainApiSpy = vi.spyOn(BlockchainApiController, 'getAddressBalance')
+
+      const result = await adapter.getBalance({
+        address: MOCK_ADDRESS,
+        caipNetwork: MOCK_TRON_SHASTA as any
+      })
+
+      expect(result).toEqual({ balance: '2.5', symbol: 'TRX' })
+      expect(mockFetch).toHaveBeenCalledWith('https://api.shasta.trongrid.io/wallet/getaccount', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: MOCK_ADDRESS, visible: true })
+      })
+      expect(blockchainApiSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps using Blockchain API for mainnet balances', async () => {
+      vi.spyOn(BlockchainApiController, 'getAddressBalance').mockResolvedValueOnce({
+        data: [{ balance: 1000000 }]
+      })
+
+      const result = await adapter.getBalance({
+        address: MOCK_ADDRESS,
+        caipNetwork: MOCK_TRON_MAINNET as any
+      })
+
+      expect(result).toEqual({ balance: '1', symbol: 'TRX' })
+      expect(BlockchainApiController.getAddressBalance).toHaveBeenCalledWith({
+        caipNetworkId: 'tron:0x2b6653dc',
+        address: MOCK_ADDRESS,
+        method: 'tron_getAddressBalance',
+        params: [{ address: MOCK_ADDRESS }]
+      })
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
# Description

Fixes TRON testnet balance fetching for the TRON adapter.

`TronAdapter.getBalance()` previously routed all TRON balance reads through `BlockchainApiController.getAddressBalance()`. For Shasta/Nile, that goes through the WalletConnect RPC proxy, which currently returns 503 for TRON testnet balance requests. This made AppKit show `0 TRX` and log repeated balance errors on Shasta.

This PR keeps the existing Blockchain API path for TRON mainnet, but uses the configured TRON fullnode `chainDefault` endpoint for testnet balances via `/wallet/getaccount`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5699

# Showcase (Optional)

No UI change. The behavior is covered by unit tests:

- Shasta/testnet balances call `https://api.shasta.trongrid.io/wallet/getaccount`
- Mainnet balances continue using `BlockchainApiController.getAddressBalance()`

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

Preview link is not applicable because this change is in adapter balance-fetching logic, not a UI surface.

# Testing

- `pnpm --filter @reown/appkit-adapter-tron... build`
- `pnpm --filter @reown/appkit-adapter-tron test`
- `pnpm --filter @reown/appkit-adapter-tron lint`

Note: lint exits successfully. It still reports the existing warning in `TronWalletConnectConnector.ts` for `usesV1Format`, which this PR does not touch.
