### PR TITLE
fix(walletconnect): scope EVM message signing

### DIFF
--- a/.changeset/siwx-walletconnect-routing.md
+++ b/.changeset/siwx-walletconnect-routing.md
@@ -1,0 +1,10 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-controllers': patch
+---
+
+Route EVM WalletConnect signatures through the shared connector.
+
+The shared WalletConnect connector now passes the captured CAIP network to UniversalProvider
+instead of relying on mutable provider state. This applies consistently across EVM adapters, and
+provider errors retain their original cause.

--- a/packages/appkit/src/client/appkit-base-client.ts
+++ b/packages/appkit/src/client/appkit-base-client.ts
@@ -78,6 +78,7 @@ import {
   SnackController,
   StorageUtil,
   ThemeController,
+  WalletConnectConnector,
   WalletUtil,
   WcHelpersUtil,
   getPreferredAccountType,
@@ -769,12 +770,37 @@ export abstract class AppKitBaseClient {
           throw new Error('signMessage: connector changed before the request was sent')
         }
 
+        const connectorId = context?.connectorId || activeConnectorId
+        if (
+          connectorId === ConstantsUtil.CONNECTOR_ID.WALLET_CONNECT &&
+          namespace === ConstantsUtil.CHAIN.EVM
+        ) {
+          const connector = ConnectorController.getConnector({
+            id: connectorId,
+            namespace
+          }) as WalletConnectConnector | undefined
+
+          if (!connector || typeof connector.signEvmMessage !== 'function') {
+            throw new Error(
+              'signMessage: WalletConnect connector does not support EVM message signing'
+            )
+          }
+
+          const result = await connector.signEvmMessage({
+            message,
+            address,
+            caipNetworkId: caipNetwork.caipNetworkId
+          })
+
+          return result.signature
+        }
+
         const result = await adapter.signMessage({
           message,
           address,
           provider: ProviderController.getProvider(namespace),
           caipNetwork,
-          connectorId: context?.connectorId || activeConnectorId
+          connectorId
         })
 
         return result?.signature || ''

--- a/packages/appkit/tests/client/sign-message.test.ts
+++ b/packages/appkit/tests/client/sign-message.test.ts
@@ -5,7 +5,8 @@ import {
   ChainController,
   ConnectorController,
   ProviderController,
-  type SignMessageContext
+  type SignMessageContext,
+  type WalletConnectConnector
 } from '@reown/appkit-controllers'
 import { mockChainControllerState } from '@reown/appkit-controllers/testing'
 
@@ -41,8 +42,8 @@ describe('AppKit message signing', () => {
     appKit = new TestAppKit(mockOptions)
   })
 
-  it('uses the captured SIWX chain and account when the active namespace changes', async () => {
-    const provider = { request: vi.fn() }
+  it('routes WalletConnect signing through the captured EVM connector', async () => {
+    const signEvmMessage = vi.fn().mockResolvedValue({ signature: '0xsignature' })
     const context: SignMessageContext = {
       chainId: mainnet.caipNetworkId,
       accountAddress: '0x1234567890123456789012345678901234567890',
@@ -55,6 +56,41 @@ describe('AppKit message signing', () => {
     })
     vi.spyOn(ChainController, 'getCaipNetworkById').mockReturnValue(mainnet)
     vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('walletConnect')
+    vi.spyOn(ConnectorController, 'getConnector').mockReturnValue({
+      signEvmMessage
+    } as unknown as WalletConnectConnector)
+    const getProviderSpy = vi.spyOn(ProviderController, 'getProvider')
+
+    const result = await appKit.testConnectionControllerClient?.signMessage('Sign in', context)
+
+    expect(ConnectorController.getConnector).toHaveBeenCalledWith({
+      id: context.connectorId,
+      namespace: ConstantsUtil.CHAIN.EVM
+    })
+    expect(signEvmMessage).toHaveBeenCalledWith({
+      message: 'Sign in',
+      address: context.accountAddress,
+      caipNetworkId: context.chainId
+    })
+    expect(getProviderSpy).not.toHaveBeenCalled()
+    expect(mockEvmAdapter.signMessage).not.toHaveBeenCalled()
+    expect(result).toBe('0xsignature')
+  })
+
+  it('keeps adapter signing for non-WalletConnect connectors', async () => {
+    const provider = { request: vi.fn() }
+    const context: SignMessageContext = {
+      chainId: mainnet.caipNetworkId,
+      accountAddress: '0x1234567890123456789012345678901234567890',
+      connectorId: 'injected'
+    }
+
+    mockChainControllerState({
+      activeChain: ConstantsUtil.CHAIN.SOLANA,
+      activeCaipNetwork: solana
+    })
+    vi.spyOn(ChainController, 'getCaipNetworkById').mockReturnValue(mainnet)
+    vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('injected')
     vi.spyOn(ProviderController, 'getProvider').mockReturnValue(provider)
     vi.spyOn(mockEvmAdapter, 'signMessage').mockResolvedValue({ signature: '0xsignature' })
 

--- a/packages/appkit/tests/connectors/WalletConnectConnector.test.ts
+++ b/packages/appkit/tests/connectors/WalletConnectConnector.test.ts
@@ -19,6 +19,7 @@ describe('WalletConnectConnector', () => {
   let provider: typeof mockProvider
 
   beforeEach(() => {
+    vi.clearAllMocks()
     caipNetworks = [
       { ...mainnet, caipNetworkId: 'eip155:1', chainNamespace: 'eip155' },
       solana,
@@ -76,6 +77,43 @@ describe('WalletConnectConnector', () => {
       await connector.connectWalletConnect()
 
       expect(provider.connect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('signEvmMessage', () => {
+    it('routes personal_sign to the supplied CAIP network', async () => {
+      vi.mocked(provider.request).mockResolvedValueOnce('0xsignature')
+
+      const result = await connector.signEvmMessage({
+        message: 'Sign in',
+        address: '0x1234567890123456789012345678901234567890',
+        caipNetworkId: 'eip155:1'
+      })
+
+      expect(provider.request).toHaveBeenCalledWith(
+        {
+          method: 'personal_sign',
+          params: ['0x5369676e20696e', '0x1234567890123456789012345678901234567890']
+        },
+        'eip155:1'
+      )
+      expect(result).toEqual({ signature: '0xsignature' })
+    })
+
+    it('preserves the provider error as the cause', async () => {
+      const cause = new Error('Wallet request failed')
+      vi.mocked(provider.request).mockRejectedValueOnce(cause)
+
+      await expect(
+        connector.signEvmMessage({
+          message: 'Sign in',
+          address: '0x1234567890123456789012345678901234567890',
+          caipNetworkId: 'eip155:1'
+        })
+      ).rejects.toMatchObject({
+        message: 'WalletConnectConnector:signEvmMessage - Sign message failed',
+        cause
+      })
     })
   })
 

--- a/packages/controllers/src/controllers/AdapterController/WalletConnectConnector.ts
+++ b/packages/controllers/src/controllers/AdapterController/WalletConnectConnector.ts
@@ -1,7 +1,14 @@
 import type { SessionTypes } from '@walletconnect/types'
 import UniversalProvider from '@walletconnect/universal-provider'
+import { isHex, stringToHex } from 'viem'
 
-import { type CaipNetwork, type ChainNamespace, ConstantsUtil } from '@reown/appkit-common'
+import {
+  type CaipNetwork,
+  type CaipNetworkId,
+  type ChainNamespace,
+  ConstantsUtil,
+  type Hex
+} from '@reown/appkit-common'
 
 import { SIWXUtil } from '../../utils/SIWXUtil.js'
 import { WcHelpersUtil } from '../../utils/WalletConnectUtil.js'
@@ -55,6 +62,29 @@ export class WalletConnectConnector<Namespace extends ChainNamespace = ChainName
     await this.provider.disconnect()
   }
 
+  async signEvmMessage({
+    message,
+    address,
+    caipNetworkId
+  }: WalletConnectConnector.SignEvmMessageParams): Promise<WalletConnectConnector.SignEvmMessageResult> {
+    try {
+      const hexMessage = isHex(message) ? message : stringToHex(message)
+      const signature = await this.provider.request<Hex>(
+        {
+          method: 'personal_sign',
+          params: [hexMessage, address]
+        },
+        caipNetworkId
+      )
+
+      return { signature }
+    } catch (error) {
+      throw new Error('WalletConnectConnector:signEvmMessage - Sign message failed', {
+        cause: error
+      })
+    }
+  }
+
   async authenticate(): Promise<boolean> {
     const chains = this.chains.map(network => network.caipNetworkId)
 
@@ -76,6 +106,16 @@ export namespace WalletConnectConnector {
   export type ConnectResult = {
     clientId: string | null
     session: SessionTypes.Struct
+  }
+
+  export type SignEvmMessageParams = {
+    message: string
+    address: string
+    caipNetworkId: CaipNetworkId
+  }
+
+  export type SignEvmMessageResult = {
+    signature: Hex
   }
 }
 


### PR DESCRIPTION
# Description

Part 2 of the native GitHub stack: **#5730 → #5732 → #5733 → #5734**.

Depends on #5730, which retains the immutable SIWX chain, account, and connector until the request
is sent.

This layer completes EVM WalletConnect routing at the shared connector level:

- `WalletConnectConnector.signEvmMessage` owns message encoding and `personal_sign`
- AppKit dispatches EVM WalletConnect requests to that connector with the captured CAIP network
- Wagmi, Ethers, Ethers5, Universal Adapter, and future standard EVM adapters share the same path
- non-WalletConnect connectors keep their existing adapter signing path
- WalletConnect provider errors retain the original error as `cause`

Solana, Bitcoin, and Tron retain their namespace-specific connector signing because they do not use
EVM `personal_sign`.

## Connector-level routing

```mermaid
sequenceDiagram
    autonumber
    participant SIWX
    participant AppKit
    participant Connector as Shared EVM WalletConnectConnector
    participant WC as UniversalProvider
    participant Wallet

    SIWX->>AppKit: signMessage(message, eip155:1, account, walletConnect)
    AppKit->>AppKit: Resolve connector by eip155 namespace
    AppKit->>Connector: signEvmMessage(message, account, eip155:1)
    Connector->>Connector: Encode message for personal_sign
    Connector->>WC: request(personal_sign, eip155:1)
    Note over WC: Other namespaces may be connected,<br/>but cannot become the request target
    WC->>Wallet: EVM personal_sign
    Wallet-->>WC: EVM signature
    WC-->>Connector: signature
    Connector-->>AppKit: signature
```

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

# Associated Issues

N/A

# Validation

- AppKit signing and WalletConnect connector suites: **10 tests pass**
- Full package build passes: **24/24 tasks**
- Controllers and AppKit typechecks pass
- Controllers and AppKit lint pass with existing warnings only
- Focused Prettier check passes

# Checklist

- [x] Code is covered by automated tests
- [x] Existing non-WalletConnect signing is preserved
- [x] Namespace-specific non-EVM signing is preserved
- [x] A changeset is included
- [x] I have reviewed my own code
