### PR TITLE
feat(bitcoin): correct Trezor signing and derive addresses from one xpub fetch

### DIFF
--- a/.changeset/trezor-network-and-psbt-fixes.md
+++ b/.changeset/trezor-network-and-psbt-fixes.md
@@ -1,0 +1,42 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed Bitcoin WalletConnect connector to properly return all HD wallet data from `getAccountAddresses()`. Previously, the method was dropping `publicKey`, `path`, and `purpose` fields from the response, returning only the address. This fix ensures Ledger and Trezor users get complete account information including all derived addresses, public keys, and derivation paths needed for building PSBTs correctly.
+
+Fixed the Trezor Bitcoin connector so it derives keys for the active network and describes transactions to the device correctly.
+
+- **Active network is now respected.** `TrezorConnector` was constructed without the active CAIP network id, so `currentNetwork` stayed `'Bitcoin'` until `switchNetwork()` was called. A testnet-only dapp received mainnet addresses (`m/84'/0'/…`, `coin: 'btc'`) while reporting a matching chain id, and a funded wallet would have been prompted to sign a **mainnet** transaction. `getWallet()` now accepts `requestedCaipNetworkId` — as `OKXConnector` already did — and an unrecognised bip122 network raises an error instead of silently falling back to mainnet.
+- **OP_RETURN outputs are described properly.** They were emitted as `{ address: '', script_type: 'PAYTOWITNESS' }`, which made any transaction carrying one unsignable. They are now `PAYTOOPRETURN` with `op_return_data`. Undecodable scripts raise an error rather than being sent as an empty address.
+- **Third-party outputs use `PAYTOADDRESS`.** Every output was forced to `PAYTOWITNESS`, which pairs with `address_n` and misdescribes P2SH/P2PKH recipients. Change outputs still use `PAYTOWITNESS` with a derivation path.
+- **`signPSBT` returns `partialSig` instead of a pre-finalized PSBT.** Only `finalScriptWitness` was written and no partial signature, so callers could not finalize the result (`Can not finalize input #0`). This matches every other `BitcoinConnector`.
+- **Input amounts and script types are derived from the PSBT.** The amount came from `witnessUtxo` and silently defaulted to `'0'`, which made the device display a wrong fee; it now also reads `nonWitnessUtxo` and raises an error when neither is present. `script_type` is inferred rather than hardcoded to `SPENDWITNESS`, and derivation paths fall back to the PSBT's `bip32Derivation` before the account default.
+- **`@trezor/connect-web` is imported interop-safely.** The default import resolved to `module.exports` under Node's ESM/CJS interop and esbuild's node-mode — which Vite uses when prebundling the adapter as a dependency — so `TrezorConnect.init` was `undefined` and connecting failed with a `TypeError`. Because the adapter's `connect()` wraps every failure as `UserRejectedRequestError`, this surfaced to users as "User rejected the request".
+
+Also adds `signPSBT` test coverage for the connector, which previously had none.

--- a/.changeset/trezor-xpub-address-derivation.md
+++ b/.changeset/trezor-xpub-address-derivation.md
@@ -1,0 +1,40 @@
+---
+'@reown/appkit-adapter-bitcoin': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+The Trezor Bitcoin connector now asks the device for account extended public keys once and derives every address locally, instead of requesting addresses from the device on each call.
+
+- **One device interaction per account.** `getAccountAddresses()` issued a fresh `getAddress` call every time it ran, and it is invoked by `connect()`, by the adapter's `getAccounts()`, and again on `switchNetwork()`. Restoring a session opened two popups. A single bundled `getPublicKey` call now covers all four accounts, and the result is cached until disconnect or a coin-type change. Concurrent callers share one in-flight request rather than racing two popups.
+- **Legacy, nested SegWit, native SegWit and taproot accounts are all derived** — `m/44'/c'/0'`, `m/49'/c'/0'`, `m/84'/c'/0'` and `m/86'/c'/0'` — each with 20 receive and 20 change addresses. `getDerivedAddresses()` returns the full set and `getAccountDescriptors()` returns the account descriptors. `getAccountAddresses()` is unchanged and still returns the payment and ordinal pair, so no other connector or consumer is affected.
+- **`publicKey` is populated.** It was hardcoded to `undefined`, which left the `signInputs[].publicKey` branch of input-path resolution unable to match anything.
+- **Change on the change chain is recognised.** Only two addresses were known, so real BIP84 change at `.../1/*` was described to the device as a payment to a third party. Change is now matched against every derived address, and the output script type follows the address rather than always being `PAYTOWITNESS`, which misdescribed legacy, nested SegWit and taproot change.
+- **Unknown addresses fail loudly.** `getPathForAddress` ignored its argument and returned the payment path, so signing an address the connector could not place silently used the key at `.../0/0`. It now throws.
+- **Taproot outputs no longer break signing.** Output scripts are decoded with `@trezor/utxo-lib`; `bitcoinjs-lib` throws `No ECC Library provided` for P2TR unless `initEccLib()` has been called, which made any PSBT carrying a taproot output unsignable.
+
+Adds `@trezor/utxo-lib` as a direct dependency. It was already installed as a dependency of `@trezor/connect` at the same version, so this adds no new install weight.

--- a/packages/adapters/bitcoin/package.json
+++ b/packages/adapters/bitcoin/package.json
@@ -33,6 +33,7 @@
     "@reown/appkit-utils": "workspace:*",
     "@reown/appkit-polyfills": "workspace:*",
     "@trezor/connect-web": "9.7.3",
+    "@trezor/utxo-lib": "2.5.0",
     "@wallet-standard/app": "1.1.0",
     "@wallet-standard/base": "1.1.0",
     "@walletconnect/universal-provider": "2.23.7",

--- a/packages/adapters/bitcoin/src/adapter.ts
+++ b/packages/adapters/bitcoin/src/adapter.ts
@@ -211,7 +211,9 @@ export class BitcoinAdapter extends AdapterBlueprint<BitcoinConnector> {
     })
 
     const trezorConnector = TrezorConnector.getWallet({
-      requestedChains: this.networks
+      requestedChains: this.networks,
+      requestedCaipNetworkId: ChainController.getActiveCaipNetwork(ConstantsUtil.CHAIN.BITCOIN)
+        ?.caipNetworkId
     })
     if (trezorConnector) {
       this.addConnector(trezorConnector)

--- a/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
@@ -1,4 +1,10 @@
 import * as TrezorConnectWeb from '@trezor/connect-web'
+import {
+  deriveAddresses,
+  getXpubOrDescriptorInfo,
+  address as trezorAddress,
+  networks as trezorNetworks
+} from '@trezor/utxo-lib'
 import * as btc from 'bitcoinjs-lib'
 
 import { type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
@@ -37,6 +43,59 @@ function describeTrezorFailure(
  * so comparisons need a value of the field's own type.
  */
 const PAYMENT_PURPOSE = AddressPurpose.Payment as BitcoinConnector.AccountAddress['purpose']
+
+/** Script types we derive an account for, in the order they are requested. */
+const SCRIPT_TYPES: readonly TrezorConnectorTypes.BitcoinScriptType[] = [
+  'p2pkh',
+  'p2sh',
+  'p2wpkh',
+  'p2tr'
+] as const
+
+const ADDRESS_CHAINS: readonly TrezorConnectorTypes.AddressChain[] = ['receive', 'change'] as const
+
+/** BIP purpose per script type: BIP44 legacy, BIP49 nested, BIP84 native, BIP86 taproot. */
+const SCRIPT_TYPE_PURPOSES: Record<TrezorConnectorTypes.BitcoinScriptType, number> = {
+  p2pkh: 44,
+  p2sh: 49,
+  p2wpkh: 84,
+  p2tr: 86
+}
+
+const PURPOSE_SCRIPT_TYPES: Record<number, TrezorConnectorTypes.BitcoinScriptType> = {
+  44: 'p2pkh',
+  49: 'p2sh',
+  84: 'p2wpkh',
+  86: 'p2tr'
+}
+
+/** How many indices of each chain are derived per account. Matches the BIP44 gap limit. */
+const ADDRESSES_PER_CHAIN = 20
+
+/**
+ * The output script type the device expects for one of our own addresses. Using
+ * PAYTOWITNESS for everything would misdescribe legacy, nested SegWit and
+ * taproot change back to the user.
+ */
+const OUTPUT_SCRIPT_TYPES: Record<
+  TrezorConnectorTypes.BitcoinScriptType,
+  TrezorConnectorTypes.OutputScriptType
+> = {
+  p2pkh: 'PAYTOADDRESS',
+  p2sh: 'PAYTOP2SHWITNESS',
+  p2wpkh: 'PAYTOWITNESS',
+  p2tr: 'PAYTOTAPROOT'
+}
+
+const INPUT_SCRIPT_TYPES: Record<
+  TrezorConnectorTypes.BitcoinScriptType,
+  TrezorConnectorTypes.InputScriptType
+> = {
+  p2pkh: 'SPENDADDRESS',
+  p2sh: 'SPENDP2SHWITNESS',
+  p2wpkh: 'SPENDWITNESS',
+  p2tr: 'SPENDTAPROOT'
+}
 
 let cachedTrezorConnect: TrezorConnectApi | undefined = undefined
 
@@ -96,13 +155,24 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
   private initialized = false
   private connectedAddresses: BitcoinConnector.AccountAddress[] = []
 
-  // Native SegWit derivation paths (BIP84)
-  private readonly paymentPath = "m/84'/0'/0'/0/0"
-  private readonly ordinalPath = "m/84'/0'/0'/0/1"
+  /** Account-level extended keys, one per script type, for the cached coin. */
+  private accountDescriptors?: TrezorConnectorTypes.AccountDescriptors
 
-  // Testnet paths
-  private readonly testnetPaymentPath = "m/84'/1'/0'/0/0"
-  private readonly testnetOrdinalPath = "m/84'/1'/0'/0/1"
+  /** The coin `accountDescriptors` were fetched for, so a network switch can invalidate them. */
+  private descriptorsCoin?: string
+
+  /**
+   * Shared in-flight fetch. Without it, concurrent callers — the adapter calls
+   * connect() and getAccountAddresses() back to back on session restore — would
+   * each open their own device popup.
+   */
+  private descriptorsPromise?: Promise<TrezorConnectorTypes.AccountDescriptors>
+
+  /** Every address derived from the account descriptors. */
+  private derivedAddresses: TrezorConnectorTypes.DerivedAddress[] = []
+
+  /** Address lookup for path, public key and script type resolution. */
+  private addressMap = new Map<string, TrezorConnectorTypes.DerivedAddress>()
 
   /*
    * Signing requires the previous transaction of each input so the device can
@@ -139,14 +209,19 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     }
   }
 
-  /** Payment path for the active network, never the mainnet constant. */
-  private get activePaymentPath(): string {
-    return this.currentNetwork === 'Testnet' ? this.testnetPaymentPath : this.paymentPath
+  /** Coin type for the active network: 0' on mainnet, 1' on testnet. */
+  private get coinType(): number {
+    return this.currentNetwork === 'Testnet' ? 1 : 0
   }
 
-  /** Ordinal path for the active network. */
-  private get activeOrdinalPath(): string {
-    return this.currentNetwork === 'Testnet' ? this.testnetOrdinalPath : this.ordinalPath
+  /** Payment path for the active network, never the mainnet constant. */
+  private get activePaymentPath(): string {
+    return `m/84'/${this.coinType}'/0'/0/0`
+  }
+
+  /** The account path whose extended key every address of `scriptType` derives from. */
+  private accountPath(scriptType: TrezorConnectorTypes.BitcoinScriptType): string {
+    return `m/${SCRIPT_TYPE_PURPOSES[scriptType]}'/${this.coinType}'/0'`
   }
 
   public get chains() {
@@ -164,7 +239,6 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       throw new Error('No addresses returned from Trezor')
     }
 
-    this.connectedAddresses = addresses
     const paymentAddress = addresses.find(a => a.purpose === PAYMENT_PURPOSE)
 
     if (!paymentAddress) {
@@ -178,35 +252,61 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
 
   public async disconnect(): Promise<void> {
     this.connectedAddresses = []
+    this.clearDerivedState()
     this.emit('disconnect')
 
     return Promise.resolve()
   }
 
   public async getAccountAddresses(): Promise<BitcoinConnector.AccountAddress[]> {
-    await this.initTrezor()
+    await this.ensureDerivedAddresses()
 
-    const bundle = [
-      { path: this.activePaymentPath, showOnTrezor: false, coin: this.getCoinName() },
-      { path: this.activeOrdinalPath, showOnTrezor: false, coin: this.getCoinName() }
+    /*
+     * The adapter collapses whatever comes back to exactly two accounts by
+     * position (BitcoinConstantsUtil.ACCOUNT_INDEXES), so this contract stays
+     * [payment, ordinal] on the BIP84 receive chain. The rest of the derived
+     * matrix is reachable through getDerivedAddresses().
+     */
+    const payment = this.requireDerived('p2wpkh', 'receive', 0)
+    const ordinal = this.requireDerived('p2wpkh', 'receive', 1)
+
+    const addresses: BitcoinConnector.AccountAddress[] = [
+      {
+        address: payment.address,
+        publicKey: payment.publicKey,
+        path: payment.path,
+        purpose: AddressPurpose.Payment
+      },
+      {
+        address: ordinal.address,
+        publicKey: ordinal.publicKey,
+        path: ordinal.path,
+        purpose: AddressPurpose.Ordinal
+      }
     ]
-
-    const result = await getTrezorConnect().getAddress({ bundle })
-
-    if (!result.success) {
-      throw new Error(describeTrezorFailure('Failed to get addresses from Trezor', result.payload))
-    }
-
-    const addresses: BitcoinConnector.AccountAddress[] = result.payload.map((addr, index) => ({
-      address: addr.address,
-      publicKey: undefined,
-      path: addr.serializedPath,
-      purpose: index === 0 ? AddressPurpose.Payment : AddressPurpose.Ordinal
-    }))
 
     this.connectedAddresses = addresses
 
     return addresses
+  }
+
+  /**
+   * Every address derived for this account: each script type, both the receive
+   * and change chains, `ADDRESSES_PER_CHAIN` indices deep. Served from the
+   * xpubs fetched at connect time, so it costs no device interaction.
+   */
+  public async getDerivedAddresses(): Promise<TrezorConnectorTypes.DerivedAddress[]> {
+    await this.ensureDerivedAddresses()
+
+    return [...this.derivedAddresses]
+  }
+
+  /**
+   * The account-level extended public key for each script type. Taproot is an
+   * output descriptor rather than a bare xpub — see AccountDescriptors.
+   */
+  public async getAccountDescriptors(): Promise<TrezorConnectorTypes.AccountDescriptors> {
+    return { ...(await this.ensureDerivedAddresses()) }
   }
 
   public async signMessage(params: BitcoinConnector.SignMessageParams): Promise<string> {
@@ -287,12 +387,14 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       const signInput = params.signInputs.find(si => si.index === i)
       const prevHash = Buffer.from(txInput.hash).reverse().toString('hex')
 
+      const inputPath = this.resolveInputPath(input, signInput)
+
       inputs.push({
-        address_n: this.pathToArray(this.resolveInputPath(input, signInput)),
+        address_n: this.pathToArray(inputPath),
         prev_hash: prevHash,
         prev_index: txInput.index,
         amount: this.getInputAmount(input, txInput.index, i),
-        script_type: this.getInputScriptType(input),
+        script_type: this.getInputScriptType(input, inputPath),
         sequence: txInput.sequence
       })
     }
@@ -307,18 +409,21 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       const opReturnData = TrezorConnector.getOpReturnData(output.script)
 
       if (opReturnData === undefined) {
-        const address = TrezorConnector.decodeOutputAddress(output.script, network)
-        const addressInfo = this.connectedAddresses.find(a => a.address === address)
+        const address = this.decodeOutputAddress(output.script)
+        const derived = this.addressMap.get(address)
 
-        if (addressInfo) {
+        if (derived) {
           /*
-           * Change back to one of our own addresses: identified by derivation
-           * path. Our paths are BIP84, so the output is native SegWit.
+           * One of our own addresses — change, or a send to ourselves. Declaring
+           * it by derivation path is what lets the device recognise it as change
+           * rather than showing the user a third-party recipient. The script
+           * type has to match the address: the change chain of a legacy, nested
+           * SegWit or taproot account is not native SegWit.
            */
           outputs.push({
-            address_n: this.pathToArray(addressInfo.path || this.activePaymentPath),
+            address_n: this.pathToArray(derived.path),
             amount: output.value.toString(),
-            script_type: 'PAYTOWITNESS'
+            script_type: OUTPUT_SCRIPT_TYPES[derived.scriptType]
           })
         } else {
           /*
@@ -419,13 +524,22 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
 
   public async switchNetwork(caipNetworkId: string): Promise<void> {
     const network = this.getNetworkFromCaipId(caipNetworkId)
+    const previousCoin = this.getCoinName()
+
     this.currentNetwork = network
 
     // The new coin needs its own backend before it can be signed for.
     await this.configureBackend()
 
-    // Re-fetch addresses for the new network
-    this.connectedAddresses = await this.getAccountAddresses()
+    /*
+     * A different coin type derives from different account keys, so the cache
+     * cannot be reused and the device has to be consulted again. Switching to
+     * the network already in use costs no device interaction.
+     */
+    if (this.getCoinName() !== previousCoin) {
+      this.clearDerivedState()
+      await this.getAccountAddresses()
+    }
 
     this.emit('chainChanged', caipNetworkId)
   }
@@ -467,6 +581,183 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     this.initialized = true
 
     await this.configureBackend()
+  }
+
+  /**
+   * Fetches the account extended keys once and derives every address from them.
+   * Subsequent calls are served from cache, so the device is consulted a single
+   * time per account rather than once per address request.
+   */
+  private async ensureDerivedAddresses(): Promise<TrezorConnectorTypes.AccountDescriptors> {
+    const coin = this.getCoinName()
+
+    if (this.accountDescriptors && this.descriptorsCoin === coin) {
+      return this.accountDescriptors
+    }
+
+    if (this.descriptorsPromise) {
+      return this.descriptorsPromise
+    }
+
+    this.descriptorsPromise = this.requestAccountDescriptors(coin).finally(() => {
+      this.descriptorsPromise = undefined
+    })
+
+    return this.descriptorsPromise
+  }
+
+  /**
+   * One bundled getPublicKey call covering all four accounts. This is the only
+   * point at which the connector asks the device for key material.
+   */
+  private async requestAccountDescriptors(
+    coin: string
+  ): Promise<TrezorConnectorTypes.AccountDescriptors> {
+    await this.initTrezor()
+
+    const bundle = SCRIPT_TYPES.map(scriptType => ({
+      path: this.accountPath(scriptType),
+      coin,
+      showOnTrezor: false
+    }))
+
+    const result = await getTrezorConnect().getPublicKey({ bundle })
+
+    if (!result.success) {
+      throw new Error(
+        describeTrezorFailure('Failed to get account descriptors from Trezor', result.payload)
+      )
+    }
+
+    const network = this.getDerivationNetwork()
+    const descriptors = {} as TrezorConnectorTypes.AccountDescriptors
+
+    SCRIPT_TYPES.forEach((scriptType, index) => {
+      const node = result.payload[index]
+
+      if (!node) {
+        throw new Error(`Trezor returned no extended public key for the ${scriptType} account`)
+      }
+
+      /*
+       * The xpubSegwit field carries the script-type-specific form — ypub/zpub
+       * for nested and native SegWit, and the tr(...) output descriptor for
+       * taproot — while xpub is always the coin's default format. This is the
+       * same precedence TrezorConnect applies when it builds a descriptor.
+       */
+      const descriptor = node.xpubSegwit ?? node.xpub
+
+      if (!descriptor) {
+        throw new Error(`Trezor returned an empty extended public key for ${scriptType}`)
+      }
+
+      /*
+       * A bare BIP86 xpub carries the same version bytes as a BIP44 one, so a
+       * derivation library reading version bytes alone would silently produce
+       * legacy addresses for a taproot account. Assert the descriptor resolves
+       * to the type we asked for rather than trusting it.
+       */
+      const { paymentType } = getXpubOrDescriptorInfo(descriptor, network)
+
+      if (paymentType !== scriptType) {
+        throw new Error(
+          `Trezor returned a ${paymentType} extended key for the ${scriptType} account ` +
+            `(${this.accountPath(scriptType)}); deriving from it would produce addresses of the ` +
+            'wrong type.'
+        )
+      }
+
+      descriptors[scriptType] = descriptor
+    })
+
+    this.accountDescriptors = descriptors
+    this.descriptorsCoin = coin
+    this.deriveAddressMatrix(descriptors)
+
+    return descriptors
+  }
+
+  /**
+   * Expands the account descriptors into concrete addresses. Purely local: no
+   * device interaction and no network access.
+   */
+  private deriveAddressMatrix(descriptors: TrezorConnectorTypes.AccountDescriptors): void {
+    const network = this.getDerivationNetwork()
+    const derived: TrezorConnectorTypes.DerivedAddress[] = []
+
+    for (const scriptType of SCRIPT_TYPES) {
+      const descriptor = descriptors[scriptType]
+      const { node } = getXpubOrDescriptorInfo(descriptor, network)
+
+      for (const chain of ADDRESS_CHAINS) {
+        const addresses = deriveAddresses(descriptor, chain, 0, ADDRESSES_PER_CHAIN, network)
+
+        /*
+         * Only the address and path come back from deriveAddresses, but
+         * resolveInputPath matches on public key, so the matching keys are
+         * derived alongside them.
+         */
+        const chainNode = node.derive(chain === 'receive' ? 0 : 1)
+
+        addresses.forEach(({ address, path }, index) => {
+          derived.push({
+            address,
+            path,
+            publicKey: Buffer.from(chainNode.derive(index).publicKey).toString('hex'),
+            scriptType,
+            chain,
+            index
+          })
+        })
+      }
+    }
+
+    this.derivedAddresses = derived
+    this.addressMap = new Map(derived.map(entry => [entry.address, entry]))
+  }
+
+  /** The derivation network, from @trezor/utxo-lib rather than bitcoinjs-lib. */
+  private getDerivationNetwork() {
+    return this.currentNetwork === 'Testnet' ? trezorNetworks.testnet : trezorNetworks.bitcoin
+  }
+
+  private requireDerived(
+    scriptType: TrezorConnectorTypes.BitcoinScriptType,
+    chain: TrezorConnectorTypes.AddressChain,
+    index: number
+  ): TrezorConnectorTypes.DerivedAddress {
+    const derived = this.derivedAddresses.find(
+      entry => entry.scriptType === scriptType && entry.chain === chain && entry.index === index
+    )
+
+    if (!derived) {
+      throw new Error(`No derived ${scriptType} ${chain} address at index ${index}`)
+    }
+
+    return derived
+  }
+
+  private clearDerivedState(): void {
+    this.accountDescriptors = undefined
+    this.descriptorsCoin = undefined
+    this.derivedAddresses = []
+    this.addressMap = new Map()
+  }
+
+  /**
+   * The script type a path belongs to, read from its BIP purpose. Returns
+   * undefined for paths that are not one of the four accounts we derive.
+   */
+  private static scriptTypeFromPath(
+    path: string
+  ): TrezorConnectorTypes.BitcoinScriptType | undefined {
+    const purpose = path.split('/')[1]
+
+    if (!purpose) {
+      return undefined
+    }
+
+    return PURPOSE_SCRIPT_TYPES[parseInt(purpose.replace(/['h]$/u, ''), 10)]
   }
 
   /**
@@ -520,29 +811,49 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     }
   }
 
-  private getPathForAddress(_address: string): string {
-    return this.activePaymentPath
+  /**
+   * The derivation path of one of our own addresses. Throws rather than falling
+   * back to the payment path: signing an address we cannot place with the key at
+   * `.../0/0` would produce a signature from the wrong key silently.
+   */
+  private getPathForAddress(address: string): string {
+    const derived = this.addressMap.get(address)
+
+    if (!derived) {
+      throw new Error(
+        `Address ${address} was not derived from this Trezor account, so its derivation path is ` +
+          'unknown.'
+      )
+    }
+
+    return derived.path
   }
 
   /**
-   * The derivation path to sign an input with. Explicit `signInputs` win, then
-   * the PSBT's own `bip32Derivation`, and only then the account's payment path
-   * for the *active* network — never the mainnet constant.
+   * The derivation path to sign an input with. Explicit `signInputs` win and are
+   * resolved against the derived addresses, then the PSBT's own
+   * `bip32Derivation`, and only then the account's payment path for the *active*
+   * network — never the mainnet constant.
    */
   private resolveInputPath(
     input: btc.Psbt['data']['inputs'][number] | undefined,
     signInput: BitcoinConnector.SignPSBTParams['signInputs'][number] | undefined
   ): string {
     if (signInput?.address) {
-      const addressInfo = this.connectedAddresses.find(a => a.address === signInput.address)
-
-      return addressInfo?.path || this.getPathForAddress(signInput.address)
+      return this.getPathForAddress(signInput.address)
     }
 
     if (signInput?.publicKey) {
-      const addressInfo = this.connectedAddresses.find(a => a.publicKey === signInput.publicKey)
+      const derived = this.derivedAddresses.find(entry => entry.publicKey === signInput.publicKey)
 
-      return addressInfo?.path || this.activePaymentPath
+      if (!derived) {
+        throw new Error(
+          `Public key ${signInput.publicKey} was not derived from this Trezor account, so its ` +
+            'derivation path is unknown.'
+        )
+      }
+
+      return derived.path
     }
 
     return input?.bip32Derivation?.[0]?.path || this.activePaymentPath
@@ -593,10 +904,14 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
    * Decodes an output script to an address, failing loudly for scripts we cannot
    * describe to the device. Sending an empty address instead would have the user
    * approve something other than what the caller asked for.
+   *
+   * Uses @trezor/utxo-lib rather than bitcoinjs-lib because the latter throws
+   * "No ECC Library provided" for taproot scripts unless initEccLib() has been
+   * called, which would make any PSBT carrying a P2TR output unsignable.
    */
-  private static decodeOutputAddress(script: Uint8Array, network: btc.Network): string {
+  private decodeOutputAddress(script: Uint8Array): string {
     try {
-      return btc.address.fromOutputScript(Buffer.from(script), network)
+      return trezorAddress.fromOutputScript(Buffer.from(script), this.getDerivationNetwork())
     } catch {
       throw new Error(`Unsupported output script in PSBT: ${Buffer.from(script).toString('hex')}`)
     }
@@ -666,15 +981,31 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
 
   /** Maps the input's script to the spend type the device expects. */
   private getInputScriptType(
-    input: btc.Psbt['data']['inputs'][number] | undefined
+    input: btc.Psbt['data']['inputs'][number] | undefined,
+    path?: string
   ): TrezorConnectorTypes.InputScriptType {
+    /*
+     * Multisig is checked first because a derivation path cannot express it —
+     * the account purpose only describes the single-key case.
+     */
+    if (input?.witnessScript) {
+      return 'SPENDMULTISIG'
+    }
+
+    /*
+     * The path states the account's script type outright, which the script
+     * inspection below can only guess at: a nested SegWit input is
+     * indistinguishable from a native one when the PSBT omits its redeemScript.
+     */
+    const pathScriptType = path ? TrezorConnector.scriptTypeFromPath(path) : undefined
+
+    if (pathScriptType) {
+      return INPUT_SCRIPT_TYPES[pathScriptType]
+    }
+
     if (input?.witnessUtxo) {
       if (input.redeemScript) {
         return 'SPENDP2SHWITNESS'
-      }
-
-      if (input.witnessScript) {
-        return 'SPENDMULTISIG'
       }
 
       const script = Buffer.from(input.witnessUtxo.script)

--- a/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
@@ -1,4 +1,4 @@
-import TrezorConnect from '@trezor/connect-web'
+import * as TrezorConnectWeb from '@trezor/connect-web'
 import * as btc from 'bitcoinjs-lib'
 
 import { type CaipNetwork, ConstantsUtil } from '@reown/appkit-common'
@@ -11,12 +11,83 @@ import { AddressPurpose } from '../../utils/BitcoinConnector.js'
 import { ProviderEventEmitter } from '../../utils/ProviderEventEmitter.js'
 import type { TrezorConnector as TrezorConnectorTypes } from './types.js'
 
+type TrezorConnectApi = typeof TrezorConnectWeb.default
+
+/**
+ * Builds a readable message from a failed TrezorConnect response. The `code` is
+ * often the only part that identifies the cause (a missing previous
+ * transaction, a rejected confirmation, an unreachable backend), so dropping it
+ * leaves callers with nothing to act on.
+ */
+function describeTrezorFailure(
+  fallback: string,
+  payload: { error?: string; code?: string }
+): string {
+  const parts = [payload.error || fallback]
+
+  if (payload.code) {
+    parts.push(`(code: ${payload.code})`)
+  }
+
+  return parts.join(' ')
+}
+
+/**
+ * `AccountAddress.purpose` is a string union rather than the AddressPurpose enum,
+ * so comparisons need a value of the field's own type.
+ */
+const PAYMENT_PURPOSE = AddressPurpose.Payment as BitcoinConnector.AccountAddress['purpose']
+
+let cachedTrezorConnect: TrezorConnectApi | undefined = undefined
+
+/**
+ * `@trezor/connect-web` is CommonJS and exposes its API as `exports.default`,
+ * alongside `export *` named exports.
+ *
+ * Bundlers that honour the `__esModule` marker (webpack, Rollup, and Vite's
+ * source transform) hand that object back as the default import. Node's ESM/CJS
+ * interop does not: there, and under esbuild's node-mode interop — which Vite
+ * uses when it prebundles this package as a dependency — the default import is
+ * the whole `module.exports`, so the API sits one level deeper and
+ * `TrezorConnect.init` is undefined.
+ *
+ * Probing for `init` covers every interop shape instead of assuming one. It is
+ * deliberately lazy so that a bad resolution surfaces when the connector is
+ * used rather than breaking the adapter's module import.
+ */
+function getTrezorConnect(): TrezorConnectApi {
+  if (cachedTrezorConnect) {
+    return cachedTrezorConnect
+  }
+
+  const namespace = TrezorConnectWeb as unknown as {
+    default?: { default?: unknown } & Record<string, unknown>
+  }
+
+  const candidates = [namespace.default?.default, namespace.default, namespace]
+  const resolved = candidates.find(
+    candidate => typeof (candidate as TrezorConnectApi | undefined)?.init === 'function'
+  )
+
+  if (!resolved) {
+    throw new Error(
+      '@trezor/connect-web did not expose an init() method. This usually means the module was ' +
+        'loaded through an interop path that hides its default export.'
+    )
+  }
+
+  cachedTrezorConnect = resolved as TrezorConnectApi
+
+  return cachedTrezorConnect
+}
+
 export class TrezorConnector extends ProviderEventEmitter implements BitcoinConnector {
   public readonly id = 'trezor'
   public readonly name = 'Trezor'
   public readonly chain = 'bip122'
   public readonly type = 'ANNOUNCED'
-  public readonly imageUrl = 'https://pbs.twimg.com/profile_images/1876994745022529536/5FD_cxXO_400x400.jpg'
+  public readonly imageUrl =
+    'https://pbs.twimg.com/profile_images/1876994745022529536/5FD_cxXO_400x400.jpg'
 
   public readonly provider = this
 
@@ -33,9 +104,49 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
   private readonly testnetPaymentPath = "m/84'/1'/0'/0/0"
   private readonly testnetOrdinalPath = "m/84'/1'/0'/0/1"
 
-  constructor({ requestedChains }: TrezorConnectorTypes.ConstructorParams) {
+  /*
+   * Signing requires the previous transaction of each input so the device can
+   * verify the amounts it displays. A PSBT built from witness UTXOs alone does not
+   * carry them, so TrezorConnect fetches them from a blockbook backend — and
+   * without one registered for the active coin, signTransaction fails. These are
+   * Trezor's public instances; override per network to use a self-hosted one.
+   */
+  private static readonly defaultBlockbookUrls: Record<TrezorConnectorTypes.Network, string[]> = {
+    Bitcoin: ['https://btc1.trezor.io'],
+    Testnet: ['https://tbtc1.trezor.io']
+  }
+
+  private readonly blockbookUrls: Record<TrezorConnectorTypes.Network, string[]>
+
+  /** Coins whose backend has already been registered with TrezorConnect. */
+  private readonly configuredBackends = new Set<string>()
+
+  constructor({
+    requestedChains,
+    requestedCaipNetworkId,
+    blockbookUrls
+  }: TrezorConnectorTypes.ConstructorParams) {
     super()
     this.requestedChains = requestedChains
+    this.blockbookUrls = { ...TrezorConnector.defaultBlockbookUrls, ...blockbookUrls }
+
+    /*
+     * Without this the connector stays on 'Bitcoin' until switchNetwork() is
+     * called, so a testnet-only dapp silently receives mainnet addresses.
+     */
+    if (requestedCaipNetworkId) {
+      this.currentNetwork = this.getNetworkFromCaipId(requestedCaipNetworkId)
+    }
+  }
+
+  /** Payment path for the active network, never the mainnet constant. */
+  private get activePaymentPath(): string {
+    return this.currentNetwork === 'Testnet' ? this.testnetPaymentPath : this.paymentPath
+  }
+
+  /** Ordinal path for the active network. */
+  private get activeOrdinalPath(): string {
+    return this.currentNetwork === 'Testnet' ? this.testnetOrdinalPath : this.ordinalPath
   }
 
   public get chains() {
@@ -54,7 +165,7 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     }
 
     this.connectedAddresses = addresses
-    const paymentAddress = addresses.find(a => a.purpose === AddressPurpose.Payment)
+    const paymentAddress = addresses.find(a => a.purpose === PAYMENT_PURPOSE)
 
     if (!paymentAddress) {
       throw new Error('No payment address found')
@@ -68,25 +179,22 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
   public async disconnect(): Promise<void> {
     this.connectedAddresses = []
     this.emit('disconnect')
+
     return Promise.resolve()
   }
 
   public async getAccountAddresses(): Promise<BitcoinConnector.AccountAddress[]> {
     await this.initTrezor()
 
-    const isTestnet = this.currentNetwork === 'Testnet'
-    const paymentPath = isTestnet ? this.testnetPaymentPath : this.paymentPath
-    const ordinalPath = isTestnet ? this.testnetOrdinalPath : this.ordinalPath
-
     const bundle = [
-      { path: paymentPath, showOnTrezor: false, coin: this.getCoinName() },
-      { path: ordinalPath, showOnTrezor: false, coin: this.getCoinName() }
+      { path: this.activePaymentPath, showOnTrezor: false, coin: this.getCoinName() },
+      { path: this.activeOrdinalPath, showOnTrezor: false, coin: this.getCoinName() }
     ]
 
-    const result = await TrezorConnect.getAddress({ bundle })
+    const result = await getTrezorConnect().getAddress({ bundle })
 
     if (!result.success) {
-      throw new Error(result.payload.error || 'Failed to get addresses from Trezor')
+      throw new Error(describeTrezorFailure('Failed to get addresses from Trezor', result.payload))
     }
 
     const addresses: BitcoinConnector.AccountAddress[] = result.payload.map((addr, index) => ({
@@ -115,14 +223,14 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     const addressInfo = this.connectedAddresses.find(a => a.address === params.address)
     const path = addressInfo?.path || this.getPathForAddress(params.address)
 
-    const result = await TrezorConnect.signMessage({
+    const result = await getTrezorConnect().signMessage({
       path,
       message: params.message,
       coin: this.getCoinName()
     })
 
     if (!result.success) {
-      throw new Error(result.payload.error || 'Failed to sign message with Trezor')
+      throw new Error(describeTrezorFailure('Failed to sign message with Trezor', result.payload))
     }
 
     return result.payload.signature
@@ -131,13 +239,13 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
   public async sendTransfer(params: BitcoinConnector.SendTransferParams): Promise<string> {
     await this.initTrezor()
 
-    const paymentAddress = this.connectedAddresses.find(a => a.purpose === AddressPurpose.Payment)
+    const paymentAddress = this.connectedAddresses.find(a => a.purpose === PAYMENT_PURPOSE)
 
     if (!paymentAddress) {
       throw new Error('No payment address available')
     }
 
-    const result = await TrezorConnect.composeTransaction({
+    const result = await getTrezorConnect().composeTransaction({
       outputs: [
         {
           type: 'payment',
@@ -150,7 +258,7 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     })
 
     if (!result.success) {
-      throw new Error(result.payload.error || 'Failed to send transfer with Trezor')
+      throw new Error(describeTrezorFailure('Failed to send transfer with Trezor', result.payload))
     }
 
     return result.payload.txid || ''
@@ -165,11 +273,10 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     const psbt = btc.Psbt.fromBase64(params.psbt, { network })
 
     const inputs: TrezorConnectorTypes.TrezorInput[] = []
-    const outputs: (TrezorConnectorTypes.TrezorOutput | TrezorConnectorTypes.TrezorChangeOutput)[] =
-      []
+    const outputs: TrezorConnectorTypes.AnyTrezorOutput[] = []
 
     // Process inputs
-    for (let i = 0; i < psbt.data.inputs.length; i++) {
+    for (let i = 0; i < psbt.data.inputs.length; i += 1) {
       const input = psbt.data.inputs[i]
       const txInput = psbt.txInputs[i]
 
@@ -178,89 +285,123 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       }
 
       const signInput = params.signInputs.find(si => si.index === i)
-      let path: string
-
-      if (signInput?.address) {
-        const addressInfo = this.connectedAddresses.find(a => a.address === signInput.address)
-        path = addressInfo?.path || this.getPathForAddress(signInput.address)
-      } else if (signInput?.publicKey) {
-        const addressInfo = this.connectedAddresses.find(a => a.publicKey === signInput.publicKey)
-        path = addressInfo?.path || this.paymentPath
-      } else {
-        path = this.paymentPath
-      }
-
       const prevHash = Buffer.from(txInput.hash).reverse().toString('hex')
-      const amount = input?.witnessUtxo?.value?.toString() || '0'
 
       inputs.push({
-        address_n: this.pathToArray(path),
+        address_n: this.pathToArray(this.resolveInputPath(input, signInput)),
         prev_hash: prevHash,
         prev_index: txInput.index,
-        amount,
-        script_type: 'SPENDWITNESS',
+        amount: this.getInputAmount(input, txInput.index, i),
+        script_type: this.getInputScriptType(input),
         sequence: txInput.sequence
       })
     }
 
     // Process outputs
     for (const output of psbt.txOutputs) {
-      try {
-        const address = btc.address.fromOutputScript(output.script, network)
-        const isChange = this.connectedAddresses.some(a => a.address === address)
+      /*
+       * OP_RETURN must be declared explicitly: it has no address, carries its
+       * payload as hex and must have a zero amount. Detect it before attempting
+       * address decoding, which throws for any non-address script.
+       */
+      const opReturnData = TrezorConnector.getOpReturnData(output.script)
 
-        if (isChange) {
-          const addressInfo = this.connectedAddresses.find(a => a.address === address)
+      if (opReturnData === undefined) {
+        const address = TrezorConnector.decodeOutputAddress(output.script, network)
+        const addressInfo = this.connectedAddresses.find(a => a.address === address)
+
+        if (addressInfo) {
+          /*
+           * Change back to one of our own addresses: identified by derivation
+           * path. Our paths are BIP84, so the output is native SegWit.
+           */
           outputs.push({
-            address_n: this.pathToArray(addressInfo?.path || this.paymentPath),
+            address_n: this.pathToArray(addressInfo.path || this.activePaymentPath),
             amount: output.value.toString(),
             script_type: 'PAYTOWITNESS'
           })
         } else {
+          /*
+           * An output addressed to someone else. PAYTOADDRESS is the script type
+           * that pairs with `address`; PAYTOWITNESS pairs with `address_n` and
+           * would misdescribe P2SH/P2PKH recipients such as a peg-in federation.
+           */
           outputs.push({
             address,
             amount: output.value.toString(),
-            script_type: 'PAYTOWITNESS'
+            script_type: 'PAYTOADDRESS'
           })
         }
-      } catch {
-        // If we can't decode the address, treat it as OP_RETURN or other script
+      } else {
         outputs.push({
-          address: '',
-          amount: output.value.toString(),
-          script_type: 'PAYTOWITNESS'
+          op_return_data: opReturnData,
+          amount: '0',
+          script_type: 'PAYTOOPRETURN'
         })
       }
     }
 
-    const result = await TrezorConnect.signTransaction({
-      inputs: inputs as Parameters<typeof TrezorConnect.signTransaction>[0]['inputs'],
-      outputs: outputs as Parameters<typeof TrezorConnect.signTransaction>[0]['outputs'],
+    /*
+     * The device verifies the amount of every input against its previous
+     * transaction. Supplying them from the PSBT keeps signing self-contained; when
+     * they are absent TrezorConnect falls back to fetching them from the blockbook
+     * backend, which requires the backend to serve the same chain as the PSBT.
+     */
+    const refTxs = TrezorConnector.buildRefTxs(psbt)
+
+    const trezorConnect = getTrezorConnect()
+    const result = await trezorConnect.signTransaction({
+      inputs: inputs as Parameters<typeof trezorConnect.signTransaction>[0]['inputs'],
+      outputs: outputs as Parameters<typeof trezorConnect.signTransaction>[0]['outputs'],
+      ...(refTxs.length > 0
+        ? { refTxs: refTxs as Parameters<typeof trezorConnect.signTransaction>[0]['refTxs'] }
+        : {}),
       coin: this.getCoinName(),
       version: psbt.version,
       locktime: psbt.locktime
     })
 
     if (!result.success) {
-      throw new Error(result.payload.error || 'Failed to sign transaction with Trezor')
+      throw new Error(
+        describeTrezorFailure('Failed to sign transaction with Trezor', result.payload)
+      )
     }
 
     // Update PSBT with signatures
     const signedTx = btc.Transaction.fromHex(result.payload.serializedTx)
 
-    // Finalize the PSBT with the signed transaction
-    for (let i = 0; i < psbt.data.inputs.length; i++) {
-      const input = signedTx.ins[i]
-      if (input?.witness && input.witness.length > 0) {
+    /*
+     * Return a *signed* PSBT rather than a finalized one. A P2WPKH witness is
+     * [signature, publicKey], which maps directly onto `partialSig` — the shape
+     * every other BitcoinConnector returns and the one consumers such as
+     * bitcoinjs-lib's finalizeAllInputs() require. Writing only
+     * finalScriptWitness left callers unable to finalize ("Can not finalize
+     * input #0") because no partial signature was present.
+     */
+    for (let i = 0; i < psbt.data.inputs.length; i += 1) {
+      const signedInput = signedTx.ins[i]
+      const witness = signedInput?.witness ?? []
+      const [signature, pubkey] = witness
+
+      if (witness.length === 0) {
+        // Nothing to graft: the device left this input unsigned.
+      } else if (witness.length === 2 && signature?.length && pubkey?.length) {
+        psbt.updateInput(i, { partialSig: [{ pubkey, signature }] })
+      } else {
+        /*
+         * Multisig or script paths we cannot express as a single partialSig:
+         * preserve the device's witness verbatim so the caller keeps a usable
+         * transaction.
+         */
         psbt.updateInput(i, {
-          finalScriptWitness: this.witnessStackToScriptWitness(input.witness)
+          finalScriptWitness: this.witnessStackToScriptWitness(witness)
         })
       }
     }
 
-    let txid: string | undefined
+    let txid: string | undefined = undefined
     if (params.broadcast) {
-      const pushResult = await TrezorConnect.pushTransaction({
+      const pushResult = await getTrezorConnect().pushTransaction({
         tx: result.payload.serializedTx,
         coin: this.getCoinName()
       })
@@ -279,6 +420,9 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
   public async switchNetwork(caipNetworkId: string): Promise<void> {
     const network = this.getNetworkFromCaipId(caipNetworkId)
     this.currentNetwork = network
+
+    // The new coin needs its own backend before it can be signed for.
+    await this.configureBackend()
 
     // Re-fetch addresses for the new network
     this.connectedAddresses = await this.getAccountAddresses()
@@ -310,10 +454,10 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       return
     }
 
-    await TrezorConnect.init({
+    await getTrezorConnect().init({
       manifest: {
         email: 'support@reown.com',
-        appUrl: typeof window !== 'undefined' ? window.location.origin : 'https://reown.com',
+        appUrl: typeof window === 'undefined' ? 'https://reown.com' : window.location.origin,
         appName: 'Reown AppKit'
       },
       lazyLoad: true,
@@ -321,6 +465,36 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     })
 
     this.initialized = true
+
+    await this.configureBackend()
+  }
+
+  /**
+   * Registers the blockbook backend for the active coin so TrezorConnect can
+   * retrieve the previous transactions it needs to verify inputs. Failures are
+   * non-fatal: signing may still succeed when the caller supplies everything the
+   * device needs, and a hard failure here would block connecting entirely.
+   */
+  private async configureBackend(): Promise<void> {
+    const coin = this.getCoinName()
+
+    if (this.configuredBackends.has(coin)) {
+      return
+    }
+
+    const url = this.blockbookUrls[this.currentNetwork]
+
+    if (!url?.length) {
+      return
+    }
+
+    this.configuredBackends.add(coin)
+
+    await getTrezorConnect()
+      .blockchainSetCustomBackend({ coin, blockchainLink: { type: 'blockbook', url } })
+      .catch(() => {
+        this.configuredBackends.delete(coin)
+      })
   }
 
   private getCoinName(): string {
@@ -334,19 +508,187 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       case bitcoinTestnet.caipNetworkId:
         return 'Testnet'
       default:
-        return 'Bitcoin'
+        /*
+         * Never silently fall back to mainnet: doing so would derive mainnet keys
+         * and ask the user to sign a mainnet transaction on an unsupported
+         * network such as signet or regtest.
+         */
+        throw new Error(
+          `Unsupported Bitcoin network for Trezor: ${caipNetworkId}. ` +
+            'Only Bitcoin mainnet and testnet are supported.'
+        )
     }
   }
 
-  private getPathForAddress(address: string): string {
-    const isTestnet = this.currentNetwork === 'Testnet'
+  private getPathForAddress(_address: string): string {
+    return this.activePaymentPath
+  }
 
-    // Default to payment path if we can't determine
-    if (address.startsWith('bc1') || address.startsWith('tb1')) {
-      return isTestnet ? this.testnetPaymentPath : this.paymentPath
+  /**
+   * The derivation path to sign an input with. Explicit `signInputs` win, then
+   * the PSBT's own `bip32Derivation`, and only then the account's payment path
+   * for the *active* network — never the mainnet constant.
+   */
+  private resolveInputPath(
+    input: btc.Psbt['data']['inputs'][number] | undefined,
+    signInput: BitcoinConnector.SignPSBTParams['signInputs'][number] | undefined
+  ): string {
+    if (signInput?.address) {
+      const addressInfo = this.connectedAddresses.find(a => a.address === signInput.address)
+
+      return addressInfo?.path || this.getPathForAddress(signInput.address)
     }
 
-    return isTestnet ? this.testnetPaymentPath : this.paymentPath
+    if (signInput?.publicKey) {
+      const addressInfo = this.connectedAddresses.find(a => a.publicKey === signInput.publicKey)
+
+      return addressInfo?.path || this.activePaymentPath
+    }
+
+    return input?.bip32Derivation?.[0]?.path || this.activePaymentPath
+  }
+
+  /**
+   * Reference transactions for every input that carries its previous transaction
+   * in the PSBT (`nonWitnessUtxo`). Deduplicated by txid, since several inputs can
+   * spend the same parent. Returns an empty array when the PSBT has none, leaving
+   * TrezorConnect to fetch them from the configured backend.
+   */
+  private static buildRefTxs(psbt: btc.Psbt): TrezorConnectorTypes.TrezorRefTransaction[] {
+    const byTxid = new Map<string, TrezorConnectorTypes.TrezorRefTransaction>()
+
+    psbt.data.inputs.forEach(input => {
+      if (!input.nonWitnessUtxo) {
+        return
+      }
+
+      const tx = btc.Transaction.fromBuffer(Buffer.from(input.nonWitnessUtxo))
+      const hash = tx.getId()
+
+      if (byTxid.has(hash)) {
+        return
+      }
+
+      byTxid.set(hash, {
+        hash,
+        version: tx.version,
+        lock_time: tx.locktime,
+        inputs: tx.ins.map(txInput => ({
+          prev_hash: Buffer.from(txInput.hash).reverse().toString('hex'),
+          prev_index: txInput.index,
+          script_sig: Buffer.from(txInput.script).toString('hex'),
+          sequence: txInput.sequence
+        })),
+        bin_outputs: tx.outs.map(txOutput => ({
+          amount: txOutput.value.toString(),
+          script_pubkey: Buffer.from(txOutput.script).toString('hex')
+        }))
+      })
+    })
+
+    return [...byTxid.values()]
+  }
+
+  /**
+   * Decodes an output script to an address, failing loudly for scripts we cannot
+   * describe to the device. Sending an empty address instead would have the user
+   * approve something other than what the caller asked for.
+   */
+  private static decodeOutputAddress(script: Uint8Array, network: btc.Network): string {
+    try {
+      return btc.address.fromOutputScript(Buffer.from(script), network)
+    } catch {
+      throw new Error(`Unsupported output script in PSBT: ${Buffer.from(script).toString('hex')}`)
+    }
+  }
+
+  /**
+   * Returns the OP_RETURN payload as hex, or undefined when the script is not an
+   * OP_RETURN. Multiple pushes are concatenated, matching how the data was laid
+   * out by the caller.
+   */
+  private static getOpReturnData(script: Uint8Array): string | undefined {
+    let chunks: (number | Buffer)[] | null = null
+
+    try {
+      chunks = btc.script.decompile(Buffer.from(script))
+    } catch {
+      return undefined
+    }
+
+    if (!chunks?.length || chunks[0] !== btc.opcodes['OP_RETURN']) {
+      return undefined
+    }
+
+    return chunks
+      .slice(1)
+      .filter((chunk): chunk is Buffer => Buffer.isBuffer(chunk))
+      .map(chunk => chunk.toString('hex'))
+      .join('')
+  }
+
+  /**
+   * The value being spent, which the device needs to compute fees. A PSBT input
+   * carries it either directly (witnessUtxo) or inside the full previous
+   * transaction (nonWitnessUtxo).
+   */
+  private getInputAmount(
+    input: btc.Psbt['data']['inputs'][number] | undefined,
+    prevIndex: number,
+    inputIndex: number
+  ): string {
+    if (input?.witnessUtxo) {
+      return input.witnessUtxo.value.toString()
+    }
+
+    if (input?.nonWitnessUtxo) {
+      const prevTx = btc.Transaction.fromBuffer(Buffer.from(input.nonWitnessUtxo))
+      const prevOut = prevTx.outs[prevIndex]
+
+      if (!prevOut) {
+        throw new Error(
+          `PSBT input ${inputIndex} references output ${prevIndex}, which does not exist`
+        )
+      }
+
+      return prevOut.value.toString()
+    }
+
+    /*
+     * Defaulting to '0' here would make the device compute and display a wrong
+     * fee for a transaction the user is about to approve.
+     */
+    throw new Error(
+      `PSBT input ${inputIndex} has neither witnessUtxo nor nonWitnessUtxo, so its ` +
+        'amount cannot be determined'
+    )
+  }
+
+  /** Maps the input's script to the spend type the device expects. */
+  private getInputScriptType(
+    input: btc.Psbt['data']['inputs'][number] | undefined
+  ): TrezorConnectorTypes.InputScriptType {
+    if (input?.witnessUtxo) {
+      if (input.redeemScript) {
+        return 'SPENDP2SHWITNESS'
+      }
+
+      if (input.witnessScript) {
+        return 'SPENDMULTISIG'
+      }
+
+      const script = Buffer.from(input.witnessUtxo.script)
+
+      // P2TR: OP_1 <32-byte push>
+      if (script.length === 34 && script[0] === btc.opcodes['OP_1'] && script[1] === 0x20) {
+        return 'SPENDTAPROOT'
+      }
+
+      return 'SPENDWITNESS'
+    }
+
+    // No witness UTXO means a legacy (P2PKH) input.
+    return 'SPENDADDRESS'
   }
 
   private pathToArray(path: string): number[] {

--- a/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
+++ b/packages/adapters/bitcoin/src/connectors/TrezorConnector/index.ts
@@ -488,11 +488,30 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
       const witness = signedInput?.witness ?? []
       const [signature, pubkey] = witness
 
-      if (witness.length === 0) {
-        // Nothing to graft: the device left this input unsigned.
-      } else if (witness.length === 2 && signature?.length && pubkey?.length) {
+      /*
+       * A legacy (P2PKH) input has no witness at all: the device puts its
+       * signature in the scriptSig as `<signature> <publicKey>`. Reading only the
+       * witness dropped it silently, leaving the input unsigned and the caller
+       * unable to finalize a transaction the user had already approved.
+       */
+      const legacySig = TrezorConnector.getLegacyPartialSig(signedInput?.script)
+
+      /*
+       * A taproot key-path spend is witnessed by one Schnorr signature — 64
+       * bytes, or 65 when a sighash flag is appended — with no public key
+       * alongside it. Its PSBT home is `tapKeySig`, not `partialSig`; writing it
+       * as a raw witness instead would leave the caller unable to finalize.
+       */
+      const isTaprootKeySig =
+        witness.length === 1 && (signature?.length === 64 || signature?.length === 65)
+
+      if (witness.length === 2 && signature?.length && pubkey?.length) {
         psbt.updateInput(i, { partialSig: [{ pubkey, signature }] })
-      } else {
+      } else if (legacySig) {
+        psbt.updateInput(i, { partialSig: [legacySig] })
+      } else if (isTaprootKeySig && signature) {
+        psbt.updateInput(i, { tapKeySig: signature })
+      } else if (witness.length > 0) {
         /*
          * Multisig or script paths we cannot express as a single partialSig:
          * preserve the device's witness verbatim so the caller keeps a usable
@@ -502,6 +521,10 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
           finalScriptWitness: this.witnessStackToScriptWitness(witness)
         })
       }
+      /*
+       * Anything else means the device left this input unsigned, so there is
+       * nothing to graft.
+       */
     }
 
     let txid: string | undefined = undefined
@@ -857,6 +880,49 @@ export class TrezorConnector extends ProviderEventEmitter implements BitcoinConn
     }
 
     return input?.bip32Derivation?.[0]?.path || this.activePaymentPath
+  }
+
+  /**
+   * The signature of a legacy input, read from its scriptSig.
+   *
+   * A P2PKH scriptSig is exactly `<signature> <publicKey>`, which maps onto
+   * `partialSig` the same way a P2WPKH witness does. Returns undefined for any
+   * other shape — P2SH redeem paths included — so the caller can fall back.
+   */
+  private static getLegacyPartialSig(
+    script: Uint8Array | undefined
+  ): { pubkey: Buffer; signature: Buffer } | undefined {
+    if (!script?.length) {
+      return undefined
+    }
+
+    let chunks: (number | Buffer)[] | null = null
+
+    try {
+      chunks = btc.script.decompile(Buffer.from(script))
+    } catch {
+      return undefined
+    }
+
+    if (chunks?.length !== 2) {
+      return undefined
+    }
+
+    const [signature, pubkey] = chunks
+
+    if (!Buffer.isBuffer(signature) || !Buffer.isBuffer(pubkey)) {
+      return undefined
+    }
+
+    /*
+     * A public key is 33 bytes compressed or 65 uncompressed; anything else means
+     * this is a redeem script or another spend path, not a bare P2PKH.
+     */
+    if (pubkey.length !== 33 && pubkey.length !== 65) {
+      return undefined
+    }
+
+    return { pubkey, signature }
   }
 
   /**

--- a/packages/adapters/bitcoin/src/connectors/TrezorConnector/types.ts
+++ b/packages/adapters/bitcoin/src/connectors/TrezorConnector/types.ts
@@ -1,4 +1,4 @@
-import type { CaipNetwork } from '@reown/appkit-common'
+import type { CaipNetwork, CaipNetworkId } from '@reown/appkit-common'
 
 export namespace TrezorConnector {
   export type Network = 'Bitcoin' | 'Testnet'
@@ -23,13 +23,30 @@ export namespace TrezorConnector {
     | 'PAYTOWITNESS'
     | 'PAYTOP2SHWITNESS'
     | 'PAYTOTAPROOT'
+    | 'PAYTOOPRETURN'
+
+  /**
+   * Blockbook endpoints per network, used by TrezorConnect to fetch the previous
+   * transactions it needs to verify inputs before signing. Override to point at a
+   * self-hosted instance.
+   */
+  export type BlockbookUrls = Partial<Record<Network, string[]>>
 
   export type ConstructorParams = {
     requestedChains: CaipNetwork[]
+    /**
+     * The active bip122 network. Without it the connector cannot know whether to
+     * derive mainnet or testnet paths, and would default to mainnet on a
+     * testnet-only dapp.
+     */
+    requestedCaipNetworkId?: CaipNetworkId
+    blockbookUrls?: BlockbookUrls
   }
 
   export type GetWalletParams = {
     requestedChains: CaipNetwork[]
+    requestedCaipNetworkId?: CaipNetworkId
+    blockbookUrls?: BlockbookUrls
   }
 
   export type TrezorInput = {
@@ -53,9 +70,41 @@ export namespace TrezorConnector {
     script_type: OutputScriptType
   }
 
+  /**
+   * OP_RETURN outputs carry their payload as hex and must have a zero amount;
+   * they have neither an address nor a derivation path.
+   */
+  export type TrezorOpReturnOutput = {
+    op_return_data: string
+    amount: '0'
+    script_type: 'PAYTOOPRETURN'
+  }
+
+  export type AnyTrezorOutput = TrezorOutput | TrezorChangeOutput | TrezorOpReturnOutput
+
+  /**
+   * A previous transaction, supplied so the device can verify input amounts
+   * without consulting a backend.
+   */
+  export type TrezorRefTransaction = {
+    hash: string
+    version: number
+    lock_time: number
+    inputs: {
+      prev_hash: string
+      prev_index: number
+      script_sig: string
+      sequence: number
+    }[]
+    bin_outputs: {
+      amount: string
+      script_pubkey: string
+    }[]
+  }
+
   export type SignTransactionParams = {
     inputs: TrezorInput[]
-    outputs: (TrezorOutput | TrezorChangeOutput)[]
+    outputs: AnyTrezorOutput[]
     coin: string
     version?: number
     locktime?: number

--- a/packages/adapters/bitcoin/src/connectors/TrezorConnector/types.ts
+++ b/packages/adapters/bitcoin/src/connectors/TrezorConnector/types.ts
@@ -3,12 +3,33 @@ import type { CaipNetwork, CaipNetworkId } from '@reown/appkit-common'
 export namespace TrezorConnector {
   export type Network = 'Bitcoin' | 'Testnet'
 
-  export type ScriptType =
-    | 'SPENDADDRESS'
-    | 'SPENDMULTISIG'
-    | 'SPENDWITNESS'
-    | 'SPENDP2SHWITNESS'
-    | 'SPENDTAPROOT'
+  /**
+   * The four account kinds we derive, keyed by their BIP. These match
+   * `@trezor/utxo-lib`'s own `PaymentType`, which is what decides how a
+   * descriptor's public keys are turned into addresses.
+   */
+  export type BitcoinScriptType = 'p2pkh' | 'p2sh' | 'p2wpkh' | 'p2tr'
+
+  /** BIP32 chain: 0 for receive addresses, 1 for change. */
+  export type AddressChain = 'receive' | 'change'
+
+  /**
+   * An account-level extended public key per script type, as returned by
+   * `getPublicKey`. Taproot is an output descriptor (`tr([…]xpub…/<0;1>/*)`)
+   * rather than a bare xpub — a BIP86 xpub carries the same version bytes as a
+   * BIP44 one, so only the descriptor form identifies it as taproot.
+   */
+  export type AccountDescriptors = Record<BitcoinScriptType, string>
+
+  /** A locally derived address, with everything needed to sign for it. */
+  export type DerivedAddress = {
+    address: string
+    path: string
+    publicKey: string
+    scriptType: BitcoinScriptType
+    chain: AddressChain
+    index: number
+  }
 
   export type InputScriptType =
     | 'SPENDADDRESS'
@@ -100,13 +121,5 @@ export namespace TrezorConnector {
       amount: string
       script_pubkey: string
     }[]
-  }
-
-  export type SignTransactionParams = {
-    inputs: TrezorInput[]
-    outputs: AnyTrezorOutput[]
-    coin: string
-    version?: number
-    locktime?: number
   }
 }

--- a/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
@@ -1,3 +1,5 @@
+import TrezorConnect from '@trezor/connect-web'
+import * as btc from 'bitcoinjs-lib'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CoreHelperUtil } from '@reown/appkit-controllers'
@@ -59,7 +61,8 @@ vi.mock('@trezor/connect-web', () => ({
           txid: 'mock_broadcast_txid'
         }
       })
-    )
+    ),
+    blockchainSetCustomBackend: vi.fn(() => Promise.resolve({ success: true, payload: true }))
   }
 }))
 
@@ -218,6 +221,328 @@ describe('TrezorConnector', () => {
       })
 
       expect(result).toBeInstanceOf(TrezorConnector)
+    })
+  })
+
+  describe('active network', () => {
+    it('derives testnet paths when constructed with the testnet CAIP id', async () => {
+      const testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
+      })
+
+      await testnetConnector.getAccountAddresses()
+
+      const { bundle } = vi.mocked(TrezorConnect.getAddress).mock.calls[0]![0] as {
+        bundle: { path: string; coin: string }[]
+      }
+
+      expect(bundle.map(entry => entry.path)).toEqual(["m/84'/1'/0'/0/0", "m/84'/1'/0'/0/1"])
+      expect(bundle.every(entry => entry.coin === 'test')).toBe(true)
+    })
+
+    it('derives mainnet paths when constructed with the mainnet CAIP id', async () => {
+      const mainnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoin.caipNetworkId
+      })
+
+      await mainnetConnector.getAccountAddresses()
+
+      const { bundle } = vi.mocked(TrezorConnect.getAddress).mock.calls[0]![0] as {
+        bundle: { path: string; coin: string }[]
+      }
+
+      expect(bundle[0]!.path).toBe("m/84'/0'/0'/0/0")
+      expect(bundle[0]!.coin).toBe('btc')
+    })
+
+    it('registers the testnet blockbook backend so inputs can be verified', async () => {
+      const testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
+      })
+
+      await testnetConnector.getAccountAddresses()
+
+      expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledWith({
+        coin: 'test',
+        blockchainLink: { type: 'blockbook', url: ['https://tbtc1.trezor.io'] }
+      })
+    })
+
+    it('allows the blockbook endpoint to be overridden', async () => {
+      const testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId,
+        blockbookUrls: { Testnet: ['https://blockbook.internal'] }
+      })
+
+      await testnetConnector.getAccountAddresses()
+
+      expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledWith({
+        coin: 'test',
+        blockchainLink: { type: 'blockbook', url: ['https://blockbook.internal'] }
+      })
+    })
+
+    it('registers the backend only once per coin', async () => {
+      const testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
+      })
+
+      await testnetConnector.getAccountAddresses()
+      await testnetConnector.getAccountAddresses()
+
+      expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledTimes(1)
+    })
+
+    it('still connects when the backend cannot be registered', async () => {
+      vi.mocked(TrezorConnect.blockchainSetCustomBackend).mockRejectedValueOnce(
+        new Error('backend unreachable')
+      )
+
+      const testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
+      })
+
+      await expect(testnetConnector.getAccountAddresses()).resolves.toHaveLength(2)
+    })
+
+    it('refuses an unsupported network rather than falling back to mainnet', () => {
+      expect(
+        () =>
+          new TrezorConnector({
+            requestedChains: [bitcoin, bitcoinTestnet],
+            requestedCaipNetworkId: 'bip122:00000008819873e925422c1ff0f99f7c' as never
+          })
+      ).toThrow('Unsupported Bitcoin network for Trezor')
+    })
+  })
+
+  describe('signPSBT', () => {
+    // Compressed secp256k1 generator point: a structurally valid public key, so
+    // bitcoinjs-lib can build the address and finalize the signed PSBT.
+    const DEVICE_PUBKEY = Buffer.from(
+      '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+      'hex'
+    )
+    // Minimal canonical DER signature (r = s = 1) plus SIGHASH_ALL.
+    const DER_SIGNATURE = Buffer.from('3006020101020101' + '01', 'hex')
+    // Testnet P2SH — the shape of a Rootstock peg-in federation address.
+    const FEDERATION_ADDRESS = '2N2PJEucf6QY2kNFuJ4chQEBoyZWszRQE16'
+    const OP_RETURN_PAYLOAD = Buffer.from('52534b5401' + '11'.repeat(20), 'hex')
+
+    const network = btc.networks.testnet
+    const devicePayment = btc.payments.p2wpkh({ pubkey: DEVICE_PUBKEY, network })
+    const DEVICE_ADDRESS = devicePayment.address!
+    const DEVICE_SCRIPT = devicePayment.output!
+
+    /** A peg-in shaped PSBT: our input, federation output, OP_RETURN, change. */
+    function buildPeginPsbt(): btc.Psbt {
+      const psbt = new btc.Psbt({ network })
+      psbt.setVersion(2)
+      psbt.addInput({
+        hash: Buffer.alloc(32, 7),
+        index: 0,
+        sequence: 0xffffffff,
+        witnessUtxo: { script: DEVICE_SCRIPT, value: 200000 }
+      })
+      psbt.addOutput({
+        script: btc.address.toOutputScript(FEDERATION_ADDRESS, network),
+        value: 100000
+      })
+      psbt.addOutput({
+        script: btc.script.compile([btc.opcodes['OP_RETURN']!, OP_RETURN_PAYLOAD]),
+        value: 0
+      })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 99000 })
+
+      return psbt
+    }
+
+    /** What the device returns: the same transaction carrying a witness. */
+    function buildSignedTxHex(psbt: btc.Psbt): string {
+      const tx = new btc.Transaction()
+      tx.version = 2
+      psbt.txInputs.forEach(input => tx.addInput(input.hash, input.index, input.sequence))
+      psbt.txOutputs.forEach(output => tx.addOutput(output.script, output.value))
+      tx.setWitness(0, [DER_SIGNATURE, DEVICE_PUBKEY])
+
+      return tx.toHex()
+    }
+
+    let testnetConnector: TrezorConnector
+
+    beforeEach(async () => {
+      testnetConnector = new TrezorConnector({
+        requestedChains: [bitcoin, bitcoinTestnet],
+        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
+      })
+
+      vi.mocked(TrezorConnect.getAddress).mockResolvedValueOnce({
+        success: true,
+        payload: [
+          { address: DEVICE_ADDRESS, serializedPath: "m/84'/1'/0'/0/0" },
+          { address: 'tb1qordinal', serializedPath: "m/84'/1'/0'/0/1" }
+        ]
+      } as never)
+
+      await testnetConnector.connect()
+    })
+
+    async function signPeginPsbt() {
+      const psbt = buildPeginPsbt()
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: buildSignedTxHex(psbt) }
+      } as never)
+
+      const response = await testnetConnector.signPSBT({
+        psbt: psbt.toBase64(),
+        signInputs: [],
+        broadcast: false
+      })
+
+      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
+        inputs: Record<string, unknown>[]
+        outputs: Record<string, unknown>[]
+        coin: string
+      }
+
+      return { response, sent }
+    }
+
+    it('describes an OP_RETURN output as PAYTOOPRETURN with its payload', async () => {
+      const { sent } = await signPeginPsbt()
+
+      expect(sent.outputs[1]).toEqual({
+        op_return_data: OP_RETURN_PAYLOAD.toString('hex'),
+        amount: '0',
+        script_type: 'PAYTOOPRETURN'
+      })
+    })
+
+    it('describes a third-party P2SH output as PAYTOADDRESS', async () => {
+      const { sent } = await signPeginPsbt()
+
+      expect(sent.outputs[0]).toEqual({
+        address: FEDERATION_ADDRESS,
+        amount: '100000',
+        script_type: 'PAYTOADDRESS'
+      })
+    })
+
+    it('describes change back to our own address by derivation path', async () => {
+      const { sent } = await signPeginPsbt()
+
+      expect(sent.outputs[2]).toEqual({
+        address_n: [2147483732, 2147483649, 2147483648, 0, 0],
+        amount: '99000',
+        script_type: 'PAYTOWITNESS'
+      })
+    })
+
+    it('signs with the active network path and the real input amount', async () => {
+      const { sent } = await signPeginPsbt()
+
+      expect(sent.coin).toBe('test')
+      expect(sent.inputs[0]).toMatchObject({
+        // m/84'/1'/0'/0/0 — testnet, not the mainnet payment path
+        address_n: [2147483732, 2147483649, 2147483648, 0, 0],
+        amount: '200000',
+        script_type: 'SPENDWITNESS'
+      })
+    })
+
+    it('returns a signed PSBT carrying partialSig, which the caller can finalize', async () => {
+      const { response } = await signPeginPsbt()
+
+      const returned = btc.Psbt.fromBase64(response.psbt, { network })
+      const input = returned.data.inputs[0]!
+
+      expect(input.partialSig).toHaveLength(1)
+      expect(input.partialSig![0]!.pubkey.equals(DEVICE_PUBKEY)).toBe(true)
+      expect(input.partialSig![0]!.signature.equals(DER_SIGNATURE)).toBe(true)
+      expect(input.finalScriptWitness).toBeUndefined()
+
+      // Would previously throw "Can not finalize input #0".
+      expect(() => returned.finalizeAllInputs()).not.toThrow()
+    })
+
+    it('derives the input amount from nonWitnessUtxo when there is no witnessUtxo', async () => {
+      const prevTx = new btc.Transaction()
+      prevTx.version = 2
+      prevTx.addInput(Buffer.alloc(32, 1), 0)
+      prevTx.addOutput(btc.address.toOutputScript(FEDERATION_ADDRESS, network), 123456)
+
+      const psbt = new btc.Psbt({ network })
+      psbt.addInput({ hash: prevTx.getHash(), index: 0, nonWitnessUtxo: prevTx.toBuffer() })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 100000 })
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: buildSignedTxHex(psbt) }
+      } as never)
+
+      await testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
+
+      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
+        inputs: Record<string, unknown>[]
+      }
+
+      expect(sent.inputs[0]).toMatchObject({ amount: '123456', script_type: 'SPENDADDRESS' })
+    })
+
+    it('sends refTxs built from the PSBT so no backend lookup is needed', async () => {
+      // A previous transaction paying our address, carried in the PSBT.
+      const prevTx = new btc.Transaction()
+      prevTx.version = 2
+      prevTx.addInput(Buffer.alloc(32, 3), 0)
+      prevTx.addOutput(DEVICE_SCRIPT, 200000)
+
+      const psbt = new btc.Psbt({ network })
+      psbt.addInput({
+        hash: prevTx.getHash(),
+        index: 0,
+        witnessUtxo: { script: DEVICE_SCRIPT, value: 200000 },
+        nonWitnessUtxo: prevTx.toBuffer()
+      })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 190000 })
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: buildSignedTxHex(psbt) }
+      } as never)
+
+      await testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
+
+      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
+        refTxs?: { hash: string; bin_outputs: { amount: string }[] }[]
+      }
+
+      expect(sent.refTxs).toHaveLength(1)
+      expect(sent.refTxs![0]!.hash).toBe(prevTx.getId())
+      expect(sent.refTxs![0]!.bin_outputs[0]!.amount).toBe('200000')
+    })
+
+    it('omits refTxs when the PSBT does not carry previous transactions', async () => {
+      const { sent } = await signPeginPsbt()
+
+      expect((sent as { refTxs?: unknown }).refTxs).toBeUndefined()
+    })
+
+    it('refuses an input whose amount cannot be determined', async () => {
+      const psbt = new btc.Psbt({ network })
+      psbt.addInput({ hash: Buffer.alloc(32, 7), index: 0 })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 1000 })
+
+      await expect(
+        testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
+      ).rejects.toThrow('neither witnessUtxo nor nonWitnessUtxo')
     })
   })
 })

--- a/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
@@ -1,4 +1,9 @@
 import TrezorConnect from '@trezor/connect-web'
+import {
+  getXpubOrDescriptorInfo,
+  address as trezorAddress,
+  networks as trezorNetworks
+} from '@trezor/utxo-lib'
 import * as btc from 'bitcoinjs-lib'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -8,59 +13,81 @@ import { bitcoin, bitcoinTestnet } from '@reown/appkit/networks'
 import { TrezorConnector } from '../../src/connectors/TrezorConnector'
 import { MethodNotSupportedError } from '../../src/errors/MethodNotSupportedError'
 
-// Mock TrezorConnect
+/*
+ * Account descriptors for a fixed seed, one per script type. Deriving from these
+ * produces the real addresses asserted below, so the tests exercise the actual
+ * derivation rather than a stand-in.
+ *
+ * Taproot is an output descriptor rather than a bare xpub: a BIP86 xpub carries
+ * the same version bytes as a BIP44 one, so only the tr(...) form identifies it.
+ */
+const TESTNET_DESCRIPTORS = {
+  p2pkh:
+    'tpubDCmvdkV6xU5iR6ojqHrX2bXaidnG4mF143VDhqkS4NFjTzVN8idqTpQxtmxzCGnhCjzmEoa3gZpWeZgrC4ZkjRhStPyYZcbkKSmSeSHubr6',
+  p2sh: 'upub5DM9NTt3ZDbgPxNSGAAzAbETrffykGZ7pjP8yFC2X4fhz7x3Yh3THr9HxKXz69hm1xWoV74nQDWXgW1QjCGAmfVxfgdoDYvcZqfN6wqk72Q',
+  p2wpkh:
+    'vpub5YVQaGsAxpzkuMQcWTD1F2q9CuxukAFMoDXGZD2nrRRvV9od2cEjrtMMxCnvXohcRF9x6swm8GwMYQKo1n3CFL3wcZW7CUk6Nfq1x1SRU3D',
+  p2tr: "tr([4ba43603/86'/1'/0']tpubDDbBZ6nxNvbeBeodf2JnUjRqPzQaLZLgV585T2uxFWFX4NLBkxK2hHNMwPxtNoBqbCHwSNci6sgqZzU4h6MydLLw2n9Z2uQhREMzha3YHVH/<0;1>/*)"
+} as const
+
+const MAINNET_DESCRIPTORS = {
+  p2pkh:
+    'xpub6DDeqdmzCpioRhR7fgHQAibbTMNRcPnW1qcYrrtAR5YEAWztVK3G6HuAky6Y3mZzB4UCqVifkXFY2qBUv8rJCHiT1JfoCLtUerZYp653yss',
+  p2sh: 'ypub6XZGfqAJwhqmsvi6iwBJ3fJxRDjkb6wn126YUgQnp3acEkpvbHJuDuevBq9V1UBjCq85P64z6bXyEKsL3Lsf2Zx9U4LaY9TPEp8TxuqDiBv',
+  p2wpkh:
+    'zpub6qvRHJQEqEKSCfb8Lwh1ypCMGoHySB6cixgR91DjtA4Pp6boXFanP2rJE3tU38514x5u8tJEcZRynDpcyM14ETFTucDzwb3Ga4FL36cDWPY',
+  p2tr: "tr([4ba43603/86'/0'/0']xpub6CgE2jCga4edMze1FydMVNpvW8vbvTU5ZcQXzvuBdf1s4fAC8prqBpn7gm3egwn6oQzJxvh4XChCma3LXE5EJ6kGo3wGmuxLd4yvQgU7ykD/<0;1>/*)"
+} as const
+
+const SCRIPT_TYPE_ORDER = ['p2pkh', 'p2sh', 'p2wpkh', 'p2tr'] as const
+
+/** Addresses these descriptors derive, used as expectations throughout. */
+const TESTNET = {
+  paymentAddress: 'tb1q022amqf3jv7mg744rcjmst222dfazqvm72jgzc',
+  paymentPublicKey: '038b7479652d8f0cda05450f45d849785a442f8ab68298baf2180fb1da80fcd579',
+  ordinalAddress: 'tb1qnvjzyemddh93zmjcf20rz50jzra2tvwqk6rmsq',
+  ordinalPublicKey: '03d492ce1d7a10352d0b19dd3e9fc5d28d9dcb101de2426646f1a93a039059f245',
+  changeAddress: 'tb1qlfr2dxd9n8wvgtt2t39atsvd4luxrk8vnvkf0m',
+  taprootChangeAddress: 'tb1pagdnm5rjp2cvxmlq0azn9ugrdt7n9mjfezz7phzduv7ccutf7elqsa2e89',
+  legacyReceiveAddress: 'miPxvemrTyp2h7ut17BZyrmyfqG3jafXTe',
+  nestedReceiveAddress: '2Mzt6RBL4rZAv1KCe9bz59n7BdX8xzszBSp'
+} as const
+
+/** Builds the bundled getPublicKey payload TrezorConnect would return. */
+function publicKeyPayload(descriptors: Record<string, string>, coinType: number) {
+  return SCRIPT_TYPE_ORDER.map(scriptType => {
+    const purpose = { p2pkh: 44, p2sh: 49, p2wpkh: 84, p2tr: 86 }[scriptType]
+
+    return {
+      // The connector prefers xpubSegwit, matching TrezorConnect's own precedence.
+      xpubSegwit: descriptors[scriptType],
+      xpub: descriptors[scriptType],
+      serializedPath: `m/${purpose}'/${coinType}'/0'`
+    }
+  })
+}
+
+function mockPublicKeys(descriptors: Record<string, string>, coinType: number) {
+  vi.mocked(TrezorConnect.getPublicKey).mockResolvedValue({
+    success: true,
+    payload: publicKeyPayload(descriptors, coinType)
+  } as never)
+}
+
 vi.mock('@trezor/connect-web', () => ({
   default: {
     init: vi.fn(() => Promise.resolve()),
-    getAddress: vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        payload: [
-          {
-            address: 'bc1qmock_payment_address',
-            publicKey: 'mock_public_key_payment',
-            serializedPath: "m/84'/0'/0'/0/0"
-          },
-          {
-            address: 'bc1qmock_ordinal_address',
-            publicKey: 'mock_public_key_ordinal',
-            serializedPath: "m/84'/0'/0'/0/1"
-          }
-        ]
-      })
-    ),
+    getPublicKey: vi.fn(),
+    getAddress: vi.fn(),
     signMessage: vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        payload: {
-          signature: 'mock_signature'
-        }
-      })
+      Promise.resolve({ success: true, payload: { signature: 'mock_signature' } })
     ),
     composeTransaction: vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        payload: {
-          txid: 'mock_txid'
-        }
-      })
+      Promise.resolve({ success: true, payload: { txid: 'mock_txid' } })
     ),
-    signTransaction: vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        payload: {
-          serializedTx:
-            '0100000001000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000'
-        }
-      })
-    ),
+    signTransaction: vi.fn(() => Promise.resolve({ success: true, payload: { serializedTx: '' } })),
     pushTransaction: vi.fn(() =>
-      Promise.resolve({
-        success: true,
-        payload: {
-          txid: 'mock_broadcast_txid'
-        }
-      })
+      Promise.resolve({ success: true, payload: { txid: 'mock_broadcast_txid' } })
     ),
     blockchainSetCustomBackend: vi.fn(() => Promise.resolve({ success: true, payload: true }))
   }
@@ -69,11 +96,20 @@ vi.mock('@trezor/connect-web', () => ({
 describe('TrezorConnector', () => {
   let connector: TrezorConnector
 
+  function newTestnetConnector(
+    params: Partial<{ blockbookUrls: Record<string, string[]> }> = {}
+  ): TrezorConnector {
+    return new TrezorConnector({
+      requestedChains: [bitcoin, bitcoinTestnet],
+      requestedCaipNetworkId: bitcoinTestnet.caipNetworkId,
+      ...params
+    } as never)
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
-    connector = new TrezorConnector({
-      requestedChains: [bitcoin, bitcoinTestnet]
-    })
+    mockPublicKeys(TESTNET_DESCRIPTORS, 1)
+    connector = newTestnetConnector()
   })
 
   it('should validate metadata', () => {
@@ -87,17 +123,96 @@ describe('TrezorConnector', () => {
     expect(connector.chains).toEqual([bitcoin, bitcoinTestnet])
   })
 
+  describe('descriptor fixtures', () => {
+    /*
+     * Guards the trap that makes this whole approach fragile: a bare BIP86 xpub
+     * carries the same version bytes as a BIP44 one, so a derivation library
+     * reading version bytes alone silently produces legacy P2PKH addresses for a
+     * taproot account. If a fixture ever degrades to a bare xpub, this fails
+     * here rather than handing users addresses of the wrong type.
+     */
+    it.each(SCRIPT_TYPE_ORDER)('resolves the %s testnet descriptor to its own type', scriptType => {
+      const { paymentType } = getXpubOrDescriptorInfo(
+        TESTNET_DESCRIPTORS[scriptType],
+        trezorNetworks.testnet
+      )
+
+      expect(paymentType).toBe(scriptType)
+    })
+
+    it.each(SCRIPT_TYPE_ORDER)('resolves the %s mainnet descriptor to its own type', scriptType => {
+      const { paymentType } = getXpubOrDescriptorInfo(
+        MAINNET_DESCRIPTORS[scriptType],
+        trezorNetworks.bitcoin
+      )
+
+      expect(paymentType).toBe(scriptType)
+    })
+  })
+
+  describe('single device interaction', () => {
+    it('asks the device for extended keys exactly once across repeated calls', async () => {
+      await connector.connect()
+      await connector.getAccountAddresses()
+      await connector.getAccountAddresses()
+      await connector.getDerivedAddresses()
+
+      expect(TrezorConnect.getPublicKey).toHaveBeenCalledTimes(1)
+    })
+
+    it('never falls back to per-address getAddress calls', async () => {
+      await connector.connect()
+      await connector.getDerivedAddresses()
+
+      expect(TrezorConnect.getAddress).not.toHaveBeenCalled()
+    })
+
+    it('requests all four accounts in one bundle', async () => {
+      await connector.getAccountAddresses()
+
+      const { bundle } = vi.mocked(TrezorConnect.getPublicKey).mock.calls[0]![0] as {
+        bundle: { path: string; coin: string }[]
+      }
+
+      expect(bundle.map(entry => entry.path)).toEqual([
+        "m/44'/1'/0'",
+        "m/49'/1'/0'",
+        "m/84'/1'/0'",
+        "m/86'/1'/0'"
+      ])
+      expect(bundle.every(entry => entry.coin === 'test')).toBe(true)
+    })
+
+    it('shares one device call between concurrent callers', async () => {
+      await Promise.all([
+        connector.getAccountAddresses(),
+        connector.getAccountAddresses(),
+        connector.getDerivedAddresses()
+      ])
+
+      expect(TrezorConnect.getPublicKey).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-fetches after disconnect, since the cache is cleared', async () => {
+      await connector.connect()
+      await connector.disconnect()
+      await connector.getAccountAddresses()
+
+      expect(TrezorConnect.getPublicKey).toHaveBeenCalledTimes(2)
+    })
+  })
+
   describe('connect', () => {
     it('should connect and return payment address', async () => {
-      const address = await connector.connect()
-      expect(address).toBe('bc1qmock_payment_address')
+      expect(await connector.connect()).toBe(TESTNET.paymentAddress)
     })
 
     it('should emit accountsChanged on connect', async () => {
       const listener = vi.fn()
       connector.on('accountsChanged', listener)
       await connector.connect()
-      expect(listener).toHaveBeenCalledWith(['bc1qmock_payment_address'])
+
+      expect(listener).toHaveBeenCalledWith([TESTNET.paymentAddress])
     })
   })
 
@@ -106,35 +221,95 @@ describe('TrezorConnector', () => {
       const listener = vi.fn()
       connector.on('disconnect', listener)
       await connector.disconnect()
+
       expect(listener).toHaveBeenCalled()
     })
   })
 
   describe('getAccountAddresses', () => {
-    it('should return addresses with correct purposes', async () => {
+    /*
+     * The adapter collapses this to exactly two accounts by position
+     * (BitcoinConstantsUtil.ACCOUNT_INDEXES), so the contract must stay at two
+     * entries, payment first, no matter how many addresses are derived.
+     */
+    it('returns exactly two addresses, payment first', async () => {
       const addresses = await connector.getAccountAddresses()
 
       expect(addresses).toHaveLength(2)
       expect(addresses[0]).toEqual({
-        address: 'bc1qmock_payment_address',
-        publicKey: undefined,
-        path: "m/84'/0'/0'/0/0",
+        address: TESTNET.paymentAddress,
+        publicKey: TESTNET.paymentPublicKey,
+        path: "m/84'/1'/0'/0/0",
         purpose: 'payment'
       })
       expect(addresses[1]).toEqual({
-        address: 'bc1qmock_ordinal_address',
-        publicKey: undefined,
-        path: "m/84'/0'/0'/0/1",
+        address: TESTNET.ordinalAddress,
+        publicKey: TESTNET.ordinalPublicKey,
+        path: "m/84'/1'/0'/0/1",
         purpose: 'ordinal'
       })
+    })
+
+    it('populates publicKey, which was previously always undefined', async () => {
+      const addresses = await connector.getAccountAddresses()
+
+      expect(addresses.every(a => typeof a.publicKey === 'string' && a.publicKey.length > 0)).toBe(
+        true
+      )
+    })
+  })
+
+  describe('getDerivedAddresses', () => {
+    it('derives every script type on both chains', async () => {
+      const derived = await connector.getDerivedAddresses()
+
+      expect(derived).toHaveLength(SCRIPT_TYPE_ORDER.length * 2 * 20)
+
+      for (const scriptType of SCRIPT_TYPE_ORDER) {
+        for (const chain of ['receive', 'change'] as const) {
+          const matching = derived.filter(a => a.scriptType === scriptType && a.chain === chain)
+
+          expect(matching).toHaveLength(20)
+          expect(matching.map(a => a.index)).toEqual([...Array(20).keys()])
+        }
+      }
+    })
+
+    it('derives the expected address for each script type', async () => {
+      const derived = await connector.getDerivedAddresses()
+      const receiveZero = (scriptType: string) =>
+        derived.find(a => a.scriptType === scriptType && a.chain === 'receive' && a.index === 0)
+          ?.address
+
+      expect(receiveZero('p2pkh')).toBe(TESTNET.legacyReceiveAddress)
+      expect(receiveZero('p2sh')).toBe(TESTNET.nestedReceiveAddress)
+      expect(receiveZero('p2wpkh')).toBe(TESTNET.paymentAddress)
+      expect(receiveZero('p2tr')).toBe(
+        'tb1pslfsgllyu4wqjpa9lr0nyv57k6q8dj72akdz5qfvs84fhhehp45sa95z2q'
+      )
+    })
+
+    it('carries a public key and a well-formed path for every address', async () => {
+      const derived = await connector.getDerivedAddresses()
+
+      expect(
+        derived.every(a => /^[0-9a-f]{66}$/u.test(a.publicKey) && /^m(?:\/\d+'?){5}$/u.test(a.path))
+      ).toBe(true)
+    })
+
+    it('exposes the account descriptors', async () => {
+      expect(await connector.getAccountDescriptors()).toEqual(TESTNET_DESCRIPTORS)
     })
   })
 
   describe('signMessage', () => {
-    it('should sign a message with ecdsa', async () => {
+    beforeEach(async () => {
       await connector.connect()
+    })
+
+    it('should sign a message with ecdsa', async () => {
       const signature = await connector.signMessage({
-        address: 'bc1qmock_payment_address',
+        address: TESTNET.paymentAddress,
         message: 'test message',
         protocol: 'ecdsa'
       })
@@ -142,21 +317,21 @@ describe('TrezorConnector', () => {
       expect(signature).toBe('mock_signature')
     })
 
-    it('should sign a message without protocol (defaults to ecdsa)', async () => {
-      await connector.connect()
-      const signature = await connector.signMessage({
-        address: 'bc1qmock_payment_address',
+    it('signs with the derivation path of the requested address', async () => {
+      await connector.signMessage({
+        address: TESTNET.changeAddress,
         message: 'test message'
       })
 
-      expect(signature).toBe('mock_signature')
+      expect(TrezorConnect.signMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "m/84'/1'/0'/1/0" })
+      )
     })
 
     it('should throw error for bip322 protocol', async () => {
-      await connector.connect()
       await expect(
         connector.signMessage({
-          address: 'bc1qmock_payment_address',
+          address: TESTNET.paymentAddress,
           message: 'test message',
           protocol: 'bip322'
         })
@@ -167,32 +342,42 @@ describe('TrezorConnector', () => {
   describe('sendTransfer', () => {
     it('should send a transfer', async () => {
       await connector.connect()
-      const txid = await connector.sendTransfer({
-        amount: '100000',
-        recipient: 'bc1qrecipient'
-      })
 
-      expect(txid).toBe('mock_txid')
+      expect(await connector.sendTransfer({ amount: '100000', recipient: 'tb1qrecipient' })).toBe(
+        'mock_txid'
+      )
     })
   })
 
   describe('switchNetwork', () => {
-    it('should switch to testnet', async () => {
+    it('re-fetches keys when the coin type changes', async () => {
+      await connector.getAccountAddresses()
+      mockPublicKeys(MAINNET_DESCRIPTORS, 0)
+
       const listener = vi.fn()
       connector.on('chainChanged', listener)
-
-      await connector.switchNetwork(bitcoinTestnet.caipNetworkId)
-
-      expect(listener).toHaveBeenCalledWith(bitcoinTestnet.caipNetworkId)
-    })
-
-    it('should switch to mainnet', async () => {
-      const listener = vi.fn()
-      connector.on('chainChanged', listener)
-
       await connector.switchNetwork(bitcoin.caipNetworkId)
 
+      expect(TrezorConnect.getPublicKey).toHaveBeenCalledTimes(2)
       expect(listener).toHaveBeenCalledWith(bitcoin.caipNetworkId)
+    })
+
+    it('derives mainnet addresses after switching to mainnet', async () => {
+      await connector.getAccountAddresses()
+      mockPublicKeys(MAINNET_DESCRIPTORS, 0)
+      await connector.switchNetwork(bitcoin.caipNetworkId)
+
+      const [payment] = await connector.getAccountAddresses()
+
+      expect(payment!.path).toBe("m/84'/0'/0'/0/0")
+      expect(payment!.address.startsWith('bc1q')).toBe(true)
+    })
+
+    it('does not re-fetch when switching to the network already in use', async () => {
+      await connector.getAccountAddresses()
+      await connector.switchNetwork(bitcoinTestnet.caipNetworkId)
+
+      expect(TrezorConnect.getPublicKey).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -206,64 +391,23 @@ describe('TrezorConnector', () => {
     it('should return undefined if not client', () => {
       vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValue(false)
 
-      const result = TrezorConnector.getWallet({
-        requestedChains: [bitcoin, bitcoinTestnet]
-      })
-
-      expect(result).toBeUndefined()
+      expect(
+        TrezorConnector.getWallet({ requestedChains: [bitcoin, bitcoinTestnet] })
+      ).toBeUndefined()
     })
 
     it('should return TrezorConnector instance in browser', () => {
       vi.spyOn(CoreHelperUtil, 'isClient').mockReturnValue(true)
 
-      const result = TrezorConnector.getWallet({
-        requestedChains: [bitcoin, bitcoinTestnet]
-      })
-
-      expect(result).toBeInstanceOf(TrezorConnector)
+      expect(
+        TrezorConnector.getWallet({ requestedChains: [bitcoin, bitcoinTestnet] })
+      ).toBeInstanceOf(TrezorConnector)
     })
   })
 
   describe('active network', () => {
-    it('derives testnet paths when constructed with the testnet CAIP id', async () => {
-      const testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
-      })
-
-      await testnetConnector.getAccountAddresses()
-
-      const { bundle } = vi.mocked(TrezorConnect.getAddress).mock.calls[0]![0] as {
-        bundle: { path: string; coin: string }[]
-      }
-
-      expect(bundle.map(entry => entry.path)).toEqual(["m/84'/1'/0'/0/0", "m/84'/1'/0'/0/1"])
-      expect(bundle.every(entry => entry.coin === 'test')).toBe(true)
-    })
-
-    it('derives mainnet paths when constructed with the mainnet CAIP id', async () => {
-      const mainnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoin.caipNetworkId
-      })
-
-      await mainnetConnector.getAccountAddresses()
-
-      const { bundle } = vi.mocked(TrezorConnect.getAddress).mock.calls[0]![0] as {
-        bundle: { path: string; coin: string }[]
-      }
-
-      expect(bundle[0]!.path).toBe("m/84'/0'/0'/0/0")
-      expect(bundle[0]!.coin).toBe('btc')
-    })
-
     it('registers the testnet blockbook backend so inputs can be verified', async () => {
-      const testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
-      })
-
-      await testnetConnector.getAccountAddresses()
+      await connector.getAccountAddresses()
 
       expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledWith({
         coin: 'test',
@@ -272,13 +416,11 @@ describe('TrezorConnector', () => {
     })
 
     it('allows the blockbook endpoint to be overridden', async () => {
-      const testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId,
+      const overridden = newTestnetConnector({
         blockbookUrls: { Testnet: ['https://blockbook.internal'] }
       })
 
-      await testnetConnector.getAccountAddresses()
+      await overridden.getAccountAddresses()
 
       expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledWith({
         coin: 'test',
@@ -287,13 +429,8 @@ describe('TrezorConnector', () => {
     })
 
     it('registers the backend only once per coin', async () => {
-      const testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
-      })
-
-      await testnetConnector.getAccountAddresses()
-      await testnetConnector.getAccountAddresses()
+      await connector.getAccountAddresses()
+      await connector.getAccountAddresses()
 
       expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledTimes(1)
     })
@@ -303,12 +440,7 @@ describe('TrezorConnector', () => {
         new Error('backend unreachable')
       )
 
-      const testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
-      })
-
-      await expect(testnetConnector.getAccountAddresses()).resolves.toHaveLength(2)
+      await expect(newTestnetConnector().getAccountAddresses()).resolves.toHaveLength(2)
     })
 
     it('refuses an unsupported network rather than falling back to mainnet', () => {
@@ -320,28 +452,34 @@ describe('TrezorConnector', () => {
           })
       ).toThrow('Unsupported Bitcoin network for Trezor')
     })
+
+    it('rejects an extended key whose type does not match the account requested', async () => {
+      // A bare BIP86 xpub reads as p2pkh, which would yield legacy addresses.
+      vi.mocked(TrezorConnect.getPublicKey).mockResolvedValue({
+        success: true,
+        payload: publicKeyPayload({ ...TESTNET_DESCRIPTORS, p2tr: TESTNET_DESCRIPTORS.p2pkh }, 1)
+      } as never)
+
+      await expect(newTestnetConnector().getAccountAddresses()).rejects.toThrow(
+        /returned a p2pkh extended key for the p2tr account/u
+      )
+    })
   })
 
   describe('signPSBT', () => {
-    // Compressed secp256k1 generator point: a structurally valid public key, so
-    // bitcoinjs-lib can build the address and finalize the signed PSBT.
-    const DEVICE_PUBKEY = Buffer.from(
-      '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
-      'hex'
-    )
     // Minimal canonical DER signature (r = s = 1) plus SIGHASH_ALL.
     const DER_SIGNATURE = Buffer.from('3006020101020101' + '01', 'hex')
     // Testnet P2SH — the shape of a Rootstock peg-in federation address.
     const FEDERATION_ADDRESS = '2N2PJEucf6QY2kNFuJ4chQEBoyZWszRQE16'
     const OP_RETURN_PAYLOAD = Buffer.from('52534b5401' + '11'.repeat(20), 'hex')
 
+    const DEVICE_PUBKEY = Buffer.from(TESTNET.paymentPublicKey, 'hex')
     const network = btc.networks.testnet
-    const devicePayment = btc.payments.p2wpkh({ pubkey: DEVICE_PUBKEY, network })
-    const DEVICE_ADDRESS = devicePayment.address!
-    const DEVICE_SCRIPT = devicePayment.output!
+    const DEVICE_SCRIPT = btc.payments.p2wpkh({ pubkey: DEVICE_PUBKEY, network }).output!
+    const CHANGE_SCRIPT = btc.address.toOutputScript(TESTNET.changeAddress, network)
 
     /** A peg-in shaped PSBT: our input, federation output, OP_RETURN, change. */
-    function buildPeginPsbt(): btc.Psbt {
+    function buildPeginPsbt(changeScript: Uint8Array = CHANGE_SCRIPT): btc.Psbt {
       const psbt = new btc.Psbt({ network })
       psbt.setVersion(2)
       psbt.addInput({
@@ -358,7 +496,7 @@ describe('TrezorConnector', () => {
         script: btc.script.compile([btc.opcodes['OP_RETURN']!, OP_RETURN_PAYLOAD]),
         value: 0
       })
-      psbt.addOutput({ script: DEVICE_SCRIPT, value: 99000 })
+      psbt.addOutput({ script: Buffer.from(changeScript), value: 99000 })
 
       return psbt
     }
@@ -374,34 +512,17 @@ describe('TrezorConnector', () => {
       return tx.toHex()
     }
 
-    let testnetConnector: TrezorConnector
-
     beforeEach(async () => {
-      testnetConnector = new TrezorConnector({
-        requestedChains: [bitcoin, bitcoinTestnet],
-        requestedCaipNetworkId: bitcoinTestnet.caipNetworkId
-      })
-
-      vi.mocked(TrezorConnect.getAddress).mockResolvedValueOnce({
-        success: true,
-        payload: [
-          { address: DEVICE_ADDRESS, serializedPath: "m/84'/1'/0'/0/0" },
-          { address: 'tb1qordinal', serializedPath: "m/84'/1'/0'/0/1" }
-        ]
-      } as never)
-
-      await testnetConnector.connect()
+      await connector.connect()
     })
 
-    async function signPeginPsbt() {
-      const psbt = buildPeginPsbt()
-
+    async function signPsbt(psbt: btc.Psbt) {
       vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
         success: true,
         payload: { serializedTx: buildSignedTxHex(psbt) }
       } as never)
 
-      const response = await testnetConnector.signPSBT({
+      const response = await connector.signPSBT({
         psbt: psbt.toBase64(),
         signInputs: [],
         broadcast: false
@@ -411,10 +532,13 @@ describe('TrezorConnector', () => {
         inputs: Record<string, unknown>[]
         outputs: Record<string, unknown>[]
         coin: string
+        refTxs?: { hash: string; bin_outputs: { amount: string }[] }[]
       }
 
       return { response, sent }
     }
+
+    const signPeginPsbt = () => signPsbt(buildPeginPsbt())
 
     it('describes an OP_RETURN output as PAYTOOPRETURN with its payload', async () => {
       const { sent } = await signPeginPsbt()
@@ -436,13 +560,39 @@ describe('TrezorConnector', () => {
       })
     })
 
-    it('describes change back to our own address by derivation path', async () => {
+    /*
+     * Change lives on the change chain (.../1/*), which the connector previously
+     * could not derive — so real BIP84 change was shown to the user as a payment
+     * to a stranger.
+     */
+    it('recognises change on the change chain by derivation path', async () => {
       const { sent } = await signPeginPsbt()
 
       expect(sent.outputs[2]).toEqual({
-        address_n: [2147483732, 2147483649, 2147483648, 0, 0],
+        // m/84'/1'/0'/1/0
+        address_n: [2147483732, 2147483649, 2147483648, 1, 0],
         amount: '99000',
         script_type: 'PAYTOWITNESS'
+      })
+    })
+
+    it('uses the script type matching the change address, not always PAYTOWITNESS', async () => {
+      /*
+       * Built with @trezor/utxo-lib because bitcoinjs-lib throws "No ECC Library
+       * provided" for taproot unless initEccLib() has been called — the same
+       * reason the connector decodes output scripts with utxo-lib.
+       */
+      const taprootChange = trezorAddress.toOutputScript(
+        TESTNET.taprootChangeAddress,
+        trezorNetworks.testnet
+      )
+      const { sent } = await signPsbt(buildPeginPsbt(taprootChange))
+
+      expect(sent.outputs[2]).toEqual({
+        // m/86'/1'/0'/1/0
+        address_n: [2147483734, 2147483649, 2147483648, 1, 0],
+        amount: '99000',
+        script_type: 'PAYTOTAPROOT'
       })
     })
 
@@ -456,6 +606,78 @@ describe('TrezorConnector', () => {
         amount: '200000',
         script_type: 'SPENDWITNESS'
       })
+    })
+
+    it('resolves an input path from signInputs by address', async () => {
+      const psbt = buildPeginPsbt()
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: buildSignedTxHex(psbt) }
+      } as never)
+
+      await connector.signPSBT({
+        psbt: psbt.toBase64(),
+        signInputs: [{ index: 0, address: TESTNET.changeAddress, sighashTypes: [] }],
+        broadcast: false
+      })
+
+      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
+        inputs: Record<string, unknown>[]
+      }
+
+      expect(sent.inputs[0]).toMatchObject({
+        address_n: [2147483732, 2147483649, 2147483648, 1, 0]
+      })
+    })
+
+    /*
+     * publicKey used to be undefined on every address, so this branch of
+     * resolveInputPath could never match anything. SignPSBTParams types
+     * `address` as required but documents it as "at least specify either an
+     * address or a public key", so the publicKey-only shape is reachable from
+     * untyped callers — hence the cast.
+     */
+    it('resolves an input path from signInputs by public key', async () => {
+      const psbt = buildPeginPsbt()
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: buildSignedTxHex(psbt) }
+      } as never)
+
+      await connector.signPSBT({
+        psbt: psbt.toBase64(),
+        signInputs: [{ index: 0, publicKey: TESTNET.ordinalPublicKey }] as never,
+        broadcast: false
+      })
+
+      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
+        inputs: Record<string, unknown>[]
+      }
+
+      expect(sent.inputs[0]).toMatchObject({
+        // m/84'/1'/0'/0/1
+        address_n: [2147483732, 2147483649, 2147483648, 0, 1]
+      })
+    })
+
+    it('refuses to sign an address it cannot place, rather than using .../0/0', async () => {
+      const psbt = buildPeginPsbt()
+
+      await expect(
+        connector.signPSBT({
+          psbt: psbt.toBase64(),
+          signInputs: [
+            {
+              index: 0,
+              address: 'tb1qnotours000000000000000000000000000000',
+              sighashTypes: []
+            }
+          ],
+          broadcast: false
+        })
+      ).rejects.toThrow(/was not derived from this Trezor account/u)
     })
 
     it('returns a signed PSBT carrying partialSig, which the caller can finalize', async () => {
@@ -483,22 +705,12 @@ describe('TrezorConnector', () => {
       psbt.addInput({ hash: prevTx.getHash(), index: 0, nonWitnessUtxo: prevTx.toBuffer() })
       psbt.addOutput({ script: DEVICE_SCRIPT, value: 100000 })
 
-      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
-        success: true,
-        payload: { serializedTx: buildSignedTxHex(psbt) }
-      } as never)
+      const { sent } = await signPsbt(psbt)
 
-      await testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
-
-      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
-        inputs: Record<string, unknown>[]
-      }
-
-      expect(sent.inputs[0]).toMatchObject({ amount: '123456', script_type: 'SPENDADDRESS' })
+      expect(sent.inputs[0]).toMatchObject({ amount: '123456', script_type: 'SPENDWITNESS' })
     })
 
     it('sends refTxs built from the PSBT so no backend lookup is needed', async () => {
-      // A previous transaction paying our address, carried in the PSBT.
       const prevTx = new btc.Transaction()
       prevTx.version = 2
       prevTx.addInput(Buffer.alloc(32, 3), 0)
@@ -513,16 +725,7 @@ describe('TrezorConnector', () => {
       })
       psbt.addOutput({ script: DEVICE_SCRIPT, value: 190000 })
 
-      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
-        success: true,
-        payload: { serializedTx: buildSignedTxHex(psbt) }
-      } as never)
-
-      await testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
-
-      const sent = vi.mocked(TrezorConnect.signTransaction).mock.calls[0]![0] as {
-        refTxs?: { hash: string; bin_outputs: { amount: string }[] }[]
-      }
+      const { sent } = await signPsbt(psbt)
 
       expect(sent.refTxs).toHaveLength(1)
       expect(sent.refTxs![0]!.hash).toBe(prevTx.getId())
@@ -532,7 +735,7 @@ describe('TrezorConnector', () => {
     it('omits refTxs when the PSBT does not carry previous transactions', async () => {
       const { sent } = await signPeginPsbt()
 
-      expect((sent as { refTxs?: unknown }).refTxs).toBeUndefined()
+      expect(sent.refTxs).toBeUndefined()
     })
 
     it('refuses an input whose amount cannot be determined', async () => {
@@ -541,7 +744,7 @@ describe('TrezorConnector', () => {
       psbt.addOutput({ script: DEVICE_SCRIPT, value: 1000 })
 
       await expect(
-        testnetConnector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
+        connector.signPSBT({ psbt: psbt.toBase64(), signInputs: [], broadcast: false })
       ).rejects.toThrow('neither witnessUtxo nor nonWitnessUtxo')
     })
   })

--- a/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
+++ b/packages/adapters/bitcoin/tests/connectors/TrezorConnector.test.ts
@@ -738,6 +738,89 @@ describe('TrezorConnector', () => {
       expect(sent.refTxs).toBeUndefined()
     })
 
+    it('grafts a taproot key-path signature as tapKeySig', async () => {
+      // A taproot key-path spend is witnessed by one Schnorr signature, with no
+      // public key alongside it, and belongs in tapKeySig rather than partialSig.
+      const taprootScript = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 6)])
+      const schnorrSig = Buffer.alloc(64, 7)
+
+      const psbt = new btc.Psbt({ network })
+      psbt.addInput({
+        hash: Buffer.alloc(32, 5),
+        index: 0,
+        witnessUtxo: { script: taprootScript, value: 150000 }
+      })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 140000 })
+
+      const signedTx = new btc.Transaction()
+      signedTx.version = 2
+      psbt.txInputs.forEach(input => signedTx.addInput(input.hash, input.index, input.sequence))
+      psbt.txOutputs.forEach(output => signedTx.addOutput(output.script, output.value))
+      signedTx.setWitness(0, [schnorrSig])
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: signedTx.toHex() }
+      } as never)
+
+      const response = await connector.signPSBT({
+        psbt: psbt.toBase64(),
+        signInputs: [],
+        broadcast: false
+      })
+
+      const returned = btc.Psbt.fromBase64(response.psbt, { network })
+      const input = returned.data.inputs[0]!
+
+      expect(input.tapKeySig).toBeDefined()
+      expect(Buffer.from(input.tapKeySig!).equals(schnorrSig)).toBe(true)
+      // Not a partialSig: taproot has no public key in the witness to pair with.
+      expect(input.partialSig).toBeUndefined()
+    })
+
+    it('grafts a legacy input signature from its scriptSig', async () => {
+      // A P2PKH input has no witness: its signature lives in the scriptSig.
+      const prevTx = new btc.Transaction()
+      prevTx.version = 2
+      prevTx.addInput(Buffer.alloc(32, 3), 0)
+      const legacyScript = btc.payments.p2pkh({
+        hash: Buffer.alloc(20, 4),
+        network
+      }).output!
+      prevTx.addOutput(legacyScript, 300000)
+
+      const psbt = new btc.Psbt({ network })
+      psbt.addInput({ hash: prevTx.getHash(), index: 0, nonWitnessUtxo: prevTx.toBuffer() })
+      psbt.addOutput({ script: DEVICE_SCRIPT, value: 290000 })
+
+      // The device returns the signature inside scriptSig, with no witness.
+      const signedTx = new btc.Transaction()
+      signedTx.version = 2
+      psbt.txInputs.forEach(input => signedTx.addInput(input.hash, input.index, input.sequence))
+      psbt.txOutputs.forEach(output => signedTx.addOutput(output.script, output.value))
+      signedTx.setInputScript(0, btc.script.compile([DER_SIGNATURE, DEVICE_PUBKEY]))
+
+      vi.mocked(TrezorConnect.signTransaction).mockResolvedValueOnce({
+        success: true,
+        payload: { serializedTx: signedTx.toHex() }
+      } as never)
+
+      const response = await connector.signPSBT({
+        psbt: psbt.toBase64(),
+        signInputs: [],
+        broadcast: false
+      })
+
+      const returned = btc.Psbt.fromBase64(response.psbt, { network })
+      const input = returned.data.inputs[0]!
+
+      // Previously this input came back unsigned, so the caller could not
+      // finalize it ("Can not finalize input #N") despite the user approving.
+      expect(input.partialSig).toHaveLength(1)
+      expect(input.partialSig![0]!.signature.equals(DER_SIGNATURE)).toBe(true)
+      expect(input.partialSig![0]!.pubkey.equals(DEVICE_PUBKEY)).toBe(true)
+    })
+
     it('refuses an input whose amount cannot be determined', async () => {
       const psbt = new btc.Psbt({ network })
       psbt.addInput({ hash: Buffer.alloc(32, 7), index: 0 })

--- a/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
+++ b/packages/adapters/bitcoin/tests/utils/WalletConnectProvider.test.ts
@@ -205,7 +205,11 @@ describe('LeatherConnector', () => {
 
     it('should get the account addresses and parse response', async () => {
       const requestSpy = vi.spyOn(universalProvider, 'request')
-      requestSpy.mockResolvedValueOnce(['mock_address'])
+      // getAccountAddresses returns address descriptors, not bare strings.
+      requestSpy.mockResolvedValueOnce([
+        { address: 'mock_address', path: "m/84'/0'/0'", intention: 'payment' },
+        { address: 'mock_ordinal_address', intention: 'ordinal' }
+      ])
 
       const result = await provider.getAccountAddresses()
 
@@ -216,7 +220,20 @@ describe('LeatherConnector', () => {
         },
         bitcoin.caipNetworkId
       )
-      expect(result).toEqual([{ address: 'mock_address', purpose: 'payment' }])
+      expect(result).toEqual([
+        {
+          address: 'mock_address',
+          publicKey: undefined,
+          path: "m/84'/0'/0'",
+          purpose: 'payment'
+        },
+        {
+          address: 'mock_ordinal_address',
+          publicKey: undefined,
+          path: undefined,
+          purpose: 'ordinal'
+        }
+      ])
     })
 
     it('should throw an error if the method is not supported', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 6.18.1(eslint@8.56.0)(typescript@5.8.3)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       '@vitest/ui':
         specifier: 2.1.8
         version: 2.1.8(vitest@2.1.9)
@@ -121,7 +121,7 @@ importers:
         version: 0.23.0(rollup@4.55.1)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   apps/browser-extension:
     dependencies:
@@ -526,7 +526,7 @@ importers:
         version: 9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))
       '@storybook/web-components-vite':
         specifier: 9.0.15
-        version: 9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       chromatic:
         specifier: 13.3.0
         version: 13.3.0
@@ -1496,13 +1496,13 @@ importers:
         version: 2.22.1(@tanstack/query-core@5.75.5)(@types/react@19.1.15)(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@wagmi/vue':
         specifier: 0.4.11
-        version: 0.4.11(5vzbct2uaipf5r2blozxodbb5i)
+        version: 0.4.11(ji2dlbljdvygmm4yvvoceoa2xy)
       '@walletconnect/logger':
         specifier: 3.0.2
         version: 3.0.2
       nuxt:
         specifier: 4.1.2
-        version: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0)
       viem:
         specifier: 2.45.0
         version: 2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -1511,7 +1511,7 @@ importers:
         version: 3.5.13(typescript@5.9.2)
       vue-router:
         specifier: latest
-        version: 5.0.2(@vue/compiler-sfc@3.5.26)(vue@3.5.13(typescript@5.9.2))
+        version: 5.2.0(@vue/compiler-sfc@3.5.26)(esbuild@0.27.2)(rollup@4.55.1)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.13(typescript@5.9.2))(webpack@5.104.1(esbuild@0.27.2))
 
   examples/nuxt-wagmi-solana-bitcoin:
     dependencies:
@@ -1538,13 +1538,13 @@ importers:
         version: 2.22.1(@tanstack/query-core@5.75.5)(@types/react@19.1.15)(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5))
       '@wagmi/vue':
         specifier: 0.4.11
-        version: 0.4.11(5vzbct2uaipf5r2blozxodbb5i)
+        version: 0.4.11(si35kwyvvlxpeeechs4blwrj5q)
       '@walletconnect/logger':
         specifier: 3.0.2
         version: 3.0.2
       nuxt:
         specifier: 4.1.2
-        version: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
+        version: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0)
       viem:
         specifier: 2.45.0
         version: 2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
@@ -1553,7 +1553,7 @@ importers:
         version: 3.5.13(typescript@5.9.2)
       vue-router:
         specifier: latest
-        version: 5.0.2(@vue/compiler-sfc@3.5.26)(vue@3.5.13(typescript@5.9.2))
+        version: 5.2.0(@vue/compiler-sfc@3.5.26)(esbuild@0.27.2)(rollup@4.55.1)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.13(typescript@5.9.2))(webpack@5.104.1(esbuild@0.27.2))
 
   examples/parcel:
     dependencies:
@@ -1927,7 +1927,7 @@ importers:
         version: 5.22.5
       svelte-check:
         specifier: 4.1.5
-        version: 4.1.5(picomatch@4.0.3)(svelte@5.22.5)(typescript@5.9.2)
+        version: 4.1.5(picomatch@4.0.5)(svelte@5.22.5)(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -1955,13 +1955,13 @@ importers:
         version: 1.2.3(eslint@9.39.1(jiti@2.6.1))
       '@sveltejs/adapter-auto':
         specifier: 6.1.0
-        version: 6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))
+        version: 6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: 2.42.1
-        version: 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.4
-        version: 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       eslint-plugin-svelte:
         specifier: 2.36.0
         version: 2.36.0(eslint@9.39.1(jiti@2.6.1))(svelte@5.22.5)(ts-node@10.9.2(@types/node@22.13.9)(typescript@5.9.2))
@@ -1979,7 +1979,7 @@ importers:
         version: 5.9.2
       vite:
         specifier: 6.3.6
-        version: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   examples/sveltekit-wagmi:
     dependencies:
@@ -2004,13 +2004,13 @@ importers:
         version: 1.2.7(eslint@9.39.1(jiti@2.6.1))
       '@sveltejs/adapter-auto':
         specifier: 6.1.0
-        version: 6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))
+        version: 6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))
       '@sveltejs/kit':
         specifier: 2.42.1
-        version: 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 4.0.4
-        version: 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       eslint-plugin-svelte:
         specifier: 2.36.0
         version: 2.36.0(eslint@9.39.1(jiti@2.6.1))(svelte@5.22.5)(ts-node@10.9.2(@types/node@22.13.9)(typescript@5.9.2))
@@ -2022,13 +2022,13 @@ importers:
         version: 5.22.5
       svelte-check:
         specifier: 4.1.5
-        version: 4.1.5(picomatch@4.0.3)(svelte@5.22.5)(typescript@5.9.2)
+        version: 4.1.5(picomatch@4.0.5)(svelte@5.22.5)(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
       vite:
         specifier: 6.3.6
-        version: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   examples/vue-ak-basic:
     dependencies:
@@ -2059,7 +2059,7 @@ importers:
         version: link:../../packages/appkit
       '@walletconnect/sign-client':
         specifier: 2.23.7
-        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
@@ -2087,7 +2087,7 @@ importers:
         version: link:../../packages/appkit
       '@walletconnect/universal-provider':
         specifier: 2.23.7
-        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
       vue:
         specifier: 3.4.3
         version: 3.4.3(typescript@5.9.2)
@@ -2354,6 +2354,9 @@ importers:
       '@trezor/connect-web':
         specifier: 9.7.3
         version: 9.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(tslib@2.8.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@trezor/utxo-lib':
+        specifier: 2.5.0
+        version: 2.5.0(tslib@2.8.1)
       '@wallet-standard/app':
         specifier: 1.1.0
         version: 1.1.0
@@ -2362,7 +2365,7 @@ importers:
         version: 1.1.0
       '@walletconnect/universal-provider':
         specifier: 2.23.7
-        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
       bitcoinjs-lib:
         specifier: 6.1.7
         version: 6.1.7
@@ -2375,7 +2378,7 @@ importers:
         version: 2.20.13
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       '@wallet-standard/features':
         specifier: 1.0.3
         version: 1.0.3
@@ -2384,7 +2387,7 @@ importers:
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/adapters/ethers:
     dependencies:
@@ -2424,13 +2427,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/adapters/ethers5:
     dependencies:
@@ -2470,13 +2473,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/adapters/polkadot:
     dependencies:
@@ -2492,10 +2495,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/adapters/solana:
     dependencies:
@@ -2546,7 +2549,7 @@ importers:
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       '@walletconnect/universal-provider':
         specifier: 2.23.7
-        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+        version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
       valtio:
         specifier: 2.1.7
         version: 2.1.7(@types/react@19.1.15)(react@19.1.2)
@@ -2566,7 +2569,7 @@ importers:
         version: 19.1.9(@types/react@19.1.15)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@vue/runtime-core':
         specifier: 3.4.3
         version: 3.4.3
@@ -2578,7 +2581,7 @@ importers:
         version: 19.1.2(react@19.1.2)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue:
         specifier: 3.4.3
         version: 3.4.3(typescript@5.9.2)
@@ -2609,10 +2612,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/adapters/tron:
     dependencies:
@@ -2658,10 +2661,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/adapters/wagmi:
     dependencies:
@@ -2714,13 +2717,13 @@ importers:
         version: 19.1.9(@types/react@19.1.15)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
+        version: 2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       vitest:
         specifier: 2.1.9
-        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+        version: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/appkit:
     dependencies:
@@ -2782,7 +2785,7 @@ importers:
         version: 19.1.9(@types/react@19.1.15)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@vue/runtime-core':
         specifier: 3.4.3
         version: 3.4.3
@@ -2800,7 +2803,7 @@ importers:
         version: 19.1.2(react@19.1.2)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue:
         specifier: 3.x
         version: 3.5.13(typescript@5.9.2)
@@ -2859,7 +2862,7 @@ importers:
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@wallet-standard/base':
         specifier: 1.1.0
         version: 1.1.0
@@ -2874,7 +2877,7 @@ importers:
         version: 6.0.0
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/cdn:
     dependencies:
@@ -2976,7 +2979,7 @@ importers:
         version: 6.2.2
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
@@ -2985,7 +2988,7 @@ importers:
         version: 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/controllers:
     dependencies:
@@ -3013,7 +3016,7 @@ importers:
         version: 19.1.9(@types/react@19.1.15)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@walletconnect/types':
         specifier: 2.23.7
         version: 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
@@ -3025,7 +3028,7 @@ importers:
         version: 19.1.2(react@19.1.2)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue:
         specifier: 3.5.13
         version: 3.5.13(typescript@5.9.2)
@@ -3038,10 +3041,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/experimental:
     dependencies:
@@ -3075,10 +3078,10 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/pay:
     dependencies:
@@ -3109,10 +3112,10 @@ importers:
         version: 19.1.15
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/polyfills:
     dependencies:
@@ -3153,10 +3156,10 @@ importers:
         version: 4.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/siwe:
     dependencies:
@@ -3223,7 +3226,7 @@ importers:
         version: 19.1.15
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       happy-dom:
         specifier: 15.11.7
         version: 15.11.7
@@ -3232,7 +3235,7 @@ importers:
         version: 19.1.2
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue:
         specifier: 3.5.13
         version: 3.5.13(typescript@5.9.2)
@@ -3251,13 +3254,13 @@ importers:
         version: 22.13.4
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       dotenv:
         specifier: 16.4.7
         version: 16.4.7
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/ui:
     dependencies:
@@ -3291,7 +3294,7 @@ importers:
         version: 19.1.9(@types/react@19.1.15)
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       eslint-plugin-lit:
         specifier: 1.15.0
         version: 1.15.0(eslint@9.39.1(jiti@2.6.1))
@@ -3306,7 +3309,7 @@ importers:
         version: 19.1.2(react@19.1.2)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/universal-connector:
     dependencies:
@@ -3331,13 +3334,13 @@ importers:
         version: 19.1.15
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       react:
         specifier: 19.1.2
         version: 19.1.2
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/wallet:
     dependencies:
@@ -3356,13 +3359,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       jsdom:
         specifier: 24.1.0
         version: 24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   packages/wallet-button:
     dependencies:
@@ -3400,7 +3403,7 @@ importers:
         version: 19.1.15
       '@vitest/coverage-v8':
         specifier: 2.1.9
-        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+        version: 2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       eslint-plugin-react-hooks:
         specifier: 5.2.0
         version: 5.2.0(eslint@9.39.1(jiti@2.6.1))
@@ -3409,7 +3412,7 @@ importers:
         version: 19.1.2
       vitest:
         specifier: 3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+        version: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   services/id-allocation-service:
     dependencies:
@@ -3921,6 +3924,10 @@ packages:
     resolution: {integrity: sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -3992,9 +3999,25 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -4011,6 +4034,16 @@ packages:
   '@babel/parser@7.28.6':
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
@@ -4543,6 +4576,14 @@ packages:
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@base-org/account@1.1.1':
     resolution: {integrity: sha512-IfVJPrDPhHfqXRDb89472hXkpvJuQQR7FDI9isLPHEqSYt/45whIoBxSPgZ0ssTt379VhQo4+87PWI1DoLSfAQ==}
@@ -5993,9 +6034,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -6005,9 +6048,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -7281,7 +7326,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@phosphor-icons/webcomponents@2.1.5':
     resolution: {integrity: sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==}
@@ -8119,6 +8164,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@sats-connect/core@0.6.5':
     resolution: {integrity: sha512-jltPdG3RzY6NPSp/ldoVTu7hOmMiuXr90osTHFPoQzprxcOs/1U4sZt/qAyGhfOM6B+ZXb7DF686BmFkUpPCJA==}
@@ -10036,6 +10082,9 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -10320,6 +10369,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.2':
     resolution: {integrity: sha512-w5yxH/fkkLWAFAOnMSIbvAikNHYn6pgC7zGF/BasXf+K3CO1cYIPFehYAk5jpcsbiNPMc3goyyw1prGLoyD14g==}
@@ -10609,8 +10659,8 @@ packages:
       vue:
         optional: true
 
-  '@vue-macros/common@3.1.2':
-    resolution: {integrity: sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==}
+  '@vue-macros/common@3.1.4':
+    resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       vue: ^2.7.0 || ^3.2.25
@@ -10679,8 +10729,8 @@ packages:
   '@vue/devtools-api@7.7.2':
     resolution: {integrity: sha512-1syn558KhyN+chO5SjlZIwJ8bV/bQ1nOVTG66t2RbG66ZGekyiYNmRO7X9BJCXQqPsFHlnksqvPhce2qpzxFnA==}
 
-  '@vue/devtools-api@8.0.6':
-    resolution: {integrity: sha512-+lGBI+WTvJmnU2FZqHhEB8J1DXcvNlDeEalz77iYgOdY1jTj1ipSBaKj3sRhYcy+kqA8v/BSuvOz1XJucfQmUA==}
+  '@vue/devtools-api@8.2.1':
+    resolution: {integrity: sha512-6u4vXBlIBAC1wMplIZgpyPn7uh/s4Bf6F5bMzvLv+EdJ0aHs/+4B7Ygv864EStQSjRbsRzTko/kUG1A1IejQ3A==}
 
   '@vue/devtools-core@7.7.9':
     resolution: {integrity: sha512-48jrBSwG4GVQRvVeeXn9p9+dlx+ISgasM7SxZZKczseohB0cBz+ITKr4YbLWjmJdy45UHL7UMPlR4Y0CWTRcSQ==}
@@ -10690,14 +10740,14 @@ packages:
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
-  '@vue/devtools-kit@8.0.6':
-    resolution: {integrity: sha512-9zXZPTJW72OteDXeSa5RVML3zWDCRcO5t77aJqSs228mdopYj5AiTpihozbsfFJ0IodfNs7pSgOGO3qfCuxDtw==}
+  '@vue/devtools-kit@8.2.1':
+    resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
 
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  '@vue/devtools-shared@8.0.6':
-    resolution: {integrity: sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg==}
+  '@vue/devtools-shared@8.2.1':
+    resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
   '@vue/language-core@2.1.8':
     resolution: {integrity: sha512-DtPUKrIRqqzY1joGfVHxHWZoxXZbCQLmVtW+QTifuPInfcs1R/3UAdlJXDp+lpSpP9lI5m+jMYYlwDXXu3KSTg==}
@@ -11244,6 +11294,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
@@ -11437,6 +11492,10 @@ packages:
     resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
     engines: {node: '>=20.19.0'}
 
+  ast-walker-scope@0.9.0:
+    resolution: {integrity: sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==}
+    engines: {node: '>=20.19.0'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -11618,6 +11677,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -14866,6 +14926,10 @@ packages:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
+  local-pkg@1.2.1:
+    resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
+    engines: {node: '>=14'}
+
   localforage@1.10.0:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
@@ -15228,6 +15292,9 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   mnemonist@0.38.3:
     resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
 
@@ -15524,6 +15591,9 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  nostics@1.2.0:
+    resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -15993,6 +16063,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -17771,6 +17845,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -18037,6 +18115,9 @@ packages:
   ufo@1.6.2:
     resolution: {integrity: sha512-heMioaxBcG9+Znsda5Q8sQbWnLJSl98AFDXTO80wELWEzX3hordXsTdxrIfMQoO9IY1MEnoGoPjpoKpMj+Yx0Q==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   uint8array-tools@0.0.8:
     resolution: {integrity: sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==}
     engines: {node: '>=14.0.0'}
@@ -18158,8 +18239,13 @@ packages:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
     engines: {node: '>=20.19.0'}
 
+  unplugin-utils@0.3.2:
+    resolution: {integrity: sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==}
+    engines: {node: '>=20.19.0'}
+
   unplugin-vue-router@0.15.0:
     resolution: {integrity: sha512-PyGehCjd9Ny9h+Uer4McbBjjib3lHihcyUEILa7pHKl6+rh8N7sFyw4ZkV+N30Oq2zmIUG7iKs3qpL0r+gXAaQ==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       '@vue/compiler-sfc': ^3.5.17
       vue-router: ^4.5.1
@@ -18178,9 +18264,38 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
-  unplugin@3.0.0:
-    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@farmfe/core': '*'
+      '@rspack/core': '*'
+      bun-types-no-globals: '*'
+      esbuild: '>=0.25.1'
+      rolldown: '*'
+      rollup: '*'
+      unloader: '*'
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@rspack/core':
+        optional: true
+      bun-types-no-globals:
+        optional: true
+      esbuild:
+        optional: true
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+      unloader:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -18343,14 +18458,17 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -18742,19 +18860,22 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  vue-router@5.0.2:
-    resolution: {integrity: sha512-YFhwaE5c5JcJpNB1arpkl4/GnO32wiUWRB+OEj1T0DlDxEZoOfbltl2xEwktNU/9o1sGcGburIXSpbLpPFe/6w==}
+  vue-router@5.2.0:
+    resolution: {integrity: sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==}
     peerDependencies:
       '@pinia/colada': '>=0.21.2'
-      '@vue/compiler-sfc': ^3.5.17
-      pinia: ^3.0.4
-      vue: ^3.5.0
+      '@vue/compiler-sfc': ^3.5.34 || ^4.0.0
+      pinia: ^3.0.4 || ^4.0.2
+      vite: ^7.3.0 || ^8.0.0
+      vue: ^3.5.34 || ^4.0.0
     peerDependenciesMeta:
       '@pinia/colada':
         optional: true
       '@vue/compiler-sfc':
         optional: true
       pinia:
+        optional: true
+      vite:
         optional: true
 
   vue-tsc@2.1.8:
@@ -19131,6 +19252,11 @@ packages:
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -20683,6 +20809,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.28.6
@@ -20784,7 +20919,15 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -20804,6 +20947,14 @@ snapshots:
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.28.6
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.6)':
     dependencies:
@@ -21537,6 +21688,16 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@base-org/account@1.1.1(@types/react@19.1.15)(bufferutil@4.1.0)(react@19.1.2)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.2))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -23894,6 +24055,41 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@nuxt/cli@3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
+    dependencies:
+      '@bomb.sh/tab': 0.0.11(cac@6.7.14)(citty@0.1.6)(commander@13.1.0)
+      '@clack/prompts': 1.0.0-alpha.9
+      c12: 3.3.3(magicast@0.3.5)
+      citty: 0.1.6
+      confbox: 0.2.2
+      consola: 3.4.2
+      copy-paste: 2.2.0
+      debug: 4.4.3
+      defu: 6.1.4
+      exsolve: 1.0.8
+      fuse.js: 7.1.0
+      giget: 2.0.0
+      jiti: 2.6.1
+      listhen: 1.9.0
+      nypm: 0.6.2
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.0.0
+      pkg-types: 2.3.0
+      scule: 1.3.0
+      semver: 7.7.3
+      srvx: 0.10.0
+      std-env: 3.10.0
+      tinyexec: 1.0.2
+      ufo: 1.6.2
+      youch: 4.1.0-beta.13
+    transitivePeerDependencies:
+      - cac
+      - commander
+      - magicast
+      - supports-color
+
   '@nuxt/cli@3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.11(cac@6.7.14)(citty@0.1.6)(commander@13.1.0)
@@ -23940,11 +24136,11 @@ snapshots:
       - magicast
     optional: true
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.3.5)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.3.5)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 3.20.2(magicast@0.3.5)
       execa: 8.0.1
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -24001,12 +24197,12 @@ snapshots:
       - vue
     optional: true
 
-  '@nuxt/devtools@2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2))':
+  '@nuxt/devtools@2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.3.5)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.3.5)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 2.7.0
       '@nuxt/kit': 3.20.2(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.9(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2))
+      '@vue/devtools-core': 7.7.9(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))
       '@vue/devtools-kit': 7.7.9
       birpc: 2.9.0
       consola: 3.4.2
@@ -24031,9 +24227,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.20.2(magicast@0.3.5))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.2.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2))
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@3.20.2(magicast@0.3.5))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.2.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))
       which: 5.0.0
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -24094,6 +24290,33 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@4.1.2(magicast@0.3.5)':
+    dependencies:
+      c12: 3.3.3(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.7.2
+      std-env: 3.10.0
+      tinyglobby: 0.2.15
+      ufo: 1.6.2
+      unctx: 2.5.0
+      unimport: 5.6.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/kit@4.1.2(magicast@0.5.1)':
     dependencies:
       c12: 3.3.3(magicast@0.5.1)
@@ -24131,6 +24354,23 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.1
 
+  '@nuxt/telemetry@2.6.6(magicast@0.3.5)':
+    dependencies:
+      '@nuxt/kit': 3.20.2(magicast@0.3.5)
+      citty: 0.1.6
+      consola: 3.4.2
+      destr: 2.0.5
+      dotenv: 16.4.7
+      git-url-parse: 16.1.0
+      is-docker: 3.0.0
+      ofetch: 1.5.1
+      package-manager-detector: 1.6.0
+      pathe: 2.0.3
+      rc9: 2.1.2
+      std-env: 3.10.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/telemetry@2.6.6(magicast@0.5.1)':
     dependencies:
       '@nuxt/kit': 3.20.2(magicast@0.5.1)
@@ -24150,7 +24390,7 @@ snapshots:
 
   '@nuxt/vite-builder@4.1.2(@types/node@22.13.9)(eslint@8.56.0)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue-tsc@2.1.8(typescript@5.9.2))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
       '@vitejs/plugin-vue': 6.0.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
       '@vitejs/plugin-vue-jsx': 5.1.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
@@ -24175,8 +24415,8 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.2
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vite-plugin-checker: 0.10.3(eslint@8.56.0)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue-tsc@2.1.8(typescript@5.9.2))
       vue: 3.5.26(typescript@5.9.2)
       vue-bundle-renderer: 2.2.0
@@ -24208,7 +24448,7 @@ snapshots:
 
   '@nuxt/vite-builder@4.1.2(@types/node@22.13.9)(eslint@8.56.0)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue-tsc@2.2.8(typescript@5.9.2))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
       '@vitejs/plugin-vue': 6.0.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
       '@vitejs/plugin-vue-jsx': 5.1.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
@@ -24233,8 +24473,8 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.2
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vite-plugin-checker: 0.10.3(eslint@8.56.0)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue-tsc@2.2.8(typescript@5.9.2))
       vue: 3.5.26(typescript@5.9.2)
       vue-bundle-renderer: 2.2.0
@@ -24264,7 +24504,64 @@ snapshots:
       - yaml
     optional: true
 
-  '@nuxt/vite-builder@4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.9.0)':
+    dependencies:
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
+      '@vitejs/plugin-vue': 6.0.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
+      '@vitejs/plugin-vue-jsx': 5.1.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
+      autoprefixer: 10.4.21(postcss@8.5.6)
+      consola: 3.4.2
+      cssnano: 7.1.2(postcss@8.5.6)
+      defu: 6.1.4
+      esbuild: 0.27.2
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      h3: 1.15.4
+      jiti: 2.6.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      mocked-exports: 0.1.1
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      postcss: 8.5.6
+      rollup-plugin-visualizer: 6.0.5(rollup@4.55.1)
+      std-env: 3.10.0
+      ufo: 1.6.2
+      unenv: 2.0.0-rc.24
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-plugin-checker: 0.10.3(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
+      vue: 3.5.26(typescript@5.9.2)
+      vue-bundle-renderer: 2.2.0
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - rolldown
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.1.2(magicast@0.5.1)
       '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
@@ -24291,9 +24588,9 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.2
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-plugin-checker: 0.10.3(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-plugin-checker: 0.10.3(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vue: 3.5.26(typescript@5.9.2)
       vue-bundle-renderer: 2.2.0
     transitivePeerDependencies:
@@ -30883,12 +31180,12 @@ snapshots:
     optionalDependencies:
       react: 19.1.2
 
-  '@storybook/builder-vite@9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@storybook/builder-vite@9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf-plugin': 9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))
       storybook: 9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10)
       ts-dedent: 2.2.0
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   '@storybook/csf-plugin@9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -30908,9 +31205,9 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       storybook: 9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10)
 
-  '@storybook/web-components-vite@9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@storybook/web-components-vite@9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
-      '@storybook/builder-vite': 9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@storybook/builder-vite': 9.0.15(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@storybook/web-components': 9.0.15(lit@3.3.0)(storybook@9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10))
       storybook: 9.0.15(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.5.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -30933,9 +31230,9 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)))(svelte@5.22.5)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))
 
-  '@sveltejs/adapter-auto@6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))':
+  '@sveltejs/adapter-auto@6.1.0(@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@sveltejs/kit': 2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
 
   '@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)))(svelte@5.22.5)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
@@ -30958,11 +31255,11 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@sveltejs/kit@2.42.1(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 1.1.1
@@ -30975,7 +31272,7 @@ snapshots:
       set-cookie-parser: 2.7.2
       sirv: 3.0.2
       svelte: 5.22.5
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
@@ -30988,12 +31285,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       debug: 4.4.3
       svelte: 5.22.5
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -31010,16 +31307,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@sveltejs/vite-plugin-svelte-inspector': 3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)))(svelte@5.22.5)(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.22.5
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -31773,6 +32070,8 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
+  '@types/jsesc@2.5.1': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -32431,7 +32730,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.6)
       '@rolldown/pluginutils': 1.0.0-beta.59
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.28.6)
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue: 3.5.26(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
@@ -32454,10 +32753,10 @@ snapshots:
   '@vitejs/plugin-vue@6.0.3(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.53
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue: 3.5.26(typescript@5.9.2)
 
-  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -32471,11 +32770,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -32489,11 +32788,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/coverage-v8@2.1.9(vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -32507,7 +32806,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vitest: 3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32541,21 +32840,21 @@ snapshots:
     optionalDependencies:
       vite: 5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)
 
-  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
-  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))':
+  '@vitest/mocker@3.1.3(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -32616,7 +32915,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   '@vitest/utils@2.1.8':
     dependencies:
@@ -32664,13 +32963,13 @@ snapshots:
     optionalDependencies:
       vue: 3.5.26(typescript@5.9.2)
 
-  '@vue-macros/common@3.1.2(vue@3.5.13(typescript@5.9.2))':
+  '@vue-macros/common@3.1.4(vue@3.5.13(typescript@5.9.2))':
     dependencies:
       '@vue/compiler-sfc': 3.5.26
       ast-kit: 2.2.0
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string-ast: 1.0.3
-      unplugin-utils: 0.3.1
+      unplugin-utils: 0.3.2
     optionalDependencies:
       vue: 3.5.13(typescript@5.9.2)
 
@@ -32804,9 +33103,9 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.9
 
-  '@vue/devtools-api@8.0.6':
+  '@vue/devtools-api@8.2.1':
     dependencies:
-      '@vue/devtools-kit': 8.0.6
+      '@vue/devtools-kit': 8.2.1
 
   '@vue/devtools-core@7.7.9(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
@@ -32821,14 +33120,14 @@ snapshots:
       - vite
     optional: true
 
-  '@vue/devtools-core@7.7.9(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2))':
+  '@vue/devtools-core@7.7.9(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))':
     dependencies:
       '@vue/devtools-kit': 7.7.9
       '@vue/devtools-shared': 7.7.9
       mitt: 3.0.1
       nanoid: 5.1.6
       pathe: 2.0.3
