### PR TITLE
fix(siwx): prevent concurrent signing actions

### DIFF
--- a/.changeset/siwx-single-flight.md
+++ b/.changeset/siwx-single-flight.md
@@ -1,0 +1,9 @@
+---
+'@reown/appkit-controllers': patch
+'@reown/appkit-scaffold-ui': patch
+---
+
+Prevent concurrent SIWX signing actions.
+
+Concurrent sign requests now share one in-flight operation, and the SIWX modal disables Sign and
+Cancel while either action is pending.

--- a/packages/controllers/src/utils/SIWXUtil.ts
+++ b/packages/controllers/src/utils/SIWXUtil.ts
@@ -22,6 +22,7 @@ import { CoreHelperUtil } from './CoreHelperUtil.js'
  */
 
 let addEmbeddedWalletSessionPromise: Promise<void> | null = null
+let requestSignMessagePromise: Promise<void> | null = null
 
 export const SIWXUtil = {
   getSIWX() {
@@ -100,83 +101,99 @@ export const SIWXUtil = {
     return sessions.length > 0
   },
   async requestSignMessage() {
-    const siwx = OptionsController.state.siwx
-    const address = CoreHelperUtil.getPlainAddress(ChainController.getActiveCaipAddress())
-    const network = getActiveCaipNetwork()
-
-    if (!siwx) {
-      throw new Error('SIWX is not enabled')
+    if (requestSignMessagePromise) {
+      return requestSignMessagePromise
     }
 
-    if (!address) {
-      throw new Error('No ActiveCaipAddress found')
-    }
+    const request = (async () => {
+      const siwx = OptionsController.state.siwx
+      const address = CoreHelperUtil.getPlainAddress(ChainController.getActiveCaipAddress())
+      const network = getActiveCaipNetwork()
 
-    if (!network) {
-      throw new Error('No ActiveCaipNetwork or client found')
-    }
+      if (!siwx) {
+        throw new Error('SIWX is not enabled')
+      }
 
-    const connectorId = ConnectorController.getConnectorId(network.chainNamespace)
+      if (!address) {
+        throw new Error('No ActiveCaipAddress found')
+      }
 
-    try {
-      const siwxMessage = await siwx.createMessage({
-        chainId: network.caipNetworkId,
-        accountAddress: address
-      })
+      if (!network) {
+        throw new Error('No ActiveCaipNetwork or client found')
+      }
 
-      const message = siwxMessage.toString()
+      const connectorId = ConnectorController.getConnectorId(network.chainNamespace)
 
-      let signature = ''
-      if (siwx.signMessage) {
-        signature = await siwx.signMessage({
-          message,
+      try {
+        const siwxMessage = await siwx.createMessage({
           chainId: network.caipNetworkId,
-          accountAddress: address,
-          connectorId
+          accountAddress: address
         })
-      } else {
-        if (connectorId === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
-          RouterController.pushTransactionStack({})
-        }
-        signature =
-          (await ConnectionController.signMessage(message, {
+
+        const message = siwxMessage.toString()
+
+        let signature = ''
+        if (siwx.signMessage) {
+          signature = await siwx.signMessage({
+            message,
             chainId: network.caipNetworkId,
             accountAddress: address,
             connectorId
-          })) || ''
-      }
+          })
+        } else {
+          if (connectorId === CommonConstantsUtil.CONNECTOR_ID.AUTH) {
+            RouterController.pushTransactionStack({})
+          }
+          signature =
+            (await ConnectionController.signMessage(message, {
+              chainId: network.caipNetworkId,
+              accountAddress: address,
+              connectorId
+            })) || ''
+        }
 
-      await siwx.addSession({
-        data: siwxMessage,
-        message,
-        signature
-      })
-
-      ChainController.setLastConnectedSIWECaipNetwork(network)
-
-      ModalController.close()
-
-      EventsController.sendEvent({
-        type: 'track',
-        event: 'SIWX_AUTH_SUCCESS',
-        properties: this.getSIWXEventProperties()
-      })
-    } catch (error) {
-      if (!ModalController.state.open || RouterController.state.view === 'ApproveTransaction') {
-        await ModalController.open({
-          view: 'SIWXSignMessage'
+        await siwx.addSession({
+          data: siwxMessage,
+          message,
+          signature
         })
+
+        ChainController.setLastConnectedSIWECaipNetwork(network)
+
+        ModalController.close()
+
+        EventsController.sendEvent({
+          type: 'track',
+          event: 'SIWX_AUTH_SUCCESS',
+          properties: this.getSIWXEventProperties()
+        })
+      } catch (error) {
+        if (!ModalController.state.open || RouterController.state.view === 'ApproveTransaction') {
+          await ModalController.open({
+            view: 'SIWXSignMessage'
+          })
+        }
+
+        SnackController.showError('Error signing message')
+        EventsController.sendEvent({
+          type: 'track',
+          event: 'SIWX_AUTH_ERROR',
+          properties: this.getSIWXEventProperties(error)
+        })
+
+        // eslint-disable-next-line no-console
+        console.error('SIWXUtil:requestSignMessage', error)
       }
+    })()
 
-      SnackController.showError('Error signing message')
-      EventsController.sendEvent({
-        type: 'track',
-        event: 'SIWX_AUTH_ERROR',
-        properties: this.getSIWXEventProperties(error)
-      })
+    requestSignMessagePromise = request
 
-      // eslint-disable-next-line no-console
-      console.error('SIWXUtil:requestSignMessage', error)
+    try {
+      return await request
+    } finally {
+      if (requestSignMessagePromise === request) {
+        requestSignMessagePromise = null
+      }
     }
   },
   async cancelSignMessage() {

--- a/packages/controllers/tests/utils/SIWXUtil.test.ts
+++ b/packages/controllers/tests/utils/SIWXUtil.test.ts
@@ -73,7 +73,7 @@ describe('SIWXUtil', () => {
       expect(getSIWXEventPropertiesSpy).toHaveBeenCalled()
     })
 
-    it('should pass the immutable signing context to SIWX', async () => {
+    it('should use one immutable signing context for concurrent requests', async () => {
       let resolveSignature: ((signature: string) => void) | undefined
       const signaturePromise = new Promise<string>(resolve => {
         resolveSignature = resolve
@@ -96,7 +96,8 @@ describe('SIWXUtil', () => {
       )
       vi.spyOn(ConnectorController, 'getConnectorId').mockReturnValue('walletConnect')
 
-      const request = SIWXUtil.requestSignMessage()
+      const firstRequest = SIWXUtil.requestSignMessage()
+      const secondRequest = SIWXUtil.requestSignMessage()
 
       await vi.waitFor(() => expect(mockSIWX.signMessage).toHaveBeenCalledOnce())
       expect(mockSIWX.signMessage).toHaveBeenCalledWith({
@@ -107,7 +108,7 @@ describe('SIWXUtil', () => {
       })
 
       resolveSignature?.('0xsignature')
-      await request
+      await Promise.all([firstRequest, secondRequest])
 
       expect(mockSIWX.createMessage).toHaveBeenCalledOnce()
       expect(mockSIWX.addSession).toHaveBeenCalledOnce()

--- a/packages/scaffold-ui/src/views/w3m-siwx-sign-message-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-siwx-sign-message-view/index.ts
@@ -47,6 +47,7 @@ export class W3mSIWXSignMessageView extends LitElement {
           fullWidth
           variant="neutral-secondary"
           ?loading=${this.isCancelling}
+          ?disabled=${this.isSigning || this.isCancelling}
           @click=${this.onCancel.bind(this)}
           data-testid="w3m-connecting-siwe-cancel"
         >
@@ -59,6 +60,7 @@ export class W3mSIWXSignMessageView extends LitElement {
           variant="neutral-primary"
           @click=${this.onSign.bind(this)}
           ?loading=${this.isSigning}
+          ?disabled=${this.isSigning || this.isCancelling}
           data-testid="w3m-connecting-siwe-sign"
         >
           ${this.isSigning ? 'Signing...' : 'Sign'}
@@ -69,6 +71,10 @@ export class W3mSIWXSignMessageView extends LitElement {
 
   // -- Private ------------------------------------------- //
   private async onSign() {
+    if (this.isSigning || this.isCancelling) {
+      return
+    }
+
     this.isSigning = true
     try {
       await SIWXUtil.requestSignMessage()
@@ -89,6 +95,10 @@ export class W3mSIWXSignMessageView extends LitElement {
   }
 
   private async onCancel() {
+    if (this.isSigning || this.isCancelling) {
+      return
+    }
+
     this.isCancelling = true
     await SIWXUtil.cancelSignMessage().finally(() => (this.isCancelling = false))
   }


### PR DESCRIPTION
# Description

Part 3 of the native GitHub stack: **#5730 → #5732 → #5733 → #5734**.

Prevent duplicate SIWX actions while a wallet request is pending.

This layer:

- makes concurrent `requestSignMessage()` calls share one in-flight promise
- creates and stores only one SIWX message/session
- disables both Sign and Cancel while either action is pending
- adds handler guards in addition to disabled button state

## Concurrent-click behavior

```mermaid
sequenceDiagram
    autonumber
    actor User
    participant Modal
    participant SIWX
    participant Wallet

    User->>Modal: Click Sign
    Modal->>SIWX: requestSignMessage()
    SIWX->>Wallet: One signature request
    User->>Modal: Click Sign or Cancel again
    Modal-->>User: Actions disabled
    Modal->>SIWX: Any concurrent caller receives same promise
    Wallet-->>SIWX: Signature
    SIWX->>SIWX: Store one authenticated session
    SIWX-->>Modal: Complete
```

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

# Associated Issues

N/A

# Validation

- Controllers SIWX suite: **5 tests pass**, including the concurrent-request regression
- Focused Prettier check passes

# Checklist

- [x] Code is covered by automated tests
- [x] A changeset is included
- [x] I have reviewed my own code
