### PR TITLE
fix: honor experimental_preferUniversalLinks on session-request re-opens

### DIFF
--- a/.changeset/prefer-universal-links-deeplink-choice.md
+++ b/.changeset/prefer-universal-links-deeplink-choice.md
@@ -1,6 +1,30 @@
 ---
-'@reown/appkit-controllers': patch
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
 '@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
 ---
 
 fix: persist the universal-link base as the WalletConnect deeplink choice when `experimental_preferUniversalLinks` is enabled, so session-request re-opens (handled by universal-provider) use the wallet's universal link instead of falling back to its native custom scheme

--- a/.changeset/prefer-universal-links-deeplink-choice.md
+++ b/.changeset/prefer-universal-links-deeplink-choice.md
@@ -1,0 +1,6 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+---
+
+fix: persist the universal-link base as the WalletConnect deeplink choice when `experimental_preferUniversalLinks` is enabled, so session-request re-opens (handled by universal-provider) use the wallet's universal link instead of falling back to its native custom scheme

--- a/packages/controllers/src/utils/ConnectionControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectionControllerUtil.ts
@@ -108,21 +108,29 @@ export const ConnectionControllerUtil = {
         ConnectionController.setWcError(false)
         const { mobile_link, link_mode, name } = wallet
         const uriWithPay = CoreHelperUtil.appendPayToUri(wcUri, wcPayUrl)
-        const { redirect, redirectUniversalLink, href } = CoreHelperUtil.formatNativeUrl(
-          mobile_link,
-          uriWithPay,
-          link_mode
-        )
+        const { redirect, redirectUniversalLink, href, universalHref } =
+          CoreHelperUtil.formatNativeUrl(mobile_link, uriWithPay, link_mode)
 
         const deepLink = redirect
         const universalLink = redirectUniversalLink
         const target = CoreHelperUtil.isIframe() ? '_top' : '_self'
 
-        ConnectionController.setWcLinking({ name, href })
+        /*
+         * The href persisted as the WC deeplink choice must match what we open with, so
+         * session-request re-opens (handled by universal-provider) use the same link.
+         */
+        const shouldPreferUniversal =
+          Boolean(OptionsController.state.experimental_preferUniversalLinks) &&
+          Boolean(universalLink)
+
+        ConnectionController.setWcLinking({
+          name,
+          href: shouldPreferUniversal ? (universalHref as string) : href
+        })
         ConnectionController.setRecentWallet(wallet)
 
-        if (OptionsController.state.experimental_preferUniversalLinks && universalLink) {
-          CoreHelperUtil.openHref(universalLink, target)
+        if (shouldPreferUniversal) {
+          CoreHelperUtil.openHref(universalLink as string, target)
         } else {
           CoreHelperUtil.openHref(deepLink, target)
         }

--- a/packages/controllers/src/utils/ConnectionControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectionControllerUtil.ts
@@ -119,21 +119,16 @@ export const ConnectionControllerUtil = {
          * The href persisted as the WC deeplink choice must match what we open with, so
          * session-request re-opens (handled by universal-provider) use the same link.
          */
-        const shouldPreferUniversal =
-          Boolean(OptionsController.state.experimental_preferUniversalLinks) &&
-          Boolean(universalLink)
+        const shouldPreferUniversal = Boolean(
+          OptionsController.state.experimental_preferUniversalLinks
+        )
+        const linkToOpen = shouldPreferUniversal && universalLink ? universalLink : deepLink
+        const hrefToPersist = shouldPreferUniversal && universalHref ? universalHref : href
 
-        ConnectionController.setWcLinking({
-          name,
-          href: shouldPreferUniversal ? (universalHref as string) : href
-        })
+        ConnectionController.setWcLinking({ name, href: hrefToPersist })
         ConnectionController.setRecentWallet(wallet)
 
-        if (shouldPreferUniversal) {
-          CoreHelperUtil.openHref(universalLink as string, target)
-        } else {
-          CoreHelperUtil.openHref(deepLink, target)
-        }
+        CoreHelperUtil.openHref(linkToOpen, target)
       } catch (e) {
         EventsController.sendEvent({
           type: 'track',

--- a/packages/controllers/src/utils/CoreHelperUtil.ts
+++ b/packages/controllers/src/utils/CoreHelperUtil.ts
@@ -191,7 +191,8 @@ export const CoreHelperUtil = {
       redirectUniversalLink: safeUniversalLink
         ? `${safeUniversalLink}wc?uri=${encodedWcUrl}`
         : undefined,
-      href: safeAppUrl
+      href: safeAppUrl,
+      universalHref: safeUniversalLink ?? undefined
     }
   },
 

--- a/packages/controllers/src/utils/TypeUtil.ts
+++ b/packages/controllers/src/utils/TypeUtil.ts
@@ -76,6 +76,7 @@ export interface LinkingRecord {
   redirect: string
   redirectUniversalLink?: string
   href: string
+  universalHref?: string
 }
 
 export type ProjectId = string

--- a/packages/controllers/tests/utils/CoreHelperUtil.test.ts
+++ b/packages/controllers/tests/utils/CoreHelperUtil.test.ts
@@ -142,9 +142,9 @@ describe('CoreHelperUtil', () => {
     })
 
     it('should return the normalized universal base as universalHref', () => {
-      const appUrl = 'bnc://app.binance.com/cedefi/'
+      const appUrl = 'somewallet://app'
       // No trailing slash: formatNativeUrl should normalize it in universalHref
-      const universalLink = 'https://app.binance.com/cedefi'
+      const universalLink = 'https://example.com/app'
 
       const result = CoreHelperUtil.formatNativeUrl(appUrl, wcUri, universalLink)
 

--- a/packages/controllers/tests/utils/CoreHelperUtil.test.ts
+++ b/packages/controllers/tests/utils/CoreHelperUtil.test.ts
@@ -136,8 +136,25 @@ describe('CoreHelperUtil', () => {
       expect(result).toEqual({
         redirect: `${appUrl}wc?uri=${encodeURIComponent(wcUri)}`,
         redirectUniversalLink: `${universalLink}wc?uri=${encodeURIComponent(wcUri)}`,
-        href: appUrl
+        href: appUrl,
+        universalHref: universalLink
       })
+    })
+
+    it('should return the normalized universal base as universalHref', () => {
+      const appUrl = 'bnc://app.binance.com/cedefi/'
+      // No trailing slash: formatNativeUrl should normalize it in universalHref
+      const universalLink = 'https://app.binance.com/cedefi'
+
+      const result = CoreHelperUtil.formatNativeUrl(appUrl, wcUri, universalLink)
+
+      expect(result.universalHref).toBe(`${universalLink}/`)
+    })
+
+    it('should leave universalHref undefined when no universal link is provided', () => {
+      const result = CoreHelperUtil.formatNativeUrl('rainbow://', wcUri, null)
+
+      expect(result.universalHref).toBeUndefined()
     })
 
     it('should format Rainbow URL with deeplink only', () => {

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-mobile.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-mobile.test.ts
@@ -109,12 +109,15 @@ describe('W3mConnectingWcMobile', () => {
     )
 
     const openHrefSpy = vi.spyOn(CoreHelperUtil, 'openHref')
+    const setWcLinkingSpy = vi.spyOn(ConnectionController, 'setWcLinking')
     el['onConnect']()
 
     expect(openHrefSpy).toHaveBeenCalledWith(
       expect.stringContaining('reown.com/appkit/wc?uri='),
       '_self'
     )
+    // The persisted deeplink choice must be the universal base so request re-opens match
+    expect(setWcLinkingSpy).toHaveBeenCalledWith({ name: 'test', href: 'reown.com/appkit/' })
   })
 
   it('should use deeplink if enableUniversalLinks is enabled but wallet has no link_mode', async () => {
@@ -140,8 +143,41 @@ describe('W3mConnectingWcMobile', () => {
     )
 
     const openHrefSpy = vi.spyOn(CoreHelperUtil, 'openHref')
+    const setWcLinkingSpy = vi.spyOn(ConnectionController, 'setWcLinking')
     el['onConnect']()
 
     expect(openHrefSpy).toHaveBeenCalledWith(expect.stringContaining('test://app/wc?uri='), '_self')
+    // No universal link available: fall back to persisting the native base
+    expect(setWcLinkingSpy).toHaveBeenCalledWith({ name: 'test', href: 'test://app/' })
+  })
+
+  it('should persist the native href when preferUniversalLinks is disabled', async () => {
+    vi.spyOn(RouterController, 'state', 'get').mockReturnValueOnce({
+      ...RouterController.state,
+      data: {
+        wallet: {
+          id: 'test',
+          name: 'test',
+          mobile_link: 'test://app',
+          link_mode: 'reown.com/appkit'
+        }
+      }
+    })
+
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      experimental_preferUniversalLinks: false
+    })
+
+    const el: W3mConnectingWcMobile = await fixture(
+      html`<w3m-connecting-wc-mobile></w3m-connecting-wc-mobile>`
+    )
+
+    const openHrefSpy = vi.spyOn(CoreHelperUtil, 'openHref')
+    const setWcLinkingSpy = vi.spyOn(ConnectionController, 'setWcLinking')
+    el['onConnect']()
+
+    expect(openHrefSpy).toHaveBeenCalledWith(expect.stringContaining('test://app/wc?uri='), '_self')
+    expect(setWcLinkingSpy).toHaveBeenCalledWith({ name: 'test', href: 'test://app/' })
   })
 })


### PR DESCRIPTION
## Problem

With `experimental_preferUniversalLinks: true`, AppKit opens a wallet via its **universal link** on connect (pairing), but every subsequent **session request** (signing / confirming a tx) re-opens the wallet via its **native custom scheme** instead, e.g. `rn-web3wallet-internal://wc?requestId=...&sessionTopic=...`.

**Root cause:** at connect time `ConnectionControllerUtil.onConnectMobile` *opens* the universal link but *persists the native `href`* (`safeAppUrl`) as the WalletConnect deeplink choice (`WALLETCONNECT_DEEPLINK_CHOICE`). `@walletconnect/universal-provider` replays that stored `href` on every `request()` (`handleDeeplinkRedirect` builds `${href}wc?requestId=...&sessionTopic=...`). Since the stored `href` is the native base, all request re-opens use the native scheme.

This breaks hosts that embed a dapp in an iOS webview and rely on universal links so they don't have to list every wallet's custom scheme in `LSApplicationQueriesSchemes`. Connect works, but the signing step falls back to a native scheme the host can't open. Reproduced headless (`appKit.connectWallet(...)`), the path WalletConnect Pay uses.

`onConnectMobile` is the single unified path — the headful `w3m-connecting-wc-mobile` partial delegates to it — so one fix covers both headful and headless. No wallet-side or universal-provider change required.

## Fix

- `formatNativeUrl` now also returns `universalHref`, the normalized universal-link base (reuses the same `safeUniversalLink` that already produces `redirectUniversalLink`).
- `onConnectMobile` persists `universalHref` as the deeplink choice when the flag is on **and** a universal link exists, so the stored choice matches what we open with.
- Behavior is unchanged when the flag is off or the wallet has no `link_mode` (native scheme, no regression).

## Tests

- `CoreHelperUtil.test.ts`: `universalHref` equals the normalized universal base, and is `undefined` when no universal link is passed.
- `w3m-connecting-wc-mobile.test.ts`: `setWcLinking` receives the universal base (flag on + `link_mode`), the native base (no `link_mode`), and the native base (flag off).

## Manual verification (recommended)

On mobile / iOS webview: connect a wallet advertising both `mobile_link` and `link_mode`, confirm `localStorage.WALLETCONNECT_DEEPLINK_CHOICE` holds the `https://…/` universal base, then trigger `personal_sign` / `eth_sendTransaction` and confirm the re-open uses the universal link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)