### PR TITLE
fix(testing): deterministic canary session-proposal timing

### DIFF
--- a/.changeset/canary-session-proposal-timing.md
+++ b/.changeset/canary-session-proposal-timing.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-testing': patch
+---
+
+Add `WalletPage.waitForSessionProposal()` — a deterministic signal (approve-button visibility) for canary session-proposal timing that replaces brittle WalletConnect console-log parsing in the laboratory canary fixture.

--- a/apps/laboratory/tests/shared/fixtures/w3m-wallet-fixture.ts
+++ b/apps/laboratory/tests/shared/fixtures/w3m-wallet-fixture.ts
@@ -32,10 +32,12 @@ export const testConnectedMW = base.extend<ModalWalletFixture>({
     const connectionInitiated = new Date()
     timeEnd('walletPage.connectWithUri')
 
-    // The session proposal is received once the wallet renders the request UI (approve button).
-    // Deterministic, owned-testid signal instead of parsing SDK console logs. Also guards delivery
-    // failures: a proposal that never arrives times out here and fails the run (pages via the
-    // success/failure canary). Interval includes the wallet's render time.
+    /*
+     * The session proposal is received once the wallet renders the request UI (approve button).
+     * Deterministic, owned-testid signal instead of parsing SDK console logs. Also guards delivery
+     * failures: a proposal that never arrives times out here and fails the run (pages via the
+     * success/failure canary). Interval includes the wallet's render time.
+     */
     timeStart('walletPage.waitForSessionProposal')
     await walletPage.waitForSessionProposal()
     const proposalReceived = new Date()

--- a/apps/laboratory/tests/shared/fixtures/w3m-wallet-fixture.ts
+++ b/apps/laboratory/tests/shared/fixtures/w3m-wallet-fixture.ts
@@ -1,4 +1,3 @@
-/* eslint no-console: 0 */
 import { WalletPage, WalletValidator } from '@reown/appkit-testing'
 import { DEFAULT_SESSION_PARAMS } from '@reown/appkit-testing'
 
@@ -14,33 +13,9 @@ interface ModalWalletFixture {
 // MW -> test Modal + Wallet
 export const testConnectedMW = base.extend<ModalWalletFixture>({
   walletPage: async ({ context, modalPage, timingRecords }, use) => {
-    // Setup
-    let pairingCreatedTime: Date | null = null
-    let verificationStartedTime: Date | null = null
-
     timeStart('new WalletPage')
     const walletPage = new WalletPage(await context.newPage())
     timeEnd('new WalletPage')
-
-    walletPage.page.on('console', msg => {
-      if (msg.text().includes('set') && msg.text().includes('core/pairing/pairing')) {
-        pairingCreatedTime = new Date()
-      }
-      if (msg.text().includes('resolving attestation')) {
-        verificationStartedTime = new Date()
-      }
-      if (msg.text().includes('session_proposal') && msg.text().includes('verifyContext')) {
-        // For some reason this log is emitted twice; so only recording the time once
-        if (verificationStartedTime) {
-          const verificationEndedTime = new Date()
-          timingRecords.push({
-            item: 'sessionProposalVerification',
-            timeMs: verificationEndedTime.getTime() - verificationStartedTime.getTime()
-          })
-          verificationStartedTime = null
-        }
-      }
-    })
 
     timeStart('walletPage.load')
     await walletPage.load()
@@ -53,28 +28,34 @@ export const testConnectedMW = base.extend<ModalWalletFixture>({
 
     timeStart('walletPage.connectWithUri')
     await walletPage.connectWithUri(uri)
+    // Capture immediately on resolution — nothing awaited in between — to avoid skewing the interval.
+    const connectionInitiated = new Date()
     timeEnd('walletPage.connectWithUri')
 
-    const connectionInitiated = new Date()
-
-    // Handle session proposal
-    timeStart('walletPage.handleSessionProposal')
-    await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
-    timeEnd('walletPage.handleSessionProposal')
-
+    // The session proposal is received once the wallet renders the request UI (approve button).
+    // Deterministic, owned-testid signal instead of parsing SDK console logs. Also guards delivery
+    // failures: a proposal that never arrives times out here and fails the run (pages via the
+    // success/failure canary). Interval includes the wallet's render time.
+    timeStart('walletPage.waitForSessionProposal')
+    await walletPage.waitForSessionProposal()
     const proposalReceived = new Date()
+    timeEnd('walletPage.waitForSessionProposal')
 
     timingRecords.push({
-      item: 'receiveSessionProposal',
+      item: 'sessionProposalReceived',
       timeMs: proposalReceived.getTime() - connectionInitiated.getTime()
     })
 
-    if (pairingCreatedTime) {
-      timingRecords.push({
-        item: 'pairingReceiveSessionProposal',
-        timeMs: proposalReceived.getTime() - (pairingCreatedTime as Date).getTime()
-      })
-    }
+    // Approve the session proposal (request UI already visible from the wait above)
+    timeStart('walletPage.handleSessionProposal')
+    await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
+    const proposalApproved = new Date()
+    timeEnd('walletPage.handleSessionProposal')
+
+    timingRecords.push({
+      item: 'sessionProposalApproved',
+      timeMs: proposalApproved.getTime() - proposalReceived.getTime()
+    })
 
     const walletValidator = new WalletValidator(walletPage.page)
 

--- a/packages/testing/src/pages/WalletPage.ts
+++ b/packages/testing/src/pages/WalletPage.ts
@@ -83,9 +83,29 @@ export class WalletPage {
     await this.performRequestAction(variant)
   }
 
+  sessionRequestButton(variant: string) {
+    return this.page.getByTestId(`session-${variant}-button`)
+  }
+
+  /**
+   * Resolves once the wallet has received a session proposal and rendered the request UI
+   * (the approve button becomes visible). Deterministic signal for canary timing — replaces
+   * brittle console-log parsing. Shares the same owned testid as `performRequestAction`, so a
+   * selector change breaks the approve flow too and fails the run (paging via the
+   * success/failure canary) rather than silently dropping the timing metric. Note: the interval
+   * includes the wallet's render time; the pure relay/SDK delivery leg needs a wallet-side signal.
+   */
+  async waitForSessionProposal(timeout = 30000) {
+    await this.page.waitForLoadState()
+    await expect(
+      this.sessionRequestButton('approve'),
+      'Session proposal should be received (approve button visible)'
+    ).toBeVisible({ timeout })
+  }
+
   async performRequestAction(variant: string) {
     await this.page.waitForLoadState()
-    const btn = this.page.getByTestId(`session-${variant}-button`)
+    const btn = this.sessionRequestButton(variant)
     await expect(btn, `Session ${variant} element should be visible`).toBeVisible({
       timeout: 30000
     })


### PR DESCRIPTION
## Why

The `AppKit Receive Session Proposal Timing > 7000ms` Grafana canary alert paged as a **false positive** (see the burst of P3 escalations on 2026-07-14). Root cause: the queried metric, `HappyPath.sign.timing.pairingReceiveSessionProposal`, was captured by **matching WalletConnect SDK `console.log` strings** on the external wallet page (`core/pairing/pairing`, `resolving attestation`, `verifyContext`). When those internal logs changed format/level the metric silently stopped emitting → the panel went blank → the gap was evaluated as a `>7000ms` breach.

The fix removes the brittle path and replaces it with a deterministic signal.

## What changed

**`packages/testing` (`@reown/appkit-testing`)**
- Add `WalletPage.waitForSessionProposal()` — resolves when the wallet renders the request UI (approve button visible). It reuses the **same owned `session-approve-button` testid** as `performRequestAction` (extracted into `sessionRequestButton()`), so a selector change breaks the approve flow *and* this wait together → the run fails and pages via the success/failure canary, rather than silently dropping just the timing metric.

**`apps/laboratory` canary fixture (`w3m-wallet-fixture.ts`)**
- Delete the `page.on('console')` block (the only console-log-gated timing capture in the suite).
- Replace `receiveSessionProposal` / `pairingReceiveSessionProposal` / `sessionProposalVerification` with two deterministic timings:
  - **`sessionProposalReceived`** — `connectWithUri` resolved → proposal rendered in wallet (the metric the alert should track)
  - **`sessionProposalApproved`** — proposal rendered → session approved (approve round-trip; the boundary split)
- Capture interval timestamps immediately on `await` resolution (no work in between) to avoid skew.

## Required monitoring-repo follow-up

Repoint the Grafana query (`cloudwatch.libsonnet`) from `timing.pairingReceiveSessionProposal` → `timing.sessionProposalReceived`. Until then the panel stays blank (timing alerts already resolve gaps to `OK`, so no false page in the interim). New baseline reads lower — it excludes the approve round-trip — so retune thresholds against real data once it flows.

## Notes / known limitations
- `sessionProposalReceived` includes the test wallet's render time; the pure relay/SDK delivery leg needs a wallet-side signal (owned markers in `react-wallet-v2`) — tracked as a separate follow-up.
- Dropped attestation-latency (`sessionProposalVerification`); Verify correctness is still covered by the pass/fail verify canaries.

## Verification
- [ ] `pnpm build && (cd apps/laboratory && pnpm typecheck)` — not run in the authoring workspace (deps not installed); relying on CI.
- [ ] Canary run: `sessionProposalReceived` + `sessionProposalApproved` present in `timingRecords`; old items absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)