### PR TITLE
test(laboratory): cover multichain WalletConnect SIWX

### DIFF
--- a/apps/laboratory/src/constants/appKitConfigs.ts
+++ b/apps/laboratory/src/constants/appKitConfigs.ts
@@ -385,7 +385,8 @@ export const appKitConfigs = {
   // ----- Custom Variants ------------------------------
   'siwx-default': {
     ...commonAppKitConfig,
-    adapters: ['ethers', 'solana', 'bitcoin', 'tron'],
+    wagmiConfig: commonWagmiConfig,
+    adapters: ['wagmi', 'solana', 'bitcoin', 'tron'],
     networks: ConstantsUtil.AllNetworks,
     siwx: new DefaultSIWX()
   },

--- a/apps/laboratory/src/utils/DataUtil.ts
+++ b/apps/laboratory/src/utils/DataUtil.ts
@@ -233,7 +233,7 @@ export const siwxSdkOptions: SdkOption[] = [
     title: 'Default SIWX',
     link: '/appkit?name=siwx-default',
     description:
-      'Multichain SIWX configuration with Ethers, Solana and Bitcoin adapters enabled for AppKit'
+      'Multichain SIWX configuration with Wagmi, Solana, Bitcoin and Tron adapters enabled for AppKit'
   }
 ]
 

--- a/apps/laboratory/tests/shared/utils/project.ts
+++ b/apps/laboratory/tests/shared/utils/project.ts
@@ -90,6 +90,8 @@ const SINGLE_ADAPTER_EVM_TESTS = [
   'flag-enable-reconnect.spec.ts'
 ]
 
+const SINGLE_ADAPTER_WAGMI_TESTS = [...SINGLE_ADAPTER_EVM_TESTS, 'siwx-walletconnect.spec.ts']
+
 const CORE_TESTS = ['sign-client.spec.ts', 'universal-provider.spec.ts', 'core.spec.ts']
 
 const SINGLE_ADAPTER_MOBILE_TESTS = ['mobile-wallet-features.spec.ts']
@@ -131,6 +133,7 @@ function createRegex(tests: string[], isDesktop = true) {
 }
 
 const SINGLE_ADAPTER_EVM_TESTS_REGEX = createRegex(SINGLE_ADAPTER_EVM_TESTS)
+const SINGLE_ADAPTER_WAGMI_TESTS_REGEX = createRegex(SINGLE_ADAPTER_WAGMI_TESTS)
 const SINGLE_ADAPTER_SOLANA_TESTS_REGEX = createRegex(SINGLE_ADAPTER_SOLANA_TESTS)
 const SINGLE_ADAPTER_BITCOIN_TESTS_REGEX = createRegex(SINGLE_ADAPTER_BITCOIN_TESTS)
 const SINGLE_ADAPTER_TON_TESTS_REGEX = createRegex(SINGLE_ADAPTER_TON_TESTS)
@@ -166,11 +169,11 @@ const customProjectProperties: CustomProjectProperties = {
     testIgnore: /reown-authentication.*\.spec\.ts/u
   },
   'Desktop Chrome/wagmi': {
-    testMatch: SINGLE_ADAPTER_EVM_TESTS_REGEX,
+    testMatch: SINGLE_ADAPTER_WAGMI_TESTS_REGEX,
     testIgnore: /reown-authentication.*\.spec\.ts/u
   },
   'Desktop Firefox/wagmi': {
-    testMatch: SINGLE_ADAPTER_EVM_TESTS_REGEX,
+    testMatch: SINGLE_ADAPTER_WAGMI_TESTS_REGEX,
     testIgnore: /reown-authentication.*\.spec\.ts/u
   },
   'Desktop Chrome/bitcoin': {

--- a/apps/laboratory/tests/siwx-walletconnect.spec.ts
+++ b/apps/laboratory/tests/siwx-walletconnect.spec.ts
@@ -1,0 +1,19 @@
+import { WalletPage } from '@reown/appkit-testing'
+
+import { timingFixture } from './shared/fixtures/timing-fixture'
+import { ModalPage } from './shared/pages/ModalPage'
+import { ModalValidator } from './shared/validators/ModalValidator'
+
+const test = timingFixture
+
+test('signs SIWX over a multichain WalletConnect session', async ({ context, page }) => {
+  const modal = new ModalPage(page, 'wagmi', 'siwx')
+  const wallet = new WalletPage(await context.newPage())
+  const validator = new ModalValidator(page)
+
+  await modal.load()
+  await modal.qrCodeFlow(modal, wallet)
+  await modal.promptSiwe()
+  await wallet.handleRequest({ accept: true })
+  await validator.expectConnected()
+})


### PR DESCRIPTION
# Description

Part 4 of the native GitHub stack: **#5730 → #5732 → #5733 → #5734**.

Add the Laboratory regression path for the SIWX race fixed by the preceding layers.

This layer:

- switches Default SIWX Laboratory from Ethers to Wagmi
- keeps Solana, Bitcoin, and Tron enabled to exercise a multichain WalletConnect session
- adds an E2E flow that connects, opens SIWX, approves the wallet request, and verifies connection
- scopes that fixture to Wagmi desktop projects

The Laboratory setup now mirrors the Wagmi + Solana shape used by Profiles Hub. The complete stack
preserves the behavior validated in the previously green combined PR, and the SIWX Laboratory flow
was manually confirmed fixed.

## Regression path

```mermaid
flowchart LR
    Lab["Default SIWX Laboratory"] --> Wagmi["Wagmi / EVM"]
    Lab --> Solana
    Lab --> Bitcoin
    Lab --> Tron
    Wagmi & Solana & Bitcoin & Tron --> WC["Multichain WalletConnect session"]
    WC --> SIWX["eip155:1 SIWX personal_sign"]
    SIWX --> Connected["Authenticated connection"]
```

## Type of change

- [x] Chore / test coverage
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

# Associated Issues

N/A

# Validation

- Laboratory TypeScript check passes
- Focused Prettier check passes
- SIWX Laboratory flow manually confirmed against the complete stack

# Checklist

- [x] Regression coverage follows the production adapter shape
- [x] No published-package changeset is required for Laboratory-only files
- [x] I have reviewed my own code
