### PR TITLE
fix(controllers): scope one-click auth chains to the connector's namespace

### DIFF
--- a/.changeset/wc-one-click-auth-namespace-scope.md
+++ b/.changeset/wc-one-click-auth-namespace-scope.md
@@ -1,0 +1,7 @@
+---
+'@reown/appkit-controllers': patch
+---
+
+Fixed WalletConnect one-click auth being silently skipped whenever more than one chain namespace is registered.
+
+`WalletConnectConnector.authenticate()` passed `this.chains` — which resolves to every registered namespace rather than the connector's own — to `SIWXUtil.universalProviderAuthenticate`, which only proceeds for a single `eip155` namespace. Any app registering a second namespace alongside EVM (for example Solana) therefore lost one-click auth for every wallet and fell back to connecting first and requesting a separate `personal_sign`. The chain list is now scoped to the connector's own namespace.

--- a/packages/controllers/src/controllers/AdapterController/WalletConnectConnector.ts
+++ b/packages/controllers/src/controllers/AdapterController/WalletConnectConnector.ts
@@ -56,7 +56,13 @@ export class WalletConnectConnector<Namespace extends ChainNamespace = ChainName
   }
 
   async authenticate(): Promise<boolean> {
-    const chains = this.chains.map(network => network.caipNetworkId)
+    /*
+     * Scope to this connector's own namespace. `this.chains` resolves to every registered
+     * namespace, while `SIWXUtil.universalProviderAuthenticate` only proceeds for a single
+     * `eip155` namespace — so passing the unscoped list silently disabled one-click auth for
+     * every wallet as soon as a second namespace (e.g. Solana) was registered.
+     */
+    const chains = this.getCaipNetworks(this.chain).map(network => network.caipNetworkId)
 
     return SIWXUtil.universalProviderAuthenticate({
       universalProvider: this.provider,

--- a/packages/controllers/tests/controllers/WalletConnectConnector.test.ts
+++ b/packages/controllers/tests/controllers/WalletConnectConnector.test.ts
@@ -1,0 +1,73 @@
+import type UniversalProvider from '@walletconnect/universal-provider'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ChainController, SIWXUtil } from '../../exports/index.js'
+import { extendedMainnet, solanaCaipNetwork, updateChainsMap } from '../../exports/testing.js'
+import { WalletConnectConnector } from '../../src/controllers/AdapterController/WalletConnectConnector.js'
+
+const mockProvider = {
+  client: { core: { crypto: { getClientId: vi.fn().mockResolvedValue('client-id') } } },
+  session: undefined
+} as unknown as UniversalProvider
+
+describe('WalletConnectConnector', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    updateChainsMap('eip155', {
+      namespace: 'eip155',
+      networkState: { requestedCaipNetworks: [extendedMainnet] }
+    })
+    updateChainsMap('solana', {
+      namespace: 'solana',
+      networkState: { requestedCaipNetworks: [solanaCaipNetwork] }
+    })
+  })
+
+  afterEach(() => {
+    ChainController.state.chains.delete('eip155')
+    ChainController.state.chains.delete('solana')
+  })
+
+  describe('authenticate', () => {
+    it('should only pass its own namespace chains when several namespaces are registered', async () => {
+      const authenticateSpy = vi
+        .spyOn(SIWXUtil, 'universalProviderAuthenticate')
+        .mockResolvedValue(true)
+
+      const connector = new WalletConnectConnector({
+        provider: mockProvider,
+        caipNetworks: [extendedMainnet, solanaCaipNetwork],
+        namespace: 'eip155'
+      })
+
+      await expect(connector.authenticate()).resolves.toBe(true)
+
+      /*
+       * `universalProviderAuthenticate` bails unless every chain shares the `eip155` namespace,
+       * so leaking the Solana network here would silently disable one-click auth.
+       */
+      expect(authenticateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ chains: ['eip155:1'] })
+      )
+    })
+
+    it('should pass its own namespace chains for a non-eip155 connector', async () => {
+      const authenticateSpy = vi
+        .spyOn(SIWXUtil, 'universalProviderAuthenticate')
+        .mockResolvedValue(false)
+
+      const connector = new WalletConnectConnector({
+        provider: mockProvider,
+        caipNetworks: [extendedMainnet, solanaCaipNetwork],
+        namespace: 'solana'
+      })
+
+      await expect(connector.authenticate()).resolves.toBe(false)
+
+      expect(authenticateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ chains: [solanaCaipNetwork.caipNetworkId] })
+      )
+    })
+  })
+})


