### PR TITLE
fix(siwx): preserve unrelated local storage sessions on delete

### DIFF
--- a/.changeset/siwx-local-storage-delete.md
+++ b/.changeset/siwx-local-storage-delete.md
@@ -1,0 +1,5 @@
+---
+'@reown/appkit-siwx': patch
+---
+
+Fix local storage session deletion to preserve sessions that do not match both the chain ID and account address.

--- a/packages/siwx/src/storages/LocalStorage.ts
+++ b/packages/siwx/src/storages/LocalStorage.ts
@@ -52,7 +52,7 @@ export class LocalStorage implements SIWXStorage {
 
   delete(chainId: string, address: string): Promise<void> {
     const sessions = this.getSessions().filter(
-      session => session.data.chainId !== chainId && session.data.accountAddress !== address
+      session => session.data.chainId !== chainId || session.data.accountAddress !== address
     )
     this.setSessions(sessions)
 

--- a/packages/siwx/tests/storages/LocalStorage.test.ts
+++ b/packages/siwx/tests/storages/LocalStorage.test.ts
@@ -53,18 +53,38 @@ describe('LocalStorage', () => {
     expect(setItem).toHaveBeenCalledWith(key, JSON.stringify([session]))
   })
 
-  test('should remove sessions', async () => {
+  test('should remove only sessions matching the chain and address', async () => {
+    const matchingSession = mockSession({
+      data: { accountAddress: '0xAAA', chainId: 'eip155:1' }
+    })
+    const duplicateMatchingSession = mockSession({
+      data: { accountAddress: '0xAAA', chainId: 'eip155:1' }
+    })
+    const sameChainSession = mockSession({
+      data: { accountAddress: '0xBBB', chainId: 'eip155:1' }
+    })
+    const sameAddressSession = mockSession({
+      data: { accountAddress: '0xAAA', chainId: 'eip155:137' }
+    })
+    const unrelatedSession = mockSession({
+      data: { accountAddress: '0xBBB', chainId: 'eip155:137' }
+    })
+
     getItem.mockImplementation(() =>
       JSON.stringify([
-        mockSession({
-          data: { accountAddress: '0x1234567890abcdef', chainId: 'eip155:1' }
-        })
+        matchingSession,
+        duplicateMatchingSession,
+        sameChainSession,
+        sameAddressSession,
+        unrelatedSession
       ])
     )
-    expect(await storage.get('eip155:1', '0x1234567890abcdef')).toHaveLength(1)
 
-    await storage.delete('eip155:1', '0x1234567890abcdef')
+    await storage.delete('eip155:1', '0xAAA')
     expect(getItem).toHaveBeenCalledWith(key)
-    expect(setItem).toHaveBeenCalledWith(key, JSON.stringify([]))
+    expect(setItem).toHaveBeenCalledWith(
+      key,
+      JSON.stringify([sameChainSession, sameAddressSession, unrelatedSession])
+    )
   })
 })


### PR DESCRIPTION
# Description

Fix `LocalStorage.delete()` in the SIWX package so that it only removes sessions matching both the requested chain ID and account address.

The existing filter uses:

```ts
session.data.chainId !== chainId &&
  session.data.accountAddress !== address
```


This unintentionally removes unrelated sessions when either the chain ID or account address matches.
For example, deleting `(eip155:1, 0xAAA)` also removes:

`(eip155:1, 0xBBB)`
`(eip155:137, 0xAAA)`


The filter now uses `||`, preserving every session except those matching both identifiers.

Regression coverage verifies that:

- the matching chain and address session is removed;
- a session with the same chain and a different address is preserved;
- a session with a different chain and the same address is preserved;
- a session with a different chain and address is preserved;
- duplicate sessions matching both identifiers are all removed.



## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

N/A — small, self-contained bug fix.

# Showcase (Optional)

N/A — no UI changes.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
