### PR TITLE
fix(wagmi): handle multi-namespace WalletConnect sessions with empty EVM accounts

### DIFF
--- a/.changeset/major-tigers-cover.md
+++ b/.changeset/major-tigers-cover.md
@@ -1,0 +1,31 @@
+---
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed an issue where connecting via WalletConnect with multiple chain namespaces (e.g., EVM + Bitcoin + Tron) would crash if the wallet returned an eip155 namespace with empty accounts. This edge case occurred with certain wallet configurations where the wallet included the eip155 namespace in the session but didn't provide any EVM accounts.

--- a/packages/adapters/wagmi/src/client.ts
+++ b/packages/adapters/wagmi/src/client.ts
@@ -655,7 +655,7 @@ export class WagmiAdapter extends AdapterBlueprint {
       })
 
       if (res.chainId !== Number(chainId)) {
-        await switchChain(this.wagmiConfig, { chainId: res.chainId })
+        await switchChain(this.wagmiConfig, { chainId: res.chainId }).catch(() => undefined)
       }
 
       return { clientId: await walletConnectConnector.provider.client.core.crypto.getClientId() }


### PR DESCRIPTION
# Description

Fixed an issue where connecting via WalletConnect with multiple chain namespaces (e.g., EVM + Bitcoin + Tron) would crash if the wallet returned an eip155 namespace with empty accounts. This edge case occurred with certain wallet configurations where the wallet included the eip155 namespace in the session but didn't provide any EVM accounts.