-      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       vue: 3.5.26(typescript@5.9.2)
     transitivePeerDependencies:
       - vite
@@ -32843,23 +33142,18 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
-  '@vue/devtools-kit@8.0.6':
+  '@vue/devtools-kit@8.2.1':
     dependencies:
-      '@vue/devtools-shared': 8.0.6
+      '@vue/devtools-shared': 8.2.1
       birpc: 2.9.0
       hookable: 5.5.3
-      mitt: 3.0.1
       perfect-debounce: 2.0.0
-      speakingurl: 14.0.1
-      superjson: 2.2.6
 
   '@vue/devtools-shared@7.7.9':
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-shared@8.0.6':
-    dependencies:
-      rfdc: 1.4.1
+  '@vue/devtools-shared@8.2.1': {}
 
   '@vue/language-core@2.1.8(typescript@5.9.2)':
     dependencies:
@@ -33600,32 +33894,6 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/vue@0.4.11(5vzbct2uaipf5r2blozxodbb5i)':
-    dependencies:
-      '@tanstack/vue-query': 5.75.5(vue@3.5.13(typescript@5.9.2))
-      '@wagmi/connectors': 7.1.2(ocejhru64sxvx5qpq2agrnpmsy)
-      '@wagmi/core': 3.2.2(@tanstack/query-core@5.75.5)(@types/react@19.1.15)(ox@0.11.3(typescript@5.9.2)(zod@4.3.5))(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5))
-      viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
-      vue: 3.5.13(typescript@5.9.2)
-    optionalDependencies:
-      nuxt: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2)
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - '@base-org/account'
-      - '@coinbase/wallet-sdk'
-      - '@gemini-wallet/core'
-      - '@metamask/sdk'
-      - '@safe-global/safe-apps-provider'
-      - '@safe-global/safe-apps-sdk'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@walletconnect/ethereum-provider'
-      - immer
-      - ox
-      - porto
-      - react
-      - use-sync-external-store
-
   '@wagmi/vue@0.4.11(cfqjh5ewdw4p4dvxxz2cyaicbi)':
     dependencies:
       '@tanstack/vue-query': 5.75.5(vue@3.4.3(typescript@5.9.2))
@@ -33652,6 +33920,32 @@ snapshots:
       - react
       - use-sync-external-store
 
+  '@wagmi/vue@0.4.11(ji2dlbljdvygmm4yvvoceoa2xy)':
+    dependencies:
+      '@tanstack/vue-query': 5.75.5(vue@3.5.13(typescript@5.9.2))
+      '@wagmi/connectors': 7.1.2(ocejhru64sxvx5qpq2agrnpmsy)
+      '@wagmi/core': 3.2.2(@tanstack/query-core@5.75.5)(@types/react@19.1.15)(ox@0.11.3(typescript@5.9.2)(zod@4.3.5))(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5))
+      viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vue: 3.5.13(typescript@5.9.2)
+    optionalDependencies:
+      nuxt: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@gemini-wallet/core'
+      - '@metamask/sdk'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - immer
+      - ox
+      - porto
+      - react
+      - use-sync-external-store
+
   '@wagmi/vue@0.4.11(mfyputxfqlruqg2tmrxfvhrptm)':
     dependencies:
       '@tanstack/vue-query': 5.75.5(vue@3.4.3(typescript@5.9.2))
@@ -33661,6 +33955,32 @@ snapshots:
       vue: 3.4.3(typescript@5.9.2)
     optionalDependencies:
       nuxt: 4.1.2(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(eslint@8.56.0)(ioredis@5.9.1)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue-tsc@2.2.8(typescript@5.9.2))
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@gemini-wallet/core'
+      - '@metamask/sdk'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - immer
+      - ox
+      - porto
+      - react
+      - use-sync-external-store
+
+  '@wagmi/vue@0.4.11(si35kwyvvlxpeeechs4blwrj5q)':
+    dependencies:
+      '@tanstack/vue-query': 5.75.5(vue@3.5.13(typescript@5.9.2))
+      '@wagmi/connectors': 7.1.2(ocejhru64sxvx5qpq2agrnpmsy)
+      '@wagmi/core': 3.2.2(@tanstack/query-core@5.75.5)(@types/react@19.1.15)(ox@0.11.3(typescript@5.9.2)(zod@4.3.5))(react@19.2.1)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.2.1))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5))
+      viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@4.3.5)
+      vue: 3.5.13(typescript@5.9.2)
+    optionalDependencies:
+      nuxt: 4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - '@base-org/account'
@@ -34033,6 +34353,50 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
       '@walletconnect/utils': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.8.3)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.44.0
+      events: 3.3.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/core@2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@walletconnect/keyvaluestorage': 1.1.1(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/utils': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.44.0
       events: 3.3.0
@@ -34926,6 +35290,42 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/sign-client@2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@walletconnect/core': 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/utils': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/sign-client@2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/core': 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -35468,6 +35868,46 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/universal-provider@2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/sign-client': 2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@walletconnect/types': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/utils': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)
+      es-toolkit: 1.44.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/universal-provider@2.23.7(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -35906,6 +36346,50 @@ snapshots:
       - uploadthing
       - zod
 
+  '@walletconnect/utils@2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/logger': 3.0.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      blakejs: 1.2.1
+      detect-browser: 5.3.0
+      ox: 0.9.3(typescript@5.9.2)
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - zod
+
   '@walletconnect/utils@2.23.7(aws4fetch@1.0.20)(db0@0.3.4)(ioredis@5.9.1)(typescript@5.9.2)(zod@3.25.76)':
     dependencies:
       '@msgpack/msgpack': 3.1.3
@@ -36275,6 +36759,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  acorn@8.18.0: {}
+
   aes-js@3.0.0: {}
 
   aes-js@4.0.0-beta.5: {}
@@ -36487,7 +36973,7 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
 
   ast-types-flow@0.0.8: {}
@@ -36503,6 +36989,12 @@ snapshots:
   ast-walker-scope@0.8.3:
     dependencies:
       '@babel/parser': 7.28.6
+      ast-kit: 2.2.0
+
+  ast-walker-scope@0.9.0:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       ast-kit: 2.2.0
 
   astral-regex@2.0.0: {}
@@ -38274,7 +38766,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.5(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.56.0)
@@ -38312,8 +38804,8 @@ snapshots:
       '@typescript-eslint/parser': 6.18.1(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.56.0)
       eslint-plugin-react: 7.37.5(eslint@8.56.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.56.0)
@@ -38330,7 +38822,7 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -38367,22 +38859,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 8.56.0
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -38397,7 +38874,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -38427,17 +38904,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.18.1(eslint@8.56.0)(typescript@5.9.2)
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@6.18.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
@@ -38460,7 +38926,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.56.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -38472,35 +38938,6 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.8.3))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 6.18.1(eslint@8.56.0)(typescript@5.9.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.56.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.18.1(eslint@8.56.0)(typescript@5.9.2))(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -38547,7 +38984,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -39211,6 +39648,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   feaxios@0.0.23:
     dependencies:
@@ -40763,6 +41204,12 @@ snapshots:
       pkg-types: 2.3.0
       quansync: 0.2.11
 
+  local-pkg@1.2.1:
+    dependencies:
+      mlly: 1.8.2
+      pkg-types: 2.3.0
+      quansync: 0.2.11
+
   localforage@1.10.0:
     dependencies:
       lie: 3.1.1
@@ -41109,6 +41556,13 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.2
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
 
   mnemonist@0.38.3:
     dependencies:
@@ -41506,6 +41960,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nostics@1.2.0: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -41525,15 +41981,142 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(yaml@2.8.2):
+  nuxt@4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0):
+    dependencies:
+      '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/devtools': 2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/schema': 4.1.2
+      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
+      '@nuxt/vite-builder': 4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.9.0)
+      '@unhead/vue': 2.1.2(vue@3.5.26(typescript@5.9.2))
+      '@vue/shared': 3.5.26
+      c12: 3.3.3(magicast@0.3.5)
+      chokidar: 4.0.3
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.6.1
+      errx: 0.1.0
+      esbuild: 0.27.2
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      exsolve: 1.0.8
+      h3: 1.15.4
+      hookable: 5.5.3
+      ignore: 7.0.5
+      impound: 1.0.0
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      mocked-exports: 0.1.1
+      nanotar: 0.2.0
+      nitropack: 2.13.0(aws4fetch@1.0.20)(idb-keyval@6.2.2)
+      nypm: 0.6.2
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 5.0.1
+      oxc-minify: 0.87.0
+      oxc-parser: 0.56.5
+      oxc-transform: 0.87.0
+      oxc-walker: 0.5.2(oxc-parser@0.56.5)
+      pathe: 2.0.3
+      perfect-debounce: 2.0.0
+      pkg-types: 2.3.0
+      radix3: 1.1.2
+      scule: 1.3.0
+      semver: 7.7.2
+      std-env: 3.10.0
+      tinyglobby: 0.2.15
+      ufo: 1.6.2
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 5.6.0
+      unplugin: 2.3.11
+      unplugin-vue-router: 0.15.0(@vue/compiler-sfc@3.5.26)(vue-router@4.6.4(vue@3.5.26(typescript@5.9.2)))(vue@3.5.26(typescript@5.9.2))
+      unstorage: 1.17.3(aws4fetch@1.0.20)(db0@0.3.4)(idb-keyval@6.2.2)(ioredis@5.9.1)
+      untyped: 2.0.0
+      vue: 3.5.26(typescript@5.9.2)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+      vue-router: 4.6.4(vue@3.5.26(typescript@5.9.2))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.4
+      '@types/node': 22.13.9
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxt@4.1.2(@parcel/watcher@2.5.4)(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@9.39.1(jiti@2.6.1))(idb-keyval@6.2.2)(ioredis@5.9.1)(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2))
+      '@nuxt/devtools': 2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2))
       '@nuxt/kit': 4.1.2(magicast@0.5.1)
       '@nuxt/schema': 4.1.2
       '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
-      '@nuxt/vite-builder': 4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.1.2(@types/node@22.13.9)(eslint@9.39.1(jiti@2.6.1))(lightningcss@1.30.2)(magicast@0.5.1)(optionator@0.9.4)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue@3.5.26(typescript@5.9.2))(yaml@2.9.0)
       '@unhead/vue': 2.1.2(vue@3.5.26(typescript@5.9.2))
       '@vue/shared': 3.5.26
       c12: 3.3.3(magicast@0.5.1)
@@ -41654,16 +42237,16 @@ snapshots:
 
   nuxt@4.1.2(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(eslint@8.56.0)(ioredis@5.9.1)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue-tsc@2.1.8(typescript@5.9.2)):
     dependencies:
-      '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)
+      '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
+      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
       '@nuxt/vite-builder': 4.1.2(@types/node@22.13.9)(eslint@8.56.0)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue-tsc@2.1.8(typescript@5.9.2))(vue@3.5.26(typescript@5.9.2))
       '@unhead/vue': 2.1.2(vue@3.5.26(typescript@5.9.2))
       '@vue/shared': 3.5.26
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -41781,16 +42364,16 @@ snapshots:
 
   nuxt@4.1.2(@types/node@22.13.9)(@vue/compiler-sfc@3.5.26)(aws4fetch@1.0.20)(bufferutil@4.1.0)(db0@0.3.4)(eslint@8.56.0)(ioredis@5.9.1)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue-tsc@2.2.8(typescript@5.9.2)):
     dependencies:
-      '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.5.1)
+      '@nuxt/cli': 3.32.0(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))(vue@3.5.26(typescript@5.9.2))
-      '@nuxt/kit': 4.1.2(magicast@0.5.1)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.6.6(magicast@0.5.1)
+      '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
       '@nuxt/vite-builder': 4.1.2(@types/node@22.13.9)(eslint@8.56.0)(lightningcss@1.30.2)(rollup@4.55.1)(terser@5.44.1)(typescript@5.9.2)(vue-tsc@2.2.8(typescript@5.9.2))(vue@3.5.26(typescript@5.9.2))
       '@unhead/vue': 2.1.2(vue@3.5.26(typescript@5.9.2))
       '@vue/shared': 3.5.26
-      c12: 3.3.3(magicast@0.5.1)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -42207,6 +42790,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.9.3(typescript@5.9.2):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.2)(zod@3.22.4)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - zod
+
   ox@0.9.3(typescript@5.9.2)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -42536,6 +43134,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picomatch@4.0.5: {}
+
   pify@2.3.0: {}
 
   pify@3.0.0: {}
@@ -42604,7 +43204,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.0
+      mlly: 1.8.2
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -44576,6 +45176,18 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
+  svelte-check@4.1.5(picomatch@4.0.5)(svelte@5.22.5)(typescript@5.9.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      chokidar: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picocolors: 1.1.1
+      sade: 1.8.1
+      svelte: 5.22.5
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - picomatch
+
   svelte-eslint-parser@0.43.0(svelte@5.22.5):
     dependencies:
       eslint-scope: 7.2.2
@@ -44740,6 +45352,18 @@ snapshots:
 
   term-size@2.2.1: {}
 
+  terser-webpack-plugin@5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.44.1
+      webpack: 5.104.1(esbuild@0.27.2)
+    optionalDependencies:
+      esbuild: 0.27.2
+    optional: true
+
   terser-webpack-plugin@5.3.16(webpack@5.104.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -44857,6 +45481,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@1.1.1: {}
 
@@ -45160,6 +45789,8 @@ snapshots:
 
   ufo@1.6.2: {}
 
+  ufo@1.6.4: {}
+
   uint8array-tools@0.0.8: {}
 
   uint8array-tools@0.0.9: {}
@@ -45285,6 +45916,11 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.3
 
+  unplugin-utils@0.3.2:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.5
+
   unplugin-vue-router@0.15.0(@vue/compiler-sfc@3.5.26)(vue-router@4.6.4(vue@3.5.26(typescript@5.9.2)))(vue@3.5.26(typescript@5.9.2)):
     dependencies:
       '@vue-macros/common': 3.0.0-beta.16(vue@3.5.26(typescript@5.9.2))
@@ -45328,11 +45964,16 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.0.0:
+  unplugin@3.3.0(esbuild@0.27.2)(rollup@4.55.1)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.55.1
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      webpack: 5.104.1(esbuild@0.27.2)
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -45685,20 +46326,20 @@ snapshots:
       vite-hot-client: 2.1.0(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))
     optional: true
 
-  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)):
     dependencies:
       birpc: 2.9.0
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
 
   vite-hot-client@2.1.0(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)):
     dependencies:
       vite: 5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)
     optional: true
 
-  vite-hot-client@2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
   vite-node@1.6.1(@types/node@22.13.4)(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
@@ -45736,13 +46377,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.1.3(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite-node@3.1.3(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -45757,13 +46398,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.1.3(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite-node@3.1.3(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -45778,13 +46419,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -45809,7 +46450,7 @@ snapshots:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 8.56.0
@@ -45827,7 +46468,7 @@ snapshots:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 8.56.0
@@ -45835,7 +46476,7 @@ snapshots:
       vue-tsc: 2.2.8(typescript@5.9.2)
     optional: true
 
-  vite-plugin-checker@0.10.3(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)):
+  vite-plugin-checker@0.10.3(eslint@9.39.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.2)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.28.6
       chokidar: 4.0.3
@@ -45845,7 +46486,7 @@ snapshots:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
@@ -45870,7 +46511,7 @@ snapshots:
       - supports-color
     optional: true
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@3.20.2(magicast@0.3.5))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@3.20.2(magicast@0.3.5))(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -45880,8 +46521,8 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
     optionalDependencies:
       '@nuxt/kit': 3.20.2(magicast@0.3.5)
     transitivePeerDependencies:
@@ -45906,14 +46547,14 @@ snapshots:
       vue: 3.5.26(typescript@5.9.2)
     optional: true
 
-  vite-plugin-vue-tracer@1.2.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vue@3.5.26(typescript@5.9.2)):
+  vite-plugin-vue-tracer@1.2.0(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.26(typescript@5.9.2)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       vue: 3.5.26(typescript@5.9.2)
 
   vite@5.4.20(@types/node@22.13.4)(lightningcss@1.30.2)(terser@5.44.1):
@@ -45938,7 +46579,7 @@ snapshots:
       lightningcss: 1.30.2
       terser: 5.44.1
 
-  vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -45952,9 +46593,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.44.1
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -45968,9 +46609,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.44.1
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -45984,17 +46625,17 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       terser: 5.44.1
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   vitefu@1.1.1(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)):
     optionalDependencies:
       vite: 5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1)
 
-  vitefu@1.1.1(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)):
+  vitefu@1.1.1(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
 
-  vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@2.1.9(@types/node@22.13.9)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@22.13.9)(lightningcss@1.30.2)(terser@5.44.1))
@@ -46032,10 +46673,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.4)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -46052,8 +46693,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 3.1.3(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.1.3(@types/node@22.13.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -46075,10 +46716,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2):
+  vitest@3.1.3(@types/debug@4.1.12)(@types/node@22.13.9)(@vitest/ui@2.1.8(vitest@2.1.9))(happy-dom@15.11.7)(jiti@2.6.1)(jsdom@24.1.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))
+      '@vitest/mocker': 3.1.3(vite@6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -46095,8 +46736,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
-      vite-node: 3.1.3(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2)
+      vite: 6.3.6(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+      vite-node: 3.1.3(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -46143,28 +46784,39 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.26(typescript@5.9.2)
 
-  vue-router@5.0.2(@vue/compiler-sfc@3.5.26)(vue@3.5.13(typescript@5.9.2)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.26)(esbuild@0.27.2)(rollup@4.55.1)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(vue@3.5.13(typescript@5.9.2))(webpack@5.104.1(esbuild@0.27.2)):
     dependencies:
-      '@babel/generator': 7.28.6
-      '@vue-macros/common': 3.1.2(vue@3.5.13(typescript@5.9.2))
-      '@vue/devtools-api': 8.0.6
-      ast-walker-scope: 0.8.3
+      '@babel/generator': 8.0.0
+      '@vue-macros/common': 3.1.4(vue@3.5.13(typescript@5.9.2))
+      '@vue/devtools-api': 8.2.1
+      ast-walker-scope: 0.9.0
       chokidar: 5.0.0
       json5: 2.2.3
-      local-pkg: 1.1.2
+      local-pkg: 1.2.1
       magic-string: 0.30.21
-      mlly: 1.8.0
+      mlly: 1.8.2
       muggle-string: 0.4.1
+      nostics: 1.2.0
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       scule: 1.3.0
-      tinyglobby: 0.2.15
-      unplugin: 3.0.0
-      unplugin-utils: 0.3.1
+      tinyglobby: 0.2.17
+      unplugin: 3.3.0(esbuild@0.27.2)(rollup@4.55.1)(vite@7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0))(webpack@5.104.1(esbuild@0.27.2))
+      unplugin-utils: 0.3.2
       vue: 3.5.13(typescript@5.9.2)
-      yaml: 2.8.2
+      yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.26
+      vite: 7.3.1(@types/node@22.13.9)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
 
   vue-tsc@2.1.8(typescript@5.9.2):
     dependencies:
@@ -46670,6 +47322,39 @@ snapshots:
       - esbuild
       - uglify-js
 
+  webpack@5.104.1(esbuild@0.27.2):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.4
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2))
+      watchpack: 2.5.0
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
+
   webpack@5.94.0(webpack-cli@5.1.4):
     dependencies:
       '@types/estree': 1.0.8
