### PR TITLE
fix(testing): publish verify canary metrics to CloudWatch

### DIFF
--- a/apps/laboratory/tests/verify.spec.ts
+++ b/apps/laboratory/tests/verify.spec.ts
@@ -11,8 +11,19 @@ import { testMWagmiVerifyDomainMismatch } from './shared/fixtures/w3m-wagmi-veri
 import { testMWagmiVerifyEvil } from './shared/fixtures/w3m-wagmi-verify-evil-fixture'
 import { testMWagmiVerifyValid } from './shared/fixtures/w3m-wagmi-verify-valid-fixture'
 import { ModalPage } from './shared/pages/ModalPage'
-import { getCanaryTagAndAnnotation } from './shared/utils/metrics'
+import { afterEachCanary, getCanaryTagAndAnnotation } from './shared/utils/metrics'
 import { ModalValidator } from './shared/validators/ModalValidator'
+
+/*
+ * Registered on the base fixture so it covers every test object in this file — Playwright scopes
+ * hooks to the suite, so registering it once per canary fixture would upload each metric twice.
+ */
+timingFixture.afterEach(async ({ browserName, timingRecords }, testInfo) => {
+  if (browserName === 'firefox') {
+    return
+  }
+  await afterEachCanary(testInfo, timingRecords)
+})
 
 testMWagmiVerifyValid(
   'wagmi: connection and signature requests from non-scam verified domain should show as domain match',


### PR DESCRIPTION
> **Supersedes/duplicates #5709.** I opened this before finding that @svenvoskamp already diagnosed the identical root cause on 2026-07-10 and has an open PR. See "Relationship to #5709" below — this PR should probably be closed in favour of reviving that one with the one-line change noted.

# Description

The two canary tests in `verify.spec.ts` are tagged `@canary` and annotated with metric names, but the file never registers the `afterEachCanary` hook that performs the `PutMetricData` call. Tag and annotation alone emit nothing.

`HappyPath.verify.*` and `UnhappyPath.verify-scam.*` have therefore never existed in the `prod_Canary_Web3Modal` CloudWatch namespace. @svenvoskamp confirmed this directly against the `monitoring` AWS account in #5709: **zero datapoints, ever, across 90 days and all regions.**

Present since #3938 (2025-03-18), which added the upload hook to `canary.spec.ts` and `siwe-email.spec.ts` and only the annotation here. Nothing in the emitting path has changed since; the most recent touch to any canary infrastructure file was 2026-02-17 and unrelated.

Coverage across the suite before this change:

| Spec | annotation | `afterEachCanary` |
| --- | --- | --- |
| `canary.spec.ts` (`HappyPath.sign`) | yes | yes |
| `siwe-email.spec.ts` (`HappyPath.email-sign`) | yes | yes |
| `verify.spec.ts` (`HappyPath.verify`, `UnhappyPath.verify-scam`) | yes | **no** |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Relationship to #5709

#5709 (open since 2026-07-10, `REVIEW_REQUIRED`, no human review in seven weeks) contains the same fix plus a second one for the Receive Session Proposal alerts. Two differences:

1. **The session-proposal half of #5709 is now stale.** It was superseded by #5710, merged 2026-08-06.
2. **Hook registration differs, and it matters.** #5709 (and the closed #5725) register `afterEach` on `testMWagmiVerifyValid` *and* `testMWagmiVerifyEvil`. Playwright scopes hooks to the suite, not to the test object they were registered on, so **both hooks run for every test in the file** and each canary datapoint gets uploaded twice. Verified against the repo's pinned Playwright 1.48.2:

```
BODY happy modalPage=valid
UPLOAD via validFixture hook -> test="happy canary" tags=["@canary"]
UPLOAD via evilFixture hook  -> test="happy canary" tags=["@canary"]
```

This PR registers once on the shared `timingFixture` parent instead, which covers every test object in the file and fires exactly once per test. Same reproduction confirms `tags` and `annotations` arrive populated, and untagged tests no-op inside `afterEachCanary`'s tag guard.

The cleanest resolution is to apply difference 2 to #5709 and close this PR.

# Notes for the reviewer

**Silence the four verify rules until the first real datapoint lands**, otherwise the fix itself reads as another no-data page on the next evaluation.

**No changeset.** The change is confined to `apps/laboratory`, which `.changeset/config.json` lists under `ignore`. Any changeset would have to name a published package this PR does not touch.

**Out of scope, but worth separate issues:**

- `tests/shared/utils/metrics.ts` hardcodes `Target: https://appkit-lab.reown.org/` while `Dockerfile.canary` runs against `BASE_URL=https://lab.reown.com/`, so every canary metric is labelled with a host it did not test.
- #5710 renamed the emitted timing metrics (`receiveSessionProposal` → `sessionProposalReceived`, `sessionProposalVerification` → `sessionProposalApproved`, `pairingReceiveSessionProposal` dropped). Any Grafana rule or panel still pointing at the old names has been reading zero since 2026-08-06. `receiveSessionProposal` was healthy (~1.8s avg) before that rename.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
