### PR TITLE
fix(siwx): preserve multichain signing context

### DIFF
--- a/.changeset/siwx-signing-context.md
+++ b/.changeset/siwx-signing-context.md
@@ -1,0 +1,10 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-siwx': patch
+---
+
+Preserve the SIWX signing context in multichain sessions.
+
+SIWX now keeps the chain, account, and connector captured when the message is created through the
+entire signing request instead of re-reading mutable AppKit state.

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -37,6 +37,7 @@ import type {
   RouterControllerState,
   SIWXConfig,
   SendTransactionArgs,
+  SignMessageContext,
   SocialProvider,
   ThemeControllerState,
   UseAppKitAccountReturn,
@@ -730,9 +731,12 @@ export abstract class AppKitBaseClient {
 
         return ids.some(id => Boolean(window.ethereum?.[String(id)]))
       },
-      signMessage: async (message: string) => {
-        const namespace = ChainController.state.activeChain
-        const adapter = this.getAdapter(ChainController.state.activeChain)
+      signMessage: async (message: string, context?: SignMessageContext) => {
+        const contextNamespace = context
+          ? ParseUtil.parseCaipNetworkId(context.chainId).chainNamespace
+          : undefined
+        const namespace = contextNamespace || ChainController.state.activeChain
+        const adapter = this.getAdapter(namespace)
 
         if (!namespace) {
           throw new Error('signMessage: namespace not found')
@@ -742,16 +746,35 @@ export abstract class AppKitBaseClient {
           throw new Error('signMessage: adapter not found')
         }
 
-        const address = this.getAddress(namespace)
+        const caipNetwork = context
+          ? ChainController.getCaipNetworkById(context.chainId, namespace)
+          : this.getCaipNetwork(namespace)
+
+        if (!caipNetwork) {
+          throw new Error('signMessage: network not found')
+        }
+
+        const address = context?.accountAddress || this.getAddress(namespace)
 
         if (!address) {
           throw new Error('signMessage: address not found')
         }
 
-        const result = await adapter?.signMessage({
+        const activeConnectorId = ConnectorController.getConnectorId(namespace)
+        if (
+          context?.connectorId &&
+          activeConnectorId &&
+          context.connectorId !== activeConnectorId
+        ) {
+          throw new Error('signMessage: connector changed before the request was sent')
+        }
+
+        const result = await adapter.signMessage({
           message,
           address,
-          provider: ProviderController.getProvider(namespace)
+          provider: ProviderController.getProvider(namespace),
+          caipNetwork,
+          connectorId: context?.connectorId || activeConnectorId
         })
 
         return result?.signature || ''

--- a/packages/appkit/tests/client/sign-message.test.ts
+++ b/packages/appkit/tests/client/sign-message.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ConstantsUtil } from '@reown/appkit-common'
+import {
+  ChainController,
+  ConnectorController,
+  ProviderController,
+  type SignMessageContext
+} from '@reown/appkit-controllers'
+import { mockChainControllerState } from '@reown/appkit-controllers/testing'
+
+import { AppKitBaseClient } from '../../src/client/appkit-base-client.js'
+import { mockEvmAdapter } from '../mocks/Adapter.js'
+import { mainnet, solana } from '../mocks/Networks.js'
+import { mockOptions } from '../mocks/Options.js'
+import {
+  mockBlockchainApiController,
+  mockStorageUtil,
+  mockWindowAndDocument
+} from '../test-utils.js'
+
+class TestAppKit extends AppKitBaseClient {
+  protected async injectModalUi(): Promise<void> {}
+  public async syncIdentity(): Promise<void> {}
+
+  public get testConnectionControllerClient() {
+    return this.connectionControllerClient
+  }
+}
+
+describe('AppKit message signing', () => {
+  let appKit: TestAppKit
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    mockWindowAndDocument()
+    mockStorageUtil()
+    mockBlockchainApiController()
+
+    appKit = new TestAppKit(mockOptions)
+  })
+
+  it('uses the captured SIWX chain and account when the active namespace changes', async () => {
+    const provider = { request: vi.fn() }
+    const context: SignMessageContext = {
+      chainId: mainnet.caipNetworkId,
+      accountAddress: '0x1234567890123456789012345678901234567890',
+      connectorId: 'walletConnect'
+    }
+
+    mockChainControllerState({
+      activeChain: ConstantsUtil.CHAIN.SOLANA,
+      activeCaipNetwork: solana
+    })
+    vi.spyOn(ChainController, 'getCaipNetworkById').mockReturnValue(mainnet)
+    vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('walletConnect')
+    vi.spyOn(ProviderController, 'getProvider').mockReturnValue(provider)
+    vi.spyOn(mockEvmAdapter, 'signMessage').mockResolvedValue({ signature: '0xsignature' })
+
+    const result = await appKit.testConnectionControllerClient?.signMessage('Sign in', context)
+
+    expect(ProviderController.getProvider).toHaveBeenCalledWith(ConstantsUtil.CHAIN.EVM)
+    expect(mockEvmAdapter.signMessage).toHaveBeenCalledWith({
+      message: 'Sign in',
+      address: context.accountAddress,
+      provider,
+      caipNetwork: mainnet,
+      connectorId: context.connectorId
+    })
+    expect(result).toBe('0xsignature')
+  })
+
+  it('stops signing if the captured connector has changed', async () => {
+    const context: SignMessageContext = {
+      chainId: mainnet.caipNetworkId,
+      accountAddress: '0x1234567890123456789012345678901234567890',
+      connectorId: 'walletConnect'
+    }
+
+    vi.spyOn(ChainController, 'getCaipNetworkById').mockReturnValue(mainnet)
+    vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('injected')
+
+    await expect(
+      appKit.testConnectionControllerClient?.signMessage('Sign in', context)
+    ).rejects.toThrow('signMessage: connector changed before the request was sent')
+    expect(mockEvmAdapter.signMessage).not.toHaveBeenCalled()
+  })
+})

--- a/packages/appkit/tests/mocks/Adapter.ts
+++ b/packages/appkit/tests/mocks/Adapter.ts
@@ -76,6 +76,7 @@ export const mockEvmAdapter = {
   getBalance: vi.fn().mockResolvedValue({ balance: '1.00', symbol: 'ETH' }),
   getWalletConnectProvider: vi.fn().mockResolvedValue(mockProvider),
   estimateGas: vi.fn().mockResolvedValue({ gas: 21000n }),
+  signMessage: vi.fn(),
   on: emitter.on.bind(emitter),
   off: emitter.off.bind(emitter),
   emit: emitter.emit.bind(emitter),

--- a/packages/controllers/exports/index.ts
+++ b/packages/controllers/exports/index.ts
@@ -36,7 +36,8 @@ export { ConnectionController } from '../src/controllers/ConnectionController.js
 export { ConnectionControllerUtil } from '../src/utils/ConnectionControllerUtil.js'
 export type {
   ConnectionControllerClient,
-  ConnectionControllerState
+  ConnectionControllerState,
+  SignMessageContext
 } from '../src/controllers/ConnectionController.js'
 export type { ConnectExternalOptions } from '../src/controllers/ConnectionController.js'
 

--- a/packages/controllers/src/controllers/AdapterController/ChainAdapterBlueprint.ts
+++ b/packages/controllers/src/controllers/AdapterController/ChainAdapterBlueprint.ts
@@ -832,6 +832,8 @@ export namespace AdapterBlueprint {
     message: string
     address: string
     provider?: AppKitConnector['provider']
+    caipNetwork?: CaipNetwork
+    connectorId?: string
   }
 
   export type SignMessageResult = {

--- a/packages/controllers/src/controllers/ConnectionController.ts
+++ b/packages/controllers/src/controllers/ConnectionController.ts
@@ -5,6 +5,7 @@ import { subscribeKey as subKey } from 'valtio/vanilla/utils'
 import {
   type CaipAddress,
   type CaipNetwork,
+  type CaipNetworkId,
   type ChainNamespace,
   ConstantsUtil as CommonConstantsUtil,
   type Connection,
@@ -95,6 +96,12 @@ export interface DisconnectParameters {
   initialDisconnect?: boolean
 }
 
+export interface SignMessageContext {
+  accountAddress: string
+  chainId: CaipNetworkId
+  connectorId?: string
+}
+
 interface DisconnectConnectorParameters {
   id: string
   namespace: ChainNamespace
@@ -108,7 +115,7 @@ export interface ConnectionControllerClient {
   connectWalletConnect?: (params?: ConnectWalletConnectParameters) => Promise<void>
   disconnect: (params?: DisconnectParameters) => Promise<void>
   disconnectConnector: (params: DisconnectConnectorParameters) => Promise<void>
-  signMessage: (message: string) => Promise<string>
+  signMessage: (message: string, context?: SignMessageContext) => Promise<string>
   sendTransaction: (args: SendTransactionArgs) => Promise<string | null>
   estimateGas: (args: EstimateGasTransactionArgs) => Promise<bigint>
   parseUnits: (value: string, decimals: number) => bigint
@@ -337,8 +344,8 @@ const controller = {
     })
   },
 
-  async signMessage(message: string) {
-    return ConnectionController._getClient()?.signMessage(message)
+  async signMessage(message: string, context?: SignMessageContext) {
+    return ConnectionController._getClient()?.signMessage(message, context)
   },
 
   parseUnits(value: string, decimals: number) {

--- a/packages/controllers/src/utils/SIWXUtil.ts
+++ b/packages/controllers/src/utils/SIWXUtil.ts
@@ -116,6 +116,8 @@ export const SIWXUtil = {
       throw new Error('No ActiveCaipNetwork or client found')
     }
 
+    const connectorId = ConnectorController.getConnectorId(network.chainNamespace)
+
     try {
       const siwxMessage = await siwx.createMessage({
         chainId: network.caipNetworkId,
@@ -129,14 +131,19 @@ export const SIWXUtil = {
         signature = await siwx.signMessage({
           message,
           chainId: network.caipNetworkId,
-          accountAddress: address
+          accountAddress: address,
+          connectorId
         })
       } else {
-        const connectorId = ConnectorController.getConnectorId(network.chainNamespace)
         if (connectorId === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
           RouterController.pushTransactionStack({})
         }
-        signature = (await ConnectionController.signMessage(message)) || ''
+        signature =
+          (await ConnectionController.signMessage(message, {
+            chainId: network.caipNetworkId,
+            accountAddress: address,
+            connectorId
+          })) || ''
       }
 
       await siwx.addSession({
@@ -169,7 +176,7 @@ export const SIWXUtil = {
       })
 
       // eslint-disable-next-line no-console
-      console.error('SWIXUtil:requestSignMessage', error)
+      console.error('SIWXUtil:requestSignMessage', error)
     }
   },
   async cancelSignMessage() {
@@ -542,11 +549,13 @@ export interface SIWXConfig {
   signMessage?: ({
     message,
     chainId,
-    accountAddress
+    accountAddress,
+    connectorId
   }: {
     message: string
-    chainId: string
+    chainId: CaipNetworkId
     accountAddress: string
+    connectorId?: string
   }) => Promise<string>
 
   /**

--- a/packages/controllers/tests/utils/SIWXUtil.test.ts
+++ b/packages/controllers/tests/utils/SIWXUtil.test.ts
@@ -1,7 +1,12 @@
 import { ref } from 'valtio/vanilla'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ChainController, type SIWXConfig, SIWXUtil } from '../../exports/index.js'
+import {
+  ChainController,
+  ConnectorController,
+  type SIWXConfig,
+  SIWXUtil
+} from '../../exports/index.js'
 import { extendedMainnet, mockChainControllerState } from '../../exports/testing.js'
 import { ConnectionController } from '../../src/controllers/ConnectionController.js'
 import { EventsController } from '../../src/controllers/EventsController.js'
@@ -19,8 +24,10 @@ describe('SIWXUtil', () => {
       vi.clearAllMocks()
 
       mockChainControllerState({
+        activeChain: 'eip155',
         activeCaipAddress: 'eip155:1:0x1234567890123456789012345678901234567890',
-        activeCaipNetwork: ref(extendedMainnet)
+        activeCaipNetwork: ref(extendedMainnet),
+        chains: new Map([['eip155', { accountState: {} }]])
       })
     })
 
@@ -64,6 +71,51 @@ describe('SIWXUtil', () => {
         }
       })
       expect(getSIWXEventPropertiesSpy).toHaveBeenCalled()
+    })
+
+    it('should pass the immutable signing context to SIWX', async () => {
+      let resolveSignature: ((signature: string) => void) | undefined
+      const signaturePromise = new Promise<string>(resolve => {
+        resolveSignature = resolve
+      })
+      const message = {
+        toString: () => 'Sign in'
+      }
+      const mockSIWX = {
+        createMessage: vi.fn().mockResolvedValue(message),
+        signMessage: vi.fn().mockReturnValue(signaturePromise),
+        addSession: vi.fn().mockResolvedValue(undefined)
+      }
+
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        siwx: mockSIWX as unknown as SIWXConfig
+      })
+      vi.spyOn(CoreHelperUtil, 'getPlainAddress').mockReturnValue(
+        '0x1234567890123456789012345678901234567890'
+      )
+      vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('walletConnect')
+
+      const request = SIWXUtil.requestSignMessage()
+
+      await vi.waitFor(() => expect(mockSIWX.signMessage).toHaveBeenCalledOnce())
+      expect(mockSIWX.signMessage).toHaveBeenCalledWith({
+        message: 'Sign in',
+        chainId: extendedMainnet.caipNetworkId,
+        accountAddress: '0x1234567890123456789012345678901234567890',
+        connectorId: 'walletConnect'
+      })
+
+      resolveSignature?.('0xsignature')
+      await request
+
+      expect(mockSIWX.createMessage).toHaveBeenCalledOnce()
+      expect(mockSIWX.addSession).toHaveBeenCalledOnce()
+      expect(mockSIWX.addSession).toHaveBeenCalledWith({
+        data: message,
+        message: 'Sign in',
+        signature: '0xsignature'
+      })
     })
   })
 

--- a/packages/siwx/src/core/SIWXConfig.ts
+++ b/packages/siwx/src/core/SIWXConfig.ts
@@ -139,13 +139,21 @@ export abstract class SIWXConfig implements SIWXConfigInterface {
   }
 
   public signMessage({
-    message
+    message,
+    chainId,
+    accountAddress,
+    connectorId
   }: {
     message: string
-    chainId: string
+    chainId: CaipNetworkId
     accountAddress: string
+    connectorId?: string
   }): Promise<string> {
-    return this.signer.signMessage(message)
+    return this.signer.signMessage(message, {
+      chainId,
+      accountAddress,
+      connectorId
+    })
   }
 }
 

--- a/packages/siwx/src/core/SIWXSigner.ts
+++ b/packages/siwx/src/core/SIWXSigner.ts
@@ -1,3 +1,5 @@
+import type { SignMessageContext } from '@reown/appkit-controllers'
+
 export abstract class SIWXSigner {
-  public abstract signMessage(message: string): Promise<string>
+  public abstract signMessage(message: string, context?: SignMessageContext): Promise<string>
 }

--- a/packages/siwx/src/signers/DefaultSigner.ts
+++ b/packages/siwx/src/signers/DefaultSigner.ts
@@ -3,32 +3,36 @@ import {
   ChainController,
   ConnectionController,
   ConnectorController,
-  RouterController
+  RouterController,
+  type SignMessageContext
 } from '@reown/appkit-controllers'
 
 import type { SIWXSigner } from '../core/SIWXSigner.js'
 
 export default class DefaultSigner implements SIWXSigner {
-  public async signMessage(message: string): Promise<string> {
+  public async signMessage(message: string, context?: SignMessageContext): Promise<string> {
     const client = ConnectionController._getClient()
 
     if (!client) {
       throw new Error('No ConnectionController client found')
     }
 
-    const network = ChainController.getActiveCaipNetwork()
+    const network = context?.chainId
+      ? ChainController.getCaipNetworkById(context.chainId)
+      : ChainController.getActiveCaipNetwork()
 
     if (!network) {
       throw new Error('No ActiveCaipNetwork or client found')
     }
 
-    const connectorId = ConnectorController.getConnectorId(network.chainNamespace)
+    const connectorId =
+      context?.connectorId || ConnectorController.getConnectorId(network.chainNamespace)
 
     if (connectorId === ConstantsUtil.CONNECTOR_ID.AUTH) {
       RouterController.pushTransactionStack({})
     }
 
-    const signature = await client.signMessage(message)
+    const signature = await client.signMessage(message, context)
 
     return signature
   }

--- a/packages/siwx/tests/core/SIWXConfig.test.ts
+++ b/packages/siwx/tests/core/SIWXConfig.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { SIWXConfig } from '../../src/core/SIWXConfig.js'
+import type { SIWXMessenger } from '../../src/core/SIWXMessenger.js'
+import type { SIWXSigner } from '../../src/core/SIWXSigner.js'
+import type { SIWXStorage } from '../../src/core/SIWXStorage.js'
+
+class TestSIWXConfig extends SIWXConfig {}
+
+describe('SIWXConfig', () => {
+  it('forwards the immutable signing context to its signer', async () => {
+    const signer = {
+      signMessage: vi.fn().mockResolvedValue('0xsignature')
+    } as unknown as SIWXSigner
+    const config = new TestSIWXConfig({
+      messenger: {} as SIWXMessenger,
+      verifiers: [],
+      storage: {} as SIWXStorage,
+      signer
+    })
+    const context = {
+      message: 'Sign in',
+      chainId: 'eip155:1' as const,
+      accountAddress: '0x1234567890123456789012345678901234567890',
+      connectorId: 'walletConnect'
+    }
+
+    await expect(config.signMessage(context)).resolves.toBe('0xsignature')
+    expect(signer.signMessage).toHaveBeenCalledWith(context.message, {
+      chainId: context.chainId,
+      accountAddress: context.accountAddress,
+      connectorId: context.connectorId
+    })
+  })
+})


### PR DESCRIPTION
# Description

Part 1 of the native GitHub stack: **#5730 → #5732 → #5733 → #5734**.

Fix the core SIWX time-of-check/time-of-use race. Message creation captured an account and CAIP
chain, but the default signing path discarded that context and later re-read mutable AppKit state.
In a multichain session, the active namespace could change before the user pressed Sign.

This layer:

- introduces an immutable `SignMessageContext` containing chain, account, and connector
- forwards it through SIWX, the default signer, and the connection controller
- selects the AppKit namespace, adapter, provider, network, and account from that context
- rejects signing if the connector changed after message creation
- tests an EVM SIWX message while the live AppKit namespace has moved to Solana

## Signing sequence

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant SIWX
    participant State as Mutable AppKit state
    participant AppKit
    participant Adapter

    SIWX->>State: Read chain, account, connector once
    State-->>SIWX: eip155:1, 0xAccount, walletConnect
    SIWX->>SIWX: Create message and retain context
    State-->>State: Active namespace may change to Solana
    User->>SIWX: Sign
    SIWX->>AppKit: signMessage(message, capturedContext)
    AppKit->>AppKit: Resolve EVM adapter and provider from eip155:1
    AppKit->>AppKit: Verify walletConnect is still active
    AppKit->>Adapter: Sign with captured network and account
```

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

# Associated Issues

N/A

# Validation

- AppKit, Controllers, and SIWX focused suites: **8 tests pass**
- Focused Prettier check passes

# Checklist

- [x] Code is covered by automated tests
- [x] No unrelated behavior is changed
- [x] A changeset is included
- [x] I have reviewed my own code