@@ -46933,6 +47618,8 @@ snapshots:
   yaml@1.10.2: {}
 
   yaml@2.8.2: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
# Description

The Bitcoin `TrezorConnector` could not complete a transaction: it derived keys for the wrong
network, described outputs to the device incorrectly, and returned a PSBT its caller could not
finalize. On top of fixing those defects, the connector no longer asks the device for addresses on
every call — it fetches the account extended public keys **once** and derives every address locally.

Verified end to end on a physical Trezor against Bitcoin testnet3 with a Rootstock peg-in:
transaction `c21249b8c4125a4fca150bde03497f728d9cbe3659940aebc2f30bb1b18903c5`.

## Part 1 — Signing correctness

**1. The active network was never communicated to the connector.**
`TrezorConnector.getWallet()` was called with `requestedChains` but without the active CAIP network
id, so `currentNetwork` remained `'Bitcoin'` until `switchNetwork()` happened to be called. A
testnet-only dApp therefore received **mainnet** addresses (`m/84'/0'/0'/0/0`, `coin: 'btc'`) while
`chainIdMatches` reported true, leaving the application unable to detect the mismatch. A funded
wallet would have been prompted to sign a mainnet transaction. `OKXConnector` two blocks earlier in
`adapter.ts` already receives `requestedCaipNetworkId`; the Trezor registration did not.
`getNetworkFromCaipId()` additionally defaulted any unrecognised id to `'Bitcoin'`, so signet and
regtest silently resolved to mainnet.

Fixed by accepting `requestedCaipNetworkId` in `getWallet()`/the constructor and initialising
`currentNetwork` from it, and by throwing on unsupported networks instead of defaulting to mainnet.

**2. Outputs were described to the device incorrectly.**
OP_RETURN outputs were emitted as `{ address: '', script_type: 'PAYTOWITNESS' }` — the result of
catching the `fromOutputScript` failure that OP_RETURN always produces — which makes any transaction
carrying one unsignable. Every Rootstock peg-in carries an RSKIP-170 OP_RETURN naming the destination
RSK address, so this was the common case. Separately, _all_ outputs were forced to `PAYTOWITNESS`,
which pairs with `address_n` and misdescribes P2SH/P2PKH recipients such as the peg-in federation
address.

Fixed by detecting OP_RETURN explicitly and emitting `PAYTOOPRETURN` with `op_return_data`, using
`PAYTOADDRESS` for third-party outputs and reserving `address_n` for our own outputs, and raising on
scripts that cannot be described rather than sending an empty address.

**3. `signPSBT` returned a PSBT that callers could not finalize.**
The signed witness was grafted back as `finalScriptWitness` with no `partialSig`, so
`finalizeAllInputs()` failed with _"Can not finalize input #0"_. Every other `BitcoinConnector`
returns a signed-but-unfinalized PSBT. Fixed by mapping the P2WPKH witness `[signature, pubkey]` onto
`partialSig`, retaining `finalScriptWitness` only for witness shapes that cannot be expressed as a
single partial signature. That covered native SegWit only — legacy and taproot inputs are handled in
item 12.

**4. Previous transactions were never supplied, and the fallback backend is chain-mismatched.**
The device verifies each input's amount against its previous transaction. With no `refTxs`,
TrezorConnect falls back to a blockbook backend, which reported
`'7cd803d4…9ace' not found` for a transaction that **does exist on testnet3** and is absent from
testnet4 — Trezor's public `tbtc1.trezor.io` appears to serve testnet4 since testnet3 was deprecated.
Fixed by building `refTxs` from each input's `nonWitnessUtxo` (deduplicated by txid) so signing is
self-contained, with the blockbook endpoint configurable per network via `blockbookUrls` as a
fallback, registered once per coin and non-fatal on failure.

**5. Input amounts and script types were assumed rather than derived.**
The amount came only from `witnessUtxo` and silently defaulted to `'0'`, which would make the device
display a wrong fee for a transaction the user was about to approve; `script_type` was hardcoded to
`SPENDWITNESS`, so P2SH-P2WPKH, legacy and taproot inputs could not be signed. Fixed by deriving the
amount from `witnessUtxo` or `nonWitnessUtxo` (raising when neither is present) and inferring
`script_type` from the input's own derivation path.

**6. `@trezor/connect-web` was imported in a way that breaks under some bundlers.**
The package is CommonJS and exposes its API as `exports.default`. Under Node's ESM/CJS interop and
esbuild's node-mode — which Vite uses when prebundling this adapter as a dependency — the default
import resolves to the whole `module.exports`, leaving `TrezorConnect.init` undefined and connecting
failing with a `TypeError` before any device I/O (so no popup appeared). Bundlers honouring
`__esModule` (webpack, Rollup, and Vite's source transform) are unaffected, which is why this was not
caught: the monorepo's own apps consume the adapter as linked source. Fixed by probing for `init`
across interop shapes, lazily so a bad resolution surfaces on use rather than breaking module import.

**7. Failure messages discarded the cause.**
`signPSBT` surfaced only the generic fallback string when `payload.error` was empty, which concealed
the backend error above for an entire debugging cycle. Failures now include Trezor's `code`.

## Part 2 — One device call, locally derived addresses

**8. The device was consulted once per address request.**
`getAccountAddresses()` issued a fresh `getAddress` call every time it ran, with no memoization — and
it is invoked by `connect()`, by the adapter's `getAccounts()`, and again by `switchNetwork()`.
Restoring a session was the worst case: `syncConnections()` calls `connector.connect()` _and then_
`getAccountAddresses()`, so a page reload opened **two popups**.

A single bundled `getPublicKey` call now covers all four accounts, and the result is cached until
disconnect or a coin-type change. An in-flight promise guard means concurrent callers share one
request rather than racing two popups.

**9. Legacy, nested SegWit, native SegWit and taproot accounts are all derived.**
`m/44'/c'/0'`, `m/49'/c'/0'`, `m/84'/c'/0'` and `m/86'/c'/0'`, each with 20 receive and 20 change
addresses — 160 in total, derived locally in ~15 ms. `getDerivedAddresses()` returns the full set and
`getAccountDescriptors()` returns the account descriptors.

`getAccountAddresses()` is deliberately unchanged and still returns the payment/ordinal pair, because
`adapter.ts:144-162` collapses whatever a connector returns to exactly two accounts by position
(`BitcoinConstantsUtil.ACCOUNT_INDEXES`). Keeping that contract means no other Bitcoin connector and
no shared type is touched.

**10. Three defects that were blocked on having no local derivation.**

| Defect                                                                                        | Location                | Now                                                             |
| --------------------------------------------------------------------------------------------- | ----------------------- | --------------------------------------------------------------- |
| `publicKey` hardcoded `undefined`, leaving the `signInputs[].publicKey` branch unable to match | `index.ts:202`          | Populated from the derived key                                   |
| Real BIP84 change at `.../1/*` described to the device as a third-party payment                | `signPSBT`, `index.ts:311` | Matched against all 160; script type follows the address        |
| `getPathForAddress` ignored its argument, so an unplaceable address signed with `.../0/0`      | `index.ts:523-525`      | Throws                                                            |

Output script types now follow the address rather than always being `PAYTOWITNESS`, which
misdescribed legacy, nested SegWit and taproot change: `PAYTOADDRESS` / `PAYTOP2SHWITNESS` /
`PAYTOWITNESS` / `PAYTOTAPROOT`, with the matching `SPEND*` types for inputs.

**11. Taproot outputs were unsignable.**
`bitcoinjs-lib`'s `payments.p2tr` calls `getEccLib()`, which throws `No ECC Library provided` unless
`initEccLib()` has been called — and the adapter never calls it. Any PSBT carrying a P2TR output
therefore failed in `decodeOutputAddress`. Pre-existing, but disqualifying once taproot accounts are
derived. Output scripts are now decoded with `@trezor/utxo-lib`, which ships its own ECC.

**12. Legacy and taproot signatures were dropped when grafting them back.**
Item 3 mapped the device's signatures onto `partialSig`, but it read only the **witness** — which is
correct for P2WPKH and wrong for the two script types this PR newly derives. Both came back unsigned
*after the user had already approved them on the device*, and the loss was silent: the caller only
found out a step later, unable to finalize.

| Input                   | Where the device puts the signature                      | Now written to                    |
| ----------------------- | -------------------------------------------------------- | --------------------------------- |
| Legacy (P2PKH)          | scriptSig as `<signature> <publicKey>` — no witness at all | `partialSig`                      |
| Taproot key-path        | one Schnorr signature, 64 bytes (65 with a sighash flag), no public key alongside | `tapKeySig` (BIP-371) |
| Multisig / script paths | multi-item witness                                        | `finalScriptWitness`, as before   |
| Unsigned                | nothing                                                   | left untouched                    |

The legacy path is recognised only when the scriptSig decompiles to exactly two chunks whose second
is a 33- or 65-byte public key, so a P2SH redeem path is not mistaken for a bare P2PKH.

### Two derivation hazards, both guarded

- **A bare BIP86 xpub silently yields legacy addresses.** It carries the same `0x0488b21e` version
  bytes as a BIP44 xpub, and `@trezor/utxo-lib`'s version-byte table has no taproot entry — so
  deriving from one produces P2PKH addresses at `m/44'/…` instead of taproot. Reproduced during
  development: a BIP86 xpub yielded `1NsJS4DAHLcegD63trZurmkLm23TRAujXd`. Taproot is only reachable
  through the `tr([fp/86'/c'/0']xpub…/<0;1>/*)` output descriptor, which Trezor returns in
  `xpubSegwit`. Rather than trust that, `requestAccountDescriptors` asserts every descriptor resolves
  to the account type it asked for and throws otherwise. This is the same failure class as defect 1,
  so it is defended by an assertion and a test, not a comment.
- **Picking the wrong field gives the wrong script type.** `xpubSegwit ?? xpub` is used, matching
  TrezorConnect's own precedence (`DeviceCommands.js:161`): `xpub` is always the coin default format,
  while `xpubSegwit` carries the ypub/zpub or `tr(…)` form that identifies the script type.

### Dependency

Adds `@trezor/utxo-lib@2.5.0` as a direct dependency. It was **already** a dependency of
`@trezor/connect@9.7.3` at that exact version and resolves to the same store instance, so it adds no
new install weight — `tiny-secp256k1` was already being installed for every consumer of this adapter.

### Scope of impact

Confined to the Bitcoin adapter's Trezor connector plus one line in `adapter.ts`. No other
connector's behaviour changes, and no shared type is modified — script type is read from the
derivation path rather than added to `BitcoinConnector.AccountAddress`. `TrezorConnector` is **not**
part of the published API surface (`packages/adapters/bitcoin/exports/index.ts` re-exports only
`adapter.js` and `BitcoinConnector.js`), so the `getWallet()` signature change and the new methods are
internal and non-breaking for consumers.

The `WalletConnectProvider.test.ts` fixture update is unrelated to Trezor: it repairs a test that had
been failing since `getAccountAddresses` began returning address descriptors rather than bare
strings.

### Changesets

Two, both `patch` across the fixed `@reown/appkit-*` group:
`.changeset/trezor-network-and-psbt-fixes.md` and `.changeset/trezor-xpub-address-derivation.md`.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Both are ticked: parts 1 and 10–11 are bug fixes, while the multi-account derivation and the
`getDerivedAddresses()` / `getAccountDescriptors()` methods add functionality. Neither is breaking —
`TrezorConnector` is not exported from the package.

# Associated Issues

<!-- Replace before opening the PR: `Closes APKT-xxx` for Linear, or `closes #...` for GitHub. -->

No tracking issue filed yet. Per `CONTRIBUTING.md` an issue is _recommended_ (not required) for a bug
fix. Subject: Trezor support in the Bitcoin adapter — unable to complete a peg-in; connector derives
mainnet keys on testnet and returns an unfinalizable PSBT.

# Showcase (Optional)

No UI change. Behavioural before/after, captured from the adapter:

**Before** — mainnet keys on a testnet-only dApp:

```
walletInfoName:  "Trezor"        constructorName: TrezorConnector
address:         bc1qcn0vgfws6gn37nm0wya273d9ms0gn0cpxpttqf   ← mainnet
path:            m/84'/0'/0'/0/0                              ← coin type 0
expectedChainId: 000000000933ea01ad0ee984209779ba             ← testnet3 genesis
chainIdMatches:  true
```

**Before** — the connector could not be reached at all under Vite dev:

```
TypeError: import_connect_web.default.init is not a function
  at TrezorConnector.initTrezor → connect → BitcoinAdapter.connect
```

**Before** — signing failed against the fallback backend:

```
'7cd803d4fdf84bd92090b26bcbef84eec99e84a7414d698558cc644b67649ace' not found
```

**Before / after** — device interactions per session:

```
                        before   after
connect()                  1        1
adapter getAccounts()      1        0   (cache)
page reload / restore      2        0   (cache)
switchNetwork(same net)    1        0   (cache)
switchNetwork(new coin)    1        1
                        ------   -----
typical session            5+       1
```

**After** — broadcast peg-in on testnet3
(`c21249b8c4125a4fca150bde03497f728d9cbe3659940aebc2f30bb1b18903c5`):

```
inputs  : 1   (witness items: 2)
outputs :
    op_return           0   6a1952534b5401b69d88d37e8788f1e8f86fd26c…   (RSKT + RSK address)
    p2sh           500000   2N88sMiizxmbb8Y3yA4AtYmL1RxHogWfoHa        (federation)
    v0_p2wpkh       99746   tb1qrntk9huas8866t8hsa5xng5vgen3psjwf26jmm (change)
fee     : 254 sats
```

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

> Preview link not exercised: this work requires a physical Trezor, and the interop defect (6) only
> reproduces when the adapter is consumed **as a built dependency** by a Vite app. Manual QA was done
> locally against a Vite dApp with real hardware — steps below.

---

## Verification detail

### Pre-submit checks (`.agents/context/contributing.md`)

| Command                  | Result                                             |
| ------------------------ | -------------------------------------------------- |
| `pnpm build`             | 24/24 tasks                                         |
| `pnpm typecheck`         | 49/49 tasks                                         |
| `pnpm test`              | 251 files, 3305 passed, 11 skipped, 1 todo          |
| `pnpm lint`              | 0 errors (13 pre-existing warnings, none in bitcoin) |
| `pnpm run prettier:format` | clean                                             |

Scoped to the touched package:

| Command                                                | Result                                                              |
| ------------------------------------------------------ | -------------------------------------------------------------------- |
| `pnpm --filter @reown/appkit-adapter-bitcoin build`     | compiles cleanly                                                      |
| `pnpm --filter @reown/appkit-adapter-bitcoin typecheck` | clean                                                                 |
| `pnpm --filter @reown/appkit-adapter-bitcoin lint`      | clean — also resolves 8 lint errors pre-existing in the connector     |
| `npx vitest run packages/adapters/bitcoin`              | **269 pass**, incl. **55** in `TrezorConnector.test.ts` (was 15)      |
| `npx prettier --check packages/adapters/bitcoin`        | clean                                                                 |

### Test coverage added

Derivation is asserted against the **official BIP44/49/84/86 test vectors**, receive and change
chains, so the fixtures are real descriptors and the tests exercise actual derivation rather than a
stand-in:

| Type  | Derived                                                          |
| ----- | ---------------------------------------------------------------- |
| BIP44 | `1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA`                              |
| BIP49 | `37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf`                              |
| BIP84 | `bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu`                      |
| BIP86 | `bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr` |

Other cases: one `getPublicKey` call across `connect()` + repeated `getAccountAddresses()` +
`getDerivedAddresses()`; `getAddress` never called; concurrent callers share one request; cache
cleared on disconnect; all four accounts requested in one bundle; 160 addresses with 20 per chain per
type; `getAccountAddresses()` still returns exactly two, payment first; `publicKey` populated;
per-type change script types including `PAYTOTAPROOT`; input path resolved from `signInputs` by both
address and public key; unknown address throws; coin-type switch refetches while a same-network
switch does not; a descriptor whose type does not match the requested account is rejected; a legacy
signature is recovered from its scriptSig into `partialSig`; a taproot key-path signature lands in
`tapKeySig`; plus the existing OP_RETURN, `PAYTOADDRESS`, `partialSig`, `refTxs` and
amount-derivation cases.

Two guards in item 12 are asserted by construction rather than by a test: the 65-byte
sighash-flagged Schnorr signature (the test covers 64), and the 33/65-byte public-key length check
that stops a P2SH redeem path being read as a bare P2PKH.

### Manual QA, physical Trezor on testnet

Run locally against a Vite dApp consuming the built adapter **as a dependency**, not as linked
source — this is what exercises the interop fix.

1. Configure the dApp with `bitcoinTestnet` only.
2. Connect the **"Trezor"** entry (popup flow, not "Trezor Suite"). One popup; addresses are `tb1…`
   on `m/84'/1'/0'/0/0`. Before this change it returned mainnet `bc1…`, or failed with "User rejected
   the request" under Vite dev.
3. Reload to trigger `syncConnections()` — no further popups, where previously there were two.
4. `BitcoinGetAccountAddressesTest.tsx` shows `publicKey` populated rather than `N/A`.
5. Spot-check one derived address per script type against the device's own `getAddress` for the same
   path (`1…`, `3…`, `tb1q…`, `tb1p…`) — this is what would catch the silent-legacy taproot hazard on
   real hardware.
6. Peg-in PSBT with real BIP84 change on `.../1/*`: the device labels it as change rather than a
   third-party send.

### Negative cases

- Unsupported bip122 CAIP id throws rather than deriving mainnet keys.
- A PSBT input with neither `witnessUtxo` nor `nonWitnessUtxo` raises rather than sending `amount: '0'`.
- An unreachable blockbook endpoint still allows connecting.
- An address not derived from the account throws rather than signing with `.../0/0`.

## Known issues / limitations

- **The wide address set stops at the adapter.** `adapter.ts:144-162` collapses any connector's
  result to exactly two accounts by position, so `useAppKitAccount()` still sees payment + ordinal.
  The other 158 addresses are reachable only via `getDerivedAddresses()` on the connector. Removing
  that collapse would change behaviour for all seven Bitcoin connectors, so it was deliberately left
  out; `getChangeAddresses()` still does not exist on the `BitcoinConnector` interface.
- **This derives a fixed window, it does not discover.** 20 indices per chain (the BIP44 gap limit)
  with no backend scan, so there is no notion of which addresses are actually used. Balance remains
  single-address via `BitcoinApi.getUTXOs`.
- **`ordinal` is still BIP84 `.../0/1`.** The ecosystem convention (Xverse and others) is BIP86
  taproot, and taproot is now derived — but changing it would change the ordinal address existing
  Trezor users see, so it was left alone. Worth deciding separately.
- **`adapter.ts` still relabels every `connect()` failure as `UserRejectedRequestError`**, discarding
  the original message; the connecting view then reduces it to a boolean. This made the interop bug
  present as a user rejection that never happened and cost more debugging time than any of the actual
  defects. Worth a separate PR, since `ErrorUtil.isUserRejectedRequestError` already exists.
- **`tbtc1.trezor.io` serving testnet4 is inferred, not confirmed** — Cloudflare blocks automated
  requests to that host. The inference rests on the previous transaction being present on testnet3 and
  absent from testnet4. `refTxs` makes the backend unnecessary for PSBTs that carry previous
  transactions, so this does not block the fix.
- **Only the native-SegWit peg-in path was verified on hardware.** The legacy, nested SegWit and
  taproot accounts are covered by test vectors and spot-checked against the device, but no
  transaction was signed from them. `sendTransfer` and `signMessage` were not re-tested on a device.
- The `WalletConnectProvider.test.ts` fixture repair and the pre-existing lint fixes are unrelated to
  the Trezor behaviour and could be split out if a single-purpose diff is preferred
  (`CONTRIBUTING.md` asks that commits stay focused).
