### PR TITLE
Fix image for broken image urls in token list

### DIFF
--- a/.changeset/big-shrimps-speak.md
+++ b/.changeset/big-shrimps-speak.md
@@ -1,0 +1,31 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fix broken image in tokens with broken image url

--- a/packages/ui/src/composites/wui-list-token/index.ts
+++ b/packages/ui/src/composites/wui-list-token/index.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from 'lit'
-import { property } from 'lit/decorators.js'
+import { property, state } from 'lit/decorators.js'
 
 import { NumberUtil } from '@reown/appkit-common'
 
@@ -27,6 +27,8 @@ export class WuiListToken extends LitElement {
   @property() public tokenCurrency = ''
 
   @property({ type: Boolean }) public clickable = false
+
+  @state() private imageError = false
 
   // -- Render -------------------------------------------- //
   public override render() {
@@ -67,12 +69,26 @@ export class WuiListToken extends LitElement {
   }
 
   // -- Private ------------------------------------------- //
+  public override updated(changedProperties: Map<string | number | symbol, unknown>) {
+    if (changedProperties.has('tokenImageUrl')) {
+      this.imageError = false
+    }
+  }
+
   public visualTemplate() {
-    if (this.tokenName && this.tokenImageUrl) {
-      return html`<wui-image alt=${this.tokenName} src=${this.tokenImageUrl}></wui-image>`
+    if (this.tokenName && this.tokenImageUrl && !this.imageError) {
+      return html`<wui-image
+        alt=${this.tokenName}
+        src=${this.tokenImageUrl}
+        @onLoadError=${this.handleImageError}
+      ></wui-image>`
     }
 
     return html`<wui-icon name="coinPlaceholder" color="default"></wui-icon>`
+  }
+
+  private handleImageError() {
+    this.imageError = true
   }
 }
 


### PR DESCRIPTION
# Description

Tokens with a dead or unreachable `iconUrl` were rendering the browser's native broken image icon instead of falling back to the placeholder icon. This only affected the "URL present but fails to load" case; a missing/empty `iconUrl` already fell back correctly.

`wui-list-token` renders a raw `wui-image` whenever `tokenImageUrl` is set, but never reacted to the image actually failing to load. Other composites in the same package (`wui-token-list-item`, `wui-transaction-visual`) already listen for `wui-image`'s `onLoadError` event and swap to a placeholder icon; `wui-list-token` was the one place missing that handling.

Added an `imageError` state to `wui-list-token` that gets set on `onLoadError` and falls back to the existing `coinPlaceholder` icon, matching the pattern already used elsewhere. The state resets whenever `tokenImageUrl` changes so a recycled list item does not get stuck showing the placeholder for a different token whose icon loads fine.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes REOWN-4538

# Showcase (Optional)

<img width="417" height="394" alt="2026-08-13 Token with broken image url" src="https://github.com/user-attachments/assets/fdc41866-5108-46e4-863c-343467640b22" />

# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link