### PR TITLE
fix(wallet): require secure-site origin on W3mFrame postMessage

### DIFF
--- a/packages/wallet/src/W3mFrame.ts
+++ b/packages/wallet/src/W3mFrame.ts
@@ -1,6 +1,11 @@
 import { ConstantsUtil } from '@reown/appkit-common'
 
-import { SECURE_SITE_SDK, SECURE_SITE_SDK_VERSION, W3mFrameConstants } from './W3mFrameConstants.js'
+import {
+  SECURE_SITE_SDK,
+  SECURE_SITE_SDK_ORIGIN,
+  SECURE_SITE_SDK_VERSION,
+  W3mFrameConstants
+} from './W3mFrameConstants.js'
 import { W3mFrameHelpers } from './W3mFrameHelpers.js'
 import { W3mFrameSchema } from './W3mFrameSchema.js'
 import { W3mFrameStorage } from './W3mFrameStorage.js'
@@ -175,7 +180,10 @@ export class W3mFrame {
       callback: (event: W3mFrameTypes.FrameEvent) => void,
       signal: AbortSignal
     ) => {
-      function eventHandler({ data }: MessageEvent) {
+      function eventHandler({ data, origin }: MessageEvent) {
+        if (origin !== SECURE_SITE_SDK_ORIGIN) {
+          return
+        }
         if (!shouldHandleEvent(W3mFrameConstants.FRAME_EVENT_KEY, data)) {
           return
         }
@@ -202,7 +210,10 @@ export class W3mFrame {
     },
     onFrameEvent: (callback: (event: W3mFrameTypes.FrameEvent) => void) => {
       if (W3mFrameHelpers.isClient) {
-        window.addEventListener('message', ({ data }) => {
+        window.addEventListener('message', ({ data, origin }) => {
+          if (origin !== SECURE_SITE_SDK_ORIGIN) {
+            return
+          }
           if (!shouldHandleEvent(W3mFrameConstants.FRAME_EVENT_KEY, data)) {
             return
           }
@@ -239,7 +250,7 @@ export class W3mFrame {
         if (!this.iframe?.contentWindow) {
           throw new Error('W3mFrame: iframe is not set')
         }
-        this.iframe.contentWindow.postMessage(event, '*')
+        this.iframe.contentWindow.postMessage(event, SECURE_SITE_SDK_ORIGIN)
       }
     },
 

--- a/packages/wallet/src/W3mFrameConstants.ts
+++ b/packages/wallet/src/W3mFrameConstants.ts
@@ -6,6 +6,15 @@ export const SECURE_SITE_SDK =
     ? process.env['NEXT_PUBLIC_SECURE_SITE_SDK_URL']
     : undefined) || DEFAULT_SDK_URL
 
+/** Origin of the secure-site iframe SDK (postMessage target / allowlist). */
+export const SECURE_SITE_SDK_ORIGIN = (() => {
+  try {
+    return new URL(SECURE_SITE_SDK).origin
+  } catch {
+    return 'https://secure.walletconnect.org'
+  }
+})()
+
 export const DEFAULT_LOG_LEVEL =
   (typeof process !== 'undefined' && typeof process.env !== 'undefined'
     ? process.env['NEXT_PUBLIC_DEFAULT_LOG_LEVEL']


### PR DESCRIPTION
## Summary
- Host-side `W3mFrame` frame-event handlers accepted any `@w3m-frame/*` `message` with no `event.origin` check.
- Sibling social/connector helpers already require `SECURE_SITE_ORIGIN`.
- Require `SECURE_SITE_SDK_ORIGIN` on `registerFrameEventHandler` / `onFrameEvent`, and target `postAppEvent` to that origin instead of `*`.

## Test plan
- [ ] Manual: email/social login via AppKit still completes
- [ ] Manual: forged `postMessage` from a same-page iframe with `@w3m-frame/GET_USER_SUCCESS` is ignored


Made with [Cursor](https://cursor.com)