### PR TITLE
fix(ui): enlarge default wallet icon fallback in visual thumbnail

### DIFF
--- a/.changeset/chubby-grapes-retire.md
+++ b/.changeset/chubby-grapes-retire.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-stellar': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Make default wallet icon bigget in Sign In message request

--- a/packages/ui/src/composites/wui-visual-thumbnail/styles.ts
+++ b/packages/ui/src/composites/wui-visual-thumbnail/styles.ts
@@ -17,7 +17,6 @@ export default css`
   }
 
   wui-icon {
-    width: 32px;
-    height: 32px;
+    font-size: 48px;
   }
 `


### PR DESCRIPTION
# Description

Make default wallet icon bigget in Sign In message request

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes FS-153

# Showcase (Optional)

## Before
<img width="618" height="652" alt="image" src="https://github.com/user-attachments/assets/73a197ff-989f-4528-82dc-91ed7cbb4943" />

## After
<img width="379" height="368" alt="Screenshot_5" src="https://github.com/user-attachments/assets/816f6e3d-e506-48b8-8a06-81d7c6778f62" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
