### PR TITLE
fix: add missing Rootstock logo's id

### DIFF
--- a/.changeset/wacky-bobcats-cross.md
+++ b/.changeset/wacky-bobcats-cross.md
@@ -1,0 +1,31 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit-common': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed Rootstock network logo not being displayed in the network selectors.

--- a/packages/appkit-utils/src/PresetsUtil.ts
+++ b/packages/appkit-utils/src/PresetsUtil.ts
@@ -108,6 +108,10 @@ export const PresetsUtil = {
     80094: 'e329c2c9-59b0-4a02-83e4-212ff3779900',
     // Abstract Mainnet
     2741: 'fc2427d1-5af9-4a9c-8da5-6f94627cd900',
+    // Rootstock Mainnet
+    30: 'fb7e1624-99e3-4c36-ea01-4cfe46c4a300',
+    // Rootstock Testnet
+    31: '2eb3d92a-3d77-42aa-87c9-190adb144800',
     // Solana networks
     '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'a1b58899-f671-4276-6a5e-56ca5bd59700',
     '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z': 'a1b58899-f671-4276-6a5e-56ca5bd59700',

--- a/packages/common/src/utils/PresetsUtil.ts
+++ b/packages/common/src/utils/PresetsUtil.ts
@@ -106,6 +106,10 @@ export const PresetsUtil = {
     80094: 'e329c2c9-59b0-4a02-83e4-212ff3779900',
     // Abstract Mainnet
     2741: 'fc2427d1-5af9-4a9c-8da5-6f94627cd900',
+    // Rootstock Mainnet
+    30: 'fb7e1624-99e3-4c36-ea01-4cfe46c4a300',
+    // Rootstock Testnet
+    31: '2eb3d92a-3d77-42aa-87c9-190adb144800',
     // Solana networks
     '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': 'a1b58899-f671-4276-6a5e-56ca5bd59700',
     '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z': 'a1b58899-f671-4276-6a5e-56ca5bd59700',


### PR DESCRIPTION
# Description

Adds Rootstock logo's ID whitelisted in the CDN

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes REOWN-3854

# Showcase (Optional)

<img width="399" height="576" alt="image" src="https://github.com/user-attachments/assets/e2cdc987-3a4f-4dbf-9b66-800f9e90fb83" />

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
