### PR TITLE
fix(ui): make monospace text follow custom font family

### DIFF
--- a/.changeset/copy-link-custom-font-family.md
+++ b/.changeset/copy-link-custom-font-family.md
@@ -1,0 +1,34 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Fixed a custom `--apkt-font-family` (or legacy `--w3m-font-family`) leaving every monospace piece of UI text unstyled — the WalletConnect "Copy link" button, wallet addresses, and amount inputs fell back to the browser default font.
+
+The mono font was hardcoded to `KHTekaMono` with no corresponding CSS variable, so it could not be themed. Because the bundled `@font-face` blocks are skipped when a custom font is set, `font-family: KHTekaMono` then pointed at a family that was never loaded, with no generic fallback.
+
+Mono now resolves to `--apkt-font-family-mono ?? --apkt-font-family ?? --w3m-font-family ?? KHTekaMono`, so setting a single custom font keeps mono text styled. A new `--apkt-font-family-mono` theme variable allows overriding the monospace font on its own, and the bundled `KHTekaMono` face is only injected when it is actually the effective mono font. Default behavior with no custom font is unchanged.

--- a/packages/controllers/src/utils/TypeUtil.ts
+++ b/packages/controllers/src/utils/TypeUtil.ts
@@ -227,6 +227,7 @@ export interface ThemeVariables {
   '--w3m-z-index'?: number
   '--w3m-qr-color'?: string
   '--apkt-font-family'?: string
+  '--apkt-font-family-mono'?: string
   '--apkt-accent'?: string
   '--apkt-color-mix'?: string
   '--apkt-color-mix-strength'?: number

--- a/packages/ui/src/utils/ThemeHelperUtil.ts
+++ b/packages/ui/src/utils/ThemeHelperUtil.ts
@@ -17,6 +17,16 @@ function normalizeThemeVariables(themeVariables?: ThemeVariables): Record<string
   normalized['font-family'] =
     themeVariables['--apkt-font-family'] ?? themeVariables['--w3m-font-family'] ?? 'KHTeka'
 
+  /*
+   * Mono falls back to the custom base font before the bundled KHTekaMono, so a single
+   * --apkt-font-family keeps mono text styled instead of dropping to the browser default.
+   */
+  normalized['font-family-mono'] =
+    themeVariables['--apkt-font-family-mono'] ??
+    themeVariables['--apkt-font-family'] ??
+    themeVariables['--w3m-font-family'] ??
+    'KHTekaMono'
+
   normalized['accent'] =
     themeVariables['--apkt-accent'] ?? themeVariables['--w3m-accent'] ?? '#0988F0'
 
@@ -214,6 +224,14 @@ export const ThemeHelperUtil = {
 
     if (themeVariables['--apkt-font-family'] || themeVariables['--w3m-font-family']) {
       overrides['--apkt-fontFamily-regular'] = normalized['font-family'] as string
+    }
+
+    if (
+      themeVariables['--apkt-font-family-mono'] ||
+      themeVariables['--apkt-font-family'] ||
+      themeVariables['--w3m-font-family']
+    ) {
+      overrides['--apkt-fontFamily-mono'] = normalized['font-family-mono'] as string
     }
 
     if (normalized['z-index'] !== undefined) {

--- a/packages/ui/src/utils/ThemeUtil.ts
+++ b/packages/ui/src/utils/ThemeUtil.ts
@@ -114,6 +114,12 @@ export function createRootStyles(_themeVariables?: ThemeVariables) {
   const hasCustomFontFamily = Boolean(
     _themeVariables?.['--apkt-font-family'] || _themeVariables?.['--w3m-font-family']
   )
+  /*
+   * Mono inherits a custom base font, so the bundled face is only needed when neither
+   * the mono nor the base font has been overridden.
+   */
+  const hasCustomMonoFontFamily =
+    Boolean(_themeVariables?.['--apkt-font-family-mono']) || hasCustomFontFamily
 
   return {
     core: css`
@@ -140,19 +146,22 @@ export function createRootStyles(_themeVariables?: ThemeVariables) {
             }
 
             @font-face {
-              font-family: 'KHTekaMono';
-              src:
-                url(${unsafeCSS(fonts['KHTekaMono-400-woff2'])}) format('woff2'),
-                url(${unsafeCSS(fonts['KHTekaMono-400-woff'])}) format('woff');
-              font-weight: 400;
-              font-style: normal;
-            }
-
-            @font-face {
               font-family: 'KHTeka';
               src:
                 url(${unsafeCSS(fonts['KHTeka-400-woff2'])}) format('woff2'),
                 url(${unsafeCSS(fonts['KHTeka-400-woff'])}) format('woff');
+              font-weight: 400;
+              font-style: normal;
+            }
+          `}
+      ${hasCustomMonoFontFamily
+        ? css``
+        : css`
+            @font-face {
+              font-family: 'KHTekaMono';
+              src:
+                url(${unsafeCSS(fonts['KHTekaMono-400-woff2'])}) format('woff2'),
+                url(${unsafeCSS(fonts['KHTekaMono-400-woff'])}) format('woff');
               font-weight: 400;
               font-style: normal;
             }

--- a/packages/ui/src/utils/TypeUtil.ts
+++ b/packages/ui/src/utils/TypeUtil.ts
@@ -384,6 +384,7 @@ export interface ThemeVariables {
   '--w3m-z-index'?: number
   '--w3m-qr-color'?: string
   '--apkt-font-family'?: string
+  '--apkt-font-family-mono'?: string
   '--apkt-accent'?: string
   '--apkt-color-mix'?: string
   '--apkt-color-mix-strength'?: number

--- a/packages/ui/tests/ThemeHelperUtils.test.ts
+++ b/packages/ui/tests/ThemeHelperUtils.test.ts
@@ -169,4 +169,38 @@ describe('ThemeHelperUtil', () => {
     const emptyOverrides = ThemeHelperUtil.generateW3MOverrides({})
     expect(emptyOverrides['--apkt-tokens-core-zIndex']).toBeUndefined()
   })
+
+  it('should override both regular and mono font families for a custom font', () => {
+    const apktOverrides = ThemeHelperUtil.generateW3MOverrides({
+      '--apkt-font-family': "'Comic Sans MS', cursive"
+    })
+    expect(apktOverrides['--apkt-fontFamily-regular']).toBe("'Comic Sans MS', cursive")
+    expect(apktOverrides['--apkt-fontFamily-mono']).toBe("'Comic Sans MS', cursive")
+
+    const w3mOverrides = ThemeHelperUtil.generateW3MOverrides({
+      '--w3m-font-family': "'Comic Sans MS', cursive"
+    })
+    expect(w3mOverrides['--apkt-fontFamily-regular']).toBe("'Comic Sans MS', cursive")
+    expect(w3mOverrides['--apkt-fontFamily-mono']).toBe("'Comic Sans MS', cursive")
+
+    const noFontOverrides = ThemeHelperUtil.generateW3MOverrides({ '--w3m-accent': '#ff0000' })
+    expect(noFontOverrides['--apkt-fontFamily-regular']).toBeUndefined()
+    expect(noFontOverrides['--apkt-fontFamily-mono']).toBeUndefined()
+  })
+
+  it('should let --apkt-font-family-mono override the mono font independently', () => {
+    const bothFonts = ThemeHelperUtil.generateW3MOverrides({
+      '--apkt-font-family': "'Comic Sans MS', cursive",
+      '--apkt-font-family-mono': "'Fira Code', monospace"
+    })
+    expect(bothFonts['--apkt-fontFamily-regular']).toBe("'Comic Sans MS', cursive")
+    expect(bothFonts['--apkt-fontFamily-mono']).toBe("'Fira Code', monospace")
+
+    // Mono alone must not drag the regular font along with it
+    const monoOnly = ThemeHelperUtil.generateW3MOverrides({
+      '--apkt-font-family-mono': "'Fira Code', monospace"
+    })
+    expect(monoOnly['--apkt-fontFamily-mono']).toBe("'Fira Code', monospace")
+    expect(monoOnly['--apkt-fontFamily-regular']).toBeUndefined()
+  })
 })


### PR DESCRIPTION
# Description

Setting a custom base font via `--apkt-font-family` (or the legacy `--w3m-font-family`) left every **monospace** piece of UI text unstyled — the WalletConnect **"Copy link"** button, wallet addresses, and amount inputs rendered in the browser default (serif) font while all regular text correctly switched to the custom font.

**Root cause.** The regular font is themeable through `--apkt-fontFamily-regular`, which `ThemeHelperUtil` overrides with the custom font. The mono font, however, was hardcoded to `KHTekaMono` (`ThemeConstantsUtil` → `fontFamily.mono`) with no corresponding CSS variable, so it could not be themed. On top of that the bundled `@font-face` blocks are skipped when a custom font is set, so `font-family: KHTekaMono` pointed at a family that was never loaded — with no generic fallback, the browser dropped to its default serif.

**Fix.** Mono now resolves to:

```
--apkt-font-family-mono ?? --apkt-font-family ?? --w3m-font-family ?? KHTekaMono
```

so the common single-custom-font case keeps mono text styled, while the new `--apkt-font-family-mono` theme variable still allows explicit monospace control:

```ts
themeVariables: {
  '--apkt-font-family': "'Comic Sans MS', cursive",
  '--apkt-font-family-mono': "'Fira Code', monospace" // optional
}
```

The bundled `KHTekaMono` `@font-face` is now gated on whether it is actually the effective mono font, mirroring how the regular faces are already gated. **Default behavior with no custom font is unchanged.**

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5681

# Showcase (Optional)
## Before

<img width="415" height="578" alt="image" src="https://github.com/user-attachments/assets/e14936bb-de3a-4476-80ff-570c3501e476" />

## After
<img width="397" height="570" alt="image" src="https://github.com/user-attachments/assets/c3b9f20c-d097-4259-aac7-a47613e599c8" />


# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
