### PR TITLE
chore(laboratory): remove Phantom from Bitcoin wallet buttons

### DIFF
--- a/apps/laboratory/src/utils/ConstantsUtil.ts
+++ b/apps/laboratory/src/utils/ConstantsUtil.ts
@@ -211,7 +211,7 @@ export const ConstantsUtil = {
     'backpack',
     'frontier'
   ] as Wallet[],
-  BitcoinWalletButtons: ['walletConnect', 'xverse', 'leather', 'okx', 'phantom'] as Wallet[],
+  BitcoinWalletButtons: ['walletConnect', 'xverse', 'leather', 'okx'] as Wallet[],
   Socials: [
     'google',
     'github',


### PR DESCRIPTION
# Description

Phantom has discontinued Bitcoin dapp connectivity (no injected provider, no Wallet Standard bitcoin:* features, no WalletConnect bip122 support), so the button never connects.

## Type of change

- [X] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Chore comes from reviewing ISSUE #5707

# Showcase (Optional)

<img width="884" height="310" alt="image" src="https://github.com/user-attachments/assets/ca5b616d-c0ba-429f-b71d-411eabdf2b28" />

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
