### PR TITLE
fix(ci): retry playwright:install-deps on transient apt mirror failures

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -300,7 +300,17 @@ jobs:
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true' # <-- Re-enable condition
         working-directory: ./apps/laboratory/
-        run: pnpm playwright:install-deps
+        run: |
+          for attempt in 1 2 3; do
+            echo "playwright:install-deps attempt $attempt/3"
+            if pnpm playwright:install-deps; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed (likely a transient apt mirror timeout) - retrying in 15s..."
+            sleep 15
+          done
+          echo "playwright:install-deps failed after 3 attempts"
+          exit 1
 
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true' # <-- Re-enable condition
@@ -429,7 +439,17 @@ jobs:
       - name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true' # <-- Re-enable condition
         working-directory: ./apps/laboratory/
-        run: pnpm playwright:install-deps
+        run: |
+          for attempt in 1 2 3; do
+            echo "playwright:install-deps attempt $attempt/3"
+            if pnpm playwright:install-deps; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed (likely a transient apt mirror timeout) - retrying in 15s..."
+            sleep 15
+          done
+          echo "playwright:install-deps failed after 3 attempts"
+          exit 1
 
       - name: Download all shard blob reports
         uses: actions/download-artifact@v4


### PR DESCRIPTION
# Description

The CI runner intermittently can't reach `security.ubuntu.com` while running `pnpm playwright:install-deps` (installing Playwright's system dependencies), which fails the whole shard with 0 tests run - unrelated to any test or app code. Confirmed in real CI logs across two separate runs (different shards each time), with `apt-get` retrying for ~8 minutes before giving up with `Connection failed`.

Wraps both occurrences of the `playwright:install-deps` step in `ui_tests.yml` (the `ui_tests` job and the `merge_reports` job) in a 3-attempt retry loop with a 15s backoff. Still fails the step (not silently) if all 3 attempts fail, so a genuinely broken install isn't masked.

**Caveat:** this hasn't been verified against a live occurrence yet - the flake didn't recur in the two CI runs checked since this landed (every shard succeeded on the first attempt), so the retry path itself is still unexercised. It's a fix for a confirmed, real failure mode, just not yet confirmed to work in practice.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

For Linear issues: Closes APKT-xxx
For GH issues: closes #...

# Showcase (Optional)

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