### PR DESCRIPTION
# Description

WalletConnect one-click auth was silently skipped for **every** wallet as soon as a second chain namespace was registered.

`WalletConnectConnector.authenticate()` passed `this.chains` to `SIWXUtil.universalProviderAuthenticate`. That getter resolves to `ChainController.getCaipNetworks()` with no namespace argument — i.e. `getAllRequestedCaipNetworks()`, every registered namespace — even though the connector is constructed per namespace and already stores it as `this.chain`:

```ts
constructor({ provider, namespace }: WalletConnectConnector.Options<Namespace>) {
  this.caipNetworks = this.getCaipNetworks()
  this.provider = provider
  this.chain = namespace          // ← the namespace is right here
}

get chains() {
  return this.getCaipNetworks()   // ← but this returns all of them
}
```

`universalProviderAuthenticate` then bails early (`SIWXUtil.ts:391`):

```ts
const namespaces = new Set(chains.map(chain => chain.split(':')[0] as ChainNamespace))

if (!siwx || namespaces.size !== 1 || !namespaces.has('eip155')) {
  return false
}
```

So an app registering, say, Solana alongside EVM produced `{eip155, solana}` → size 2 → `authenticate()` returned `false`, and `connectWalletConnect()` fell back to `provider.connect()` plus a separate `personal_sign` round trip on every login. That fallback is markedly less reliable on mobile wallets — it reproduces as "Error signing message" on Trust Wallet mobile, where one-click auth would otherwise be used and works.

`getCaipNetworks()` already accepts a namespace, so this passes `this.chain`.

**Single-namespace apps are unaffected** — the set was already size 1, so the value is identical.

### Why `authenticate()` and not the `chains` getter

`chains` is part of the public `ChainAdapterConnector` surface, and the bitcoin, tron and ton adapters read `connector.chains[0]`, so narrowing it deserves its own change. Two things worth noting for a follow-up:

- `TonWalletConnectConnector` and `TronWalletConnectConnector` already `override get chains()` to scope by namespace, which suggests namespace-scoping is the intended semantics of the base getter and the eip155/solana connectors simply never got it.
- With the unscoped getter, `connector.chains[0]` on a non-EVM connector can currently return a network from a different namespace.

Also unused but not touched here: `WalletConnectConnector.Options.caipNetworks` is accepted by the constructor and then discarded in favour of `this.getCaipNetworks()`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

None filed — found while debugging a multi-namespace (EVM + Solana) app with SIWX, and independently reproduced on SIWX in the laboratory app.

# Showcase (Optional)

Effect on a hub registering 11 EVM chains plus Solana with `siwx` and `required: true`:

| connector | chains passed to `universalProviderAuthenticate` | one-click auth |
|---|---|---|
| `eip155` — before | 12 chains, `{eip155, solana}` | not offered |
| `eip155` — after | 11 chains, `{eip155}` | **offered** |
| `solana` — after | 1 chain, `{solana}` | correctly declines (EIP-4361 is EVM-only) |

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

## Test notes

New `packages/controllers/tests/controllers/WalletConnectConnector.test.ts` covers an eip155 and a non-eip155 connector while two namespaces are registered. Confirmed it is a real regression test — both cases fail on `main` and pass with the fix.

`packages/controllers`: 49/50 test files pass. The one failure, `tests/features/ReownAuthentication.test.ts` (25 tests), fails identically on unmodified `main` in my environment — it expects a populated `projectId` in request URLs — so it is pre-existing and unrelated.

Not run locally: `eslint` crashes in a `node:fs` callback on my machine regardless of heap size, and `tsc --noEmit` in `packages/controllers` reports 7 pre-existing `ChainNamespace`/`tron` errors from a stale local `appkit-common` build. Neither implicates the changed files (0 errors reference them); leaving both to CI.

I have not been able to verify the Trust Wallet mobile flow end-to-end against a preview build — happy to if someone can point me at one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)