### PR TITLE
fix(ethers,ethers5): restore Coinbase Wallet / Base Account session on page reload

### DIFF
--- a/.changeset/wide-plums-yell.md
+++ b/.changeset/wide-plums-yell.md
@@ -1,0 +1,30 @@
+---
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fix Coinbase Wallet and Base Account not reconnecting on page reload with ethers and ethers5 adapters

--- a/packages/adapters/ethers/src/client.ts
+++ b/packages/adapters/ethers/src/client.ts
@@ -80,11 +80,17 @@ export class EthersAdapter extends AdapterBlueprint {
     if (enableBaseAccount !== false) {
       // Do not initialize provider to prevent unnecessary api calls - lazy load
       this.ethersProviders.baseAccount = new BaseProvider()
+      if (this.hasStoredConnection(CommonConstantsUtil.CONNECTOR_ID.BASE_ACCOUNT)) {
+        await this.ethersProviders.baseAccount.initialize()
+      }
     }
 
     if (enableCoinbase !== false) {
       // Do not initialize provider to prevent unnecessary api calls - lazy load
       this.ethersProviders.coinbaseWallet = new CoinbaseWalletProvider()
+      if (this.hasStoredConnection(CommonConstantsUtil.CONNECTOR_ID.COINBASE)) {
+        await this.ethersProviders.coinbaseWallet.initialize()
+      }
     }
 
     if (CoreHelperUtil.isSafeApp()) {
@@ -99,6 +105,15 @@ export class EthersAdapter extends AdapterBlueprint {
       EIP6963: enableEIP6963 !== false,
       metadata
     }
+  }
+
+  private hasStoredConnection(connectorId: string) {
+    const { hasConnected, hasDisconnected } = HelpersUtil.getConnectorStorageInfo(
+      connectorId,
+      this.namespace as ChainNamespace
+    )
+
+    return hasConnected && !hasDisconnected
   }
 
   public async signMessage(

--- a/packages/adapters/ethers/src/tests/client.test.ts
+++ b/packages/adapters/ethers/src/tests/client.test.ts
@@ -1431,5 +1431,77 @@ describe('EthersAdapter', () => {
 
       expect(providers?.safe).toBeDefined()
     })
+
+    it('should initialize coinbase wallet provider if the user was previously connected with it', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: mockEthersConfig.metadata
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockImplementation(connectorId => ({
+        hasConnected: connectorId === CommonConstantsUtil.CONNECTOR_ID.COINBASE,
+        hasDisconnected: false
+      }))
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).toHaveBeenCalledTimes(1)
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should initialize base account provider if the user was previously connected with it', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: mockEthersConfig.metadata
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockImplementation(connectorId => ({
+        hasConnected: connectorId === CommonConstantsUtil.CONNECTOR_ID.BASE_ACCOUNT,
+        hasDisconnected: false
+      }))
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.baseAccount?.initialize).toHaveBeenCalledTimes(1)
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should not initialize coinbase wallet and base account providers if the user was never connected with them', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: mockEthersConfig.metadata
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockReturnValue({
+        hasConnected: false,
+        hasDisconnected: false
+      })
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should not initialize coinbase wallet and base account providers if the user explicitly disconnected them', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: mockEthersConfig.metadata
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockReturnValue({
+        hasConnected: true,
+        hasDisconnected: true
+      })
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/adapters/ethers5/src/client.ts
+++ b/packages/adapters/ethers5/src/client.ts
@@ -78,11 +78,17 @@ export class Ethers5Adapter extends AdapterBlueprint {
     if (enableBaseAccount !== false) {
       // Do not initialize provider to prevent unnecessary api calls - lazy load
       this.ethersProviders.baseAccount = new BaseProvider()
+      if (this.hasStoredConnection(CommonConstantsUtil.CONNECTOR_ID.BASE_ACCOUNT)) {
+        await this.ethersProviders.baseAccount.initialize()
+      }
     }
 
     if (enableCoinbase !== false) {
       // Do not initialize provider to prevent unnecessary api calls - lazy load
       this.ethersProviders.coinbaseWallet = new CoinbaseWalletProvider()
+      if (this.hasStoredConnection(CommonConstantsUtil.CONNECTOR_ID.COINBASE)) {
+        await this.ethersProviders.coinbaseWallet.initialize()
+      }
     }
 
     if (CoreHelperUtil.isSafeApp()) {
@@ -96,6 +102,15 @@ export class Ethers5Adapter extends AdapterBlueprint {
       EIP6963: enableEIP6963 !== false,
       metadata
     }
+  }
+
+  private hasStoredConnection(connectorId: string) {
+    const { hasConnected, hasDisconnected } = HelpersUtil.getConnectorStorageInfo(
+      connectorId,
+      this.namespace as ChainNamespace
+    )
+
+    return hasConnected && !hasDisconnected
   }
 
   public async signMessage(

--- a/packages/adapters/ethers5/src/tests/client.test.ts
+++ b/packages/adapters/ethers5/src/tests/client.test.ts
@@ -1247,5 +1247,97 @@ describe('Ethers5Adapter', () => {
 
       expect(providers?.safe).toBeDefined()
     })
+
+    it('should initialize coinbase wallet provider if the user was previously connected with it', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: {
+          name: 'Test App',
+          description: 'Test Description',
+          url: 'https://test.com',
+          icons: ['https://test.com/icon.png']
+        }
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockImplementation(connectorId => ({
+        hasConnected: connectorId === CommonConstantsUtil.CONNECTOR_ID.COINBASE,
+        hasDisconnected: false
+      }))
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).toHaveBeenCalledTimes(1)
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should initialize base account provider if the user was previously connected with it', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: {
+          name: 'Test App',
+          description: 'Test Description',
+          url: 'https://test.com',
+          icons: ['https://test.com/icon.png']
+        }
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockImplementation(connectorId => ({
+        hasConnected: connectorId === CommonConstantsUtil.CONNECTOR_ID.BASE_ACCOUNT,
+        hasDisconnected: false
+      }))
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.baseAccount?.initialize).toHaveBeenCalledTimes(1)
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should not initialize coinbase wallet and base account providers if the user was never connected with them', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: {
+          name: 'Test App',
+          description: 'Test Description',
+          url: 'https://test.com',
+          icons: ['https://test.com/icon.png']
+        }
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockReturnValue({
+        hasConnected: false,
+        hasDisconnected: false
+      })
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
+
+    it('should not initialize coinbase wallet and base account providers if the user explicitly disconnected them', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        enableCoinbase: true,
+        enableBaseAccount: true,
+        metadata: {
+          name: 'Test App',
+          description: 'Test Description',
+          url: 'https://test.com',
+          icons: ['https://test.com/icon.png']
+        }
+      })
+      vi.spyOn(HelpersUtil, 'getConnectorStorageInfo').mockReturnValue({
+        hasConnected: true,
+        hasDisconnected: true
+      })
+
+      const providers = await adapter['createEthersConfig']()
+
+      expect(providers?.coinbaseWallet?.initialize).not.toHaveBeenCalled()
+      expect(providers?.baseAccount?.initialize).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
# Description

Fixes Coinbase Smart Wallet / Base Account sessions being dropped on page reload with the ethers and ethers5 adapters.

### Root cause

Regression from #5336 (lazy load coinbase, shipped in 1.8.15).

- `createEthersConfig()` creates `CoinbaseWalletProvider` and `BaseProvider` but intentionally does not call `initialize()`, so the SDK is only loaded when needed.
- `syncConnectors()` then registers each connector with `provider: await provider.getProvider()`, which is `undefined` for those two because nothing has built the SDK yet.
- `connect()` was updated to call `initialize()` before use, so the first connection works.
- The reload path was not. On page load the core calls `syncConnection()`, which reads `connector.provider` directly:

```ts
const selectedProvider = connector?.provider as Provider // undefined for coinbaseWallet / baseAccount

if (!selectedProvider) {
  throw new Error('Provider not found')
}
```

- The core catches that error and calls `onDisconnectNamespace()`, so the user is silently logged out. The SDK is never created on that page load.

### Fix

Keep the lazy load, but treat a returning user as the one exception. In `createEthersConfig()`, right where each lazy provider is created:

```ts
this.ethersProviders.coinbaseWallet = new CoinbaseWalletProvider()
if (this.hasStoredConnection(CommonConstantsUtil.CONNECTOR_ID.COINBASE)) {
  await this.ethersProviders.coinbaseWallet.initialize()
}
```

`hasStoredConnection()` is a small private helper around `HelpersUtil.getConnectorStorageInfo()`, the same check `syncConnections()` already uses (`hasConnected && !hasDisconnected`).

### Tests

Four cases added to the existing `createEthersConfig` suite in each adapter:

- previously connected with coinbase: `coinbaseWallet.initialize()` called once, base not touched
- previously connected with base account: the mirror
- never connected: neither initialized
- explicitly disconnected: neither initialized

The first two fail on the current `main` and pass with this change.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5749

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
