### PR TITLE
fix: recover headless WalletConnect connects after a disconnect

### DIFF
--- a/.changeset/headless-wc-reconnect-after-disconnect.md
+++ b/.changeset/headless-wc-reconnect-after-disconnect.md
@@ -33,3 +33,8 @@ Two gaps, both only reachable without scaffold-ui (which re-fetches the URI per 
 
 - `wcError` was only ever cleared by a successful mobile deeplink or the headful "try again" button, so a single failure left every later attempt reading as failed. A new `connectWalletConnect` attempt now starts from a clean error state.
 - `ConnectionControllerUtil.onConnectMobile` is a no-op without a pairing URI, and a disconnect clears it (`resetWcConnection`). `connectWallet` / the `useAppKitWallets` `connect` now reject in that case (`ConnectionControllerUtil.assertWcUriForDeeplink`) instead of resolving as if a wallet had been opened, so the host can pre-fetch a URI and retry rather than waiting on a redirect that never fires.
+
+Headless hosts can also now read the pairing expiry: `getWalletConnectUri()` returns `wcPairingExpiry` alongside `wcUri` / `wcError` / `wcFetchingUri`, and `subscribeWalletConnectUri` fires on it. `ConnectionController.setUri` has always stamped it four minutes out, and scaffold-ui reads it (`isPairingExpired`) to decide whether to re-connect — it simply was never passed through to the headless read.
+
+It matters for a host that consumes the URI later than it fetched it. Scaffold-ui generates a URI and acts on it in one gesture, so a lapsed pairing is nearly unreachable there. A host whose picker fetches on wallet select and deeplinks on a second, user-paced click can easily be past four minutes by the time the user taps, and no other field in the snapshot distinguishes a fresh URI from a dead one.
+

--- a/.changeset/headless-wc-reconnect-after-disconnect.md
+++ b/.changeset/headless-wc-reconnect-after-disconnect.md
@@ -1,0 +1,35 @@
+---
+'@reown/appkit-utils': patch
+'@reown/appkit': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet-button': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+---
+
+Fix headless hosts getting stuck after a disconnect, where connecting any wallet afterwards silently did nothing and every attempt reported a connection error until the page was reloaded.
+
+Two gaps, both only reachable without scaffold-ui (which re-fetches the URI per view and clears the error on "try again"):
+
+- `wcError` was only ever cleared by a successful mobile deeplink or the headful "try again" button, so a single failure left every later attempt reading as failed. A new `connectWalletConnect` attempt now starts from a clean error state.
+- `ConnectionControllerUtil.onConnectMobile` is a no-op without a pairing URI, and a disconnect clears it (`resetWcConnection`). `connectWallet` / the `useAppKitWallets` `connect` now reject in that case (`ConnectionControllerUtil.assertWcUriForDeeplink`) instead of resolving as if a wallet had been opened, so the host can pre-fetch a URI and retry rather than waiting on a redirect that never fires.

--- a/packages/controllers/exports/react.ts
+++ b/packages/controllers/exports/react.ts
@@ -542,6 +542,7 @@ export function useAppKitWallets(): UseAppKitWalletsReturn {
         const wcWallet = ConnectUtil.mapWalletItemToWcWallet(_wallet)
 
         if (wcWallet.mobile_link) {
+          ConnectionControllerUtil.assertWcUriForDeeplink()
           ConnectionControllerUtil.onConnectMobile(wcWallet, options?.wcPayUrl)
         } else {
           MobileWalletUtil.handleMobileDeeplinkRedirect(_wallet.id, activeNamespace, {

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -227,11 +227,6 @@ const controller = {
 
   async connectWalletConnect({ cache = 'auto' }: ConnectWalletConnectParameters = {}) {
     state.wcFetchingUri = true
-    /*
-     * A new attempt starts from a clean error state — `wcError` is otherwise only cleared by a
-     * successful mobile deeplink or the headful "try again" button, so a headless host (no
-     * scaffold-ui) that hit one error stayed in an error state for the rest of the page's life.
-     */
     state.wcError = false
     const isInTelegramOrSafariIos =
       CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos())

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -227,6 +227,12 @@ const controller = {
 
   async connectWalletConnect({ cache = 'auto' }: ConnectWalletConnectParameters = {}) {
     state.wcFetchingUri = true
+    /*
+     * A new attempt starts from a clean error state — `wcError` is otherwise only cleared by a
+     * successful mobile deeplink or the headful "try again" button, so a headless host (no
+     * scaffold-ui) that hit one error stayed in an error state for the rest of the page's life.
+     */
+    state.wcError = false
     const isInTelegramOrSafariIos =
       CoreHelperUtil.isTelegram() || (CoreHelperUtil.isSafari() && CoreHelperUtil.isIos())
 

--- a/packages/controllers/src/utils/ConnectionControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectionControllerUtil.ts
@@ -100,6 +100,25 @@ export const ConnectionControllerUtil = {
       recentConnections: dedupedRecentConnections
     }
   },
+  /**
+   * Throw when there is no WalletConnect pairing URI to deeplink into.
+   *
+   * {@link ConnectionControllerUtil.onConnectMobile} is a no-op without a URI, and it cannot
+   * fetch one itself: the redirect has to happen inside the tap that triggered it (iOS Safari
+   * blocks a redirect issued after an await). A headless host is the layer that pre-fetches the
+   * URI, so it needs the failure as a rejection — otherwise a connect() call that opened nothing
+   * looks like a connect() call still in flight, and the buyer waits on a wallet that never opens.
+   *
+   * The URI is missing whenever the last one was consumed or cleared — most visibly after a
+   * disconnect (`resetWcConnection`), which is when reconnecting used to silently do nothing.
+   */
+  assertWcUriForDeeplink() {
+    if (!ConnectionController.state.wcUri) {
+      throw new Error(
+        'No WalletConnect URI available to deeplink into. Pre-fetch one (connectWalletConnect / prefetchWalletConnectUri) before connecting a mobile wallet.'
+      )
+    }
+  },
   onConnectMobile(wallet: WcWallet | undefined, wcPayUrl?: string) {
     const wcUri = ConnectionController.state.wcUri
 

--- a/packages/controllers/src/utils/ConnectionControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectionControllerUtil.ts
@@ -100,8 +100,10 @@ export const ConnectionControllerUtil = {
       recentConnections: dedupedRecentConnections
     }
   },
-  // Not fetched here on purpose: the deeplink has to open inside the tap that triggered it
-  // (iOS Safari blocks a redirect issued after an await), so the caller pre-fetches the URI.
+  /*
+   * Not fetched here on purpose: the deeplink has to open inside the tap that triggered it
+   * (iOS Safari blocks a redirect issued after an await), so the caller pre-fetches the URI.
+   */
   assertWcUriForDeeplink() {
     if (!ConnectionController.state.wcUri) {
       throw new Error(

--- a/packages/controllers/src/utils/ConnectionControllerUtil.ts
+++ b/packages/controllers/src/utils/ConnectionControllerUtil.ts
@@ -100,18 +100,8 @@ export const ConnectionControllerUtil = {
       recentConnections: dedupedRecentConnections
     }
   },
-  /**
-   * Throw when there is no WalletConnect pairing URI to deeplink into.
-   *
-   * {@link ConnectionControllerUtil.onConnectMobile} is a no-op without a URI, and it cannot
-   * fetch one itself: the redirect has to happen inside the tap that triggered it (iOS Safari
-   * blocks a redirect issued after an await). A headless host is the layer that pre-fetches the
-   * URI, so it needs the failure as a rejection — otherwise a connect() call that opened nothing
-   * looks like a connect() call still in flight, and the buyer waits on a wallet that never opens.
-   *
-   * The URI is missing whenever the last one was consumed or cleared — most visibly after a
-   * disconnect (`resetWcConnection`), which is when reconnecting used to silently do nothing.
-   */
+  // Not fetched here on purpose: the deeplink has to open inside the tap that triggered it
+  // (iOS Safari blocks a redirect issued after an await), so the caller pre-fetches the URI.
   assertWcUriForDeeplink() {
     if (!ConnectionController.state.wcUri) {
       throw new Error(

--- a/packages/controllers/src/utils/HeadlessWalletUtil.ts
+++ b/packages/controllers/src/utils/HeadlessWalletUtil.ts
@@ -217,6 +217,7 @@ export const HeadlessWalletUtil = {
         const wcWallet = ConnectUtil.mapWalletItemToWcWallet(wallet)
 
         if (wcWallet.mobile_link) {
+          ConnectionControllerUtil.assertWcUriForDeeplink()
           ConnectionControllerUtil.onConnectMobile(wcWallet, options?.wcPayUrl)
         } else {
           MobileWalletUtil.handleMobileDeeplinkRedirect(wallet.id, activeNamespace, {

--- a/packages/controllers/src/utils/HeadlessWalletUtil.ts
+++ b/packages/controllers/src/utils/HeadlessWalletUtil.ts
@@ -70,6 +70,16 @@ export interface WalletConnectUriSnapshot {
   wcError: boolean
   /** Whether a WalletConnect URI is currently being fetched. */
   wcFetchingUri: boolean
+  /**
+   * When the pairing behind `wcUri` expires, as an epoch ms timestamp — `undefined` when there
+   * is no URI. Set four minutes out on every delivery (see `ConnectionController.setUri`).
+   *
+   * A host that renders the URI immediately rarely needs this, but one that consumes it later
+   * does: the URI can be well past its pairing by the time the user acts on it, and nothing else
+   * in this snapshot distinguishes a fresh URI from a dead one. Compare with
+   * `CoreHelperUtil.isPairingExpired`, which treats the last ten seconds as already expired.
+   */
+  wcPairingExpiry: number | undefined
 }
 
 /**
@@ -150,12 +160,14 @@ export const HeadlessWalletUtil = {
     return {
       wcUri: ConnectionController.state.wcUri,
       wcError: Boolean(ConnectionController.state.wcError),
-      wcFetchingUri: ConnectionController.state.wcFetchingUri
+      wcFetchingUri: ConnectionController.state.wcFetchingUri,
+      wcPairingExpiry: ConnectionController.state.wcPairingExpiry
     }
   },
 
   /**
-   * Subscribe to WalletConnect URI state changes (wcUri / wcError / wcFetchingUri). The
+   * Subscribe to WalletConnect URI state changes (wcUri / wcError / wcFetchingUri /
+   * wcPairingExpiry). The
    * callback receives no arguments — read the current values with {@link getWalletConnectUri}.
    * Returns an unsubscribe.
    */
@@ -163,7 +175,8 @@ export const HeadlessWalletUtil = {
     const unsubscribers = [
       subKey(ConnectionController.state, 'wcUri', callback),
       subKey(ConnectionController.state, 'wcError', callback),
-      subKey(ConnectionController.state, 'wcFetchingUri', callback)
+      subKey(ConnectionController.state, 'wcFetchingUri', callback),
+      subKey(ConnectionController.state, 'wcPairingExpiry', callback)
     ]
 
     return () => unsubscribers.forEach(unsubscribe => unsubscribe())

--- a/packages/controllers/tests/controllers/ConnectionController.test.ts
+++ b/packages/controllers/tests/controllers/ConnectionController.test.ts
@@ -333,6 +333,20 @@ describe('ConnectionController', () => {
     expect(ConnectionController.state.status).toEqual('disconnected')
   })
 
+  it('should clear a previous wcError when a new connectWalletConnect attempt starts', async () => {
+    /*
+     * Without this, a host with no scaffold-ui (headless) stays in an error state for the rest
+     * of the page's life: nothing else clears `wcError` except a successful mobile deeplink or
+     * the headful "try again" button, so every later attempt still reads as failed.
+     */
+    client.connectWalletConnect = vi.fn().mockResolvedValueOnce(undefined)
+    ConnectionController.state.wcError = true
+
+    await ConnectionController.connectWalletConnect({ cache: 'never' })
+
+    expect(ConnectionController.state.wcError).toEqual(false)
+  })
+
   it('should not set wcError when connectWalletConnect succeeds in cached mode', async () => {
     client.connectWalletConnect = vi.fn().mockResolvedValueOnce(undefined)
     vi.spyOn(CoreHelperUtil, 'isPairingExpired').mockReturnValue(true)

--- a/packages/controllers/tests/utils/HeadlessWalletUtil.test.ts
+++ b/packages/controllers/tests/utils/HeadlessWalletUtil.test.ts
@@ -135,6 +135,7 @@ describe('HeadlessWalletUtil.connect', () => {
       name: 'Some Wallet',
       mobile_link: 'somewallet://'
     } as never)
+    ConnectionController.state.wcUri = 'wc:pairing'
     const onConnectMobile = vi
       .spyOn(ConnectionControllerUtil, 'onConnectMobile')
       .mockImplementation(vi.fn())
@@ -145,6 +146,33 @@ describe('HeadlessWalletUtil.connect', () => {
       expect.objectContaining({ mobile_link: 'somewallet://' }),
       'https://pay/x'
     )
+  })
+
+  it('rejects instead of deeplinking into nothing when the WalletConnect URI is gone', async () => {
+    /*
+     * The state after a disconnect (`resetWcConnection` clears the URI). `onConnectMobile` is a
+     * silent no-op without one, so the host would sit in a connecting state waiting on a wallet
+     * that never opens — it has to learn the attempt failed so it can re-fetch a URI and retry.
+     */
+    vi.spyOn(ConnectorController, 'getConnector').mockReturnValue(undefined as never)
+    vi.spyOn(CoreHelperUtil, 'isMobile').mockReturnValue(true)
+    vi.spyOn(ConnectUtil, 'mapWalletItemToWcWallet').mockReturnValue({
+      id: 'wc_wallet',
+      name: 'Some Wallet',
+      mobile_link: 'somewallet://'
+    } as never)
+    ConnectionController.state.wcUri = undefined
+    const onConnectMobile = vi
+      .spyOn(ConnectionControllerUtil, 'onConnectMobile')
+      .mockImplementation(vi.fn())
+
+    await expect(HeadlessWalletUtil.connect(apiWallet, 'eip155')).rejects.toThrow(
+      'No WalletConnect URI available'
+    )
+
+    expect(onConnectMobile).not.toHaveBeenCalled()
+    // The spinner must not outlive the failed attempt.
+    expect(PublicStateController.set).toHaveBeenCalledWith({ connectingWallet: undefined })
   })
 
   it('redirects via MobileWalletUtil on mobile when there is no mobile link', async () => {

--- a/packages/controllers/tests/utils/HeadlessWalletUtil.test.ts
+++ b/packages/controllers/tests/utils/HeadlessWalletUtil.test.ts
@@ -243,15 +243,17 @@ describe('HeadlessWalletUtil.prefetchWalletConnectUri', () => {
 })
 
 describe('HeadlessWalletUtil.getWalletConnectUri', () => {
-  it('reads wcUri / wcError / wcFetchingUri from the connection layer', () => {
+  it('reads wcUri / wcError / wcFetchingUri / wcPairingExpiry from the connection layer', () => {
     ConnectionController.state.wcUri = 'wc:read-test'
     ConnectionController.state.wcError = true
     ConnectionController.state.wcFetchingUri = false
+    ConnectionController.state.wcPairingExpiry = 1_700_000_000_000
 
     expect(HeadlessWalletUtil.getWalletConnectUri()).toEqual({
       wcUri: 'wc:read-test',
       wcError: true,
-      wcFetchingUri: false
+      wcFetchingUri: false,
+      wcPairingExpiry: 1_700_000_000_000
     })
   })
 
@@ -259,17 +261,35 @@ describe('HeadlessWalletUtil.getWalletConnectUri', () => {
     ConnectionController.state.wcUri = undefined
     ConnectionController.state.wcError = undefined
     ConnectionController.state.wcFetchingUri = true
+    ConnectionController.state.wcPairingExpiry = undefined
 
     expect(HeadlessWalletUtil.getWalletConnectUri()).toEqual({
       wcUri: undefined,
       wcError: false,
-      wcFetchingUri: true
+      wcFetchingUri: true,
+      wcPairingExpiry: undefined
     })
+  })
+
+  /*
+   * The reason the field is exposed at all: a host that consumes the URI later than it fetched
+   * it (a picker whose deeplink fires on a second, user-paced click) otherwise cannot tell a
+   * fresh URI from one whose pairing has lapsed — every other field reads identically.
+   */
+  it('surfaces the expiry stamped by setUri so a stale pairing is detectable', () => {
+    ConnectionController.state.wcPairingExpiry = undefined
+    ConnectionController.setUri('wc:fresh')
+
+    const { wcUri, wcPairingExpiry } = HeadlessWalletUtil.getWalletConnectUri()
+
+    expect(wcUri).toBe('wc:fresh')
+    expect(wcPairingExpiry).toBeGreaterThan(Date.now())
+    expect(CoreHelperUtil.isPairingExpired(wcPairingExpiry)).toBe(false)
   })
 })
 
 describe('HeadlessWalletUtil.subscribeWalletConnectUri', () => {
-  it('fires on wcUri / wcError / wcFetchingUri changes and unsubscribes cleanly', async () => {
+  it('fires on wcUri / wcError / wcFetchingUri / wcPairingExpiry changes and unsubscribes cleanly', async () => {
     const flush = () => new Promise(resolve => setTimeout(resolve, 0))
     const callback = vi.fn()
 
@@ -287,10 +307,14 @@ describe('HeadlessWalletUtil.subscribeWalletConnectUri', () => {
     await flush()
     expect(callback).toHaveBeenCalledTimes(2)
 
+    ConnectionController.state.wcPairingExpiry = Date.now() + 60_000
+    await flush()
+    expect(callback).toHaveBeenCalledTimes(3)
+
     unsubscribe()
     ConnectionController.state.wcUri = 'wc:after-unsub'
     await flush()
-    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenCalledTimes(3)
   })
 })
 


### PR DESCRIPTION
## Problem

On a headless host (AppKit with no scaffold-ui — e.g. WalletConnect Pay's Buyer Experience), connecting a wallet after disconnecting a previous one leaves the page unusable until a reload: taps open nothing, and every subsequent attempt surfaces a connection error. Reported as [WCPBX-1014](https://linear.app/reown/issue/WCPBX-1014/switching-wallets-after-disconnect-leaves-wallet-connection-broken).

Two gaps, both unreachable in headful mode (`w3m-connecting-wc-mobile` only fires `onConnect` once it has a URI, and its "try again" clears the error):

1. **`wcError` is sticky.** It is set in `connectWalletConnect`'s catch, but cleared only by a successful mobile deeplink (`onConnectMobile`) or the headful "try again" button. A headless host that hit one error reads as failed for the rest of the page's life.
2. **A mobile deeplink with no URI fails silently.** `ConnectionControllerUtil.onConnectMobile` is a no-op when `wcUri` is missing — which is exactly the state a disconnect leaves behind (`resetWcConnection` clears the URI). `connectWallet()` resolved as though a wallet had been opened, so the host sat in a connecting state waiting on a redirect that never fires.

## Change

- `ConnectionController.connectWalletConnect` clears `wcError` when a new attempt starts (same thing headful's "try again" does manually).
- New `ConnectionControllerUtil.assertWcUriForDeeplink()`, called by both headless connect paths (`HeadlessWalletUtil.connect` and `useAppKitWallets`' `connect`) before the mobile deeplink branch. The attempt now rejects — which also clears `connectingWallet` via the existing catch — so the host can pre-fetch a URI and retry. It cannot be fetched here: the redirect has to happen inside the tap (iOS Safari blocks one issued after an await).

Deliberately not changed: `resetWcConnection` does **not** clear `wcError`, because `w3m-connecting-wc-view` sets the error and then calls `resetWcConnection` — clearing it there would wipe the headful error UI.

## Tests

- `connectWalletConnect` clears a previous `wcError` on a new attempt.
- `HeadlessWalletUtil.connect` rejects and clears `connectingWallet` when the URI is gone, without calling `onConnectMobile`.
- Existing mobile-deeplink test now sets a URI (it relied on the silent no-op).

`packages/controllers` + `packages/scaffold-ui` suites pass; the 5 failing files on this branch (`w3m-connecting-wc-mobile` universal-link href, `ChainController`, and three localStorage/OTP view files) fail identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)