### PR TITLE
fix(ui): show full wallet name in download CTA instead of truncating at 12 chars

### DIFF
--- a/.changeset/jolly-mugs-fail.md
+++ b/.changeset/jolly-mugs-fail.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-stellar': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Show the full wallet name in the "Don't have X?" download CTA instead of always hard-truncating it to 12 characters

--- a/packages/scaffold-ui/src/partials/w3m-mobile-download-links/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-mobile-download-links/index.ts
@@ -3,7 +3,7 @@ import { property } from 'lit/decorators.js'
 
 import type { WcWallet } from '@reown/appkit-controllers'
 import { CoreHelperUtil, RouterController } from '@reown/appkit-controllers'
-import { UiHelperUtil, customElement } from '@reown/appkit-ui'
+import { customElement } from '@reown/appkit-ui'
 import '@reown/appkit-ui/wui-cta-button'
 
 import styles from './styles.js'
@@ -27,17 +27,11 @@ export class W3mMobileDownloadLinks extends LitElement {
     const isIos = CoreHelperUtil.isIos()
     const isAndroid = CoreHelperUtil.isAndroid()
     const isMultiple = [app_store, play_store, homepage, chrome_store].filter(Boolean).length > 1
-    const shortName = UiHelperUtil.getTruncateString({
-      string: name,
-      charsStart: 12,
-      charsEnd: 0,
-      truncate: 'end'
-    })
 
     if (isMultiple && !isMobile) {
       return html`
         <wui-cta-button
-          label=${`Don't have ${shortName}?`}
+          label=${`Don't have ${name}?`}
           buttonLabel="Get"
           @click=${() => RouterController.push('Downloads', { wallet: this.wallet })}
         ></wui-cta-button>
@@ -47,7 +41,7 @@ export class W3mMobileDownloadLinks extends LitElement {
     if (!isMultiple && homepage) {
       return html`
         <wui-cta-button
-          label=${`Don't have ${shortName}?`}
+          label=${`Don't have ${name}?`}
           buttonLabel="Get"
           @click=${this.onHomePage.bind(this)}
         ></wui-cta-button>
@@ -57,7 +51,7 @@ export class W3mMobileDownloadLinks extends LitElement {
     if (app_store && isIos) {
       return html`
         <wui-cta-button
-          label=${`Don't have ${shortName}?`}
+          label=${`Don't have ${name}?`}
           buttonLabel="Get"
           @click=${this.onAppStore.bind(this)}
         ></wui-cta-button>
@@ -67,7 +61,7 @@ export class W3mMobileDownloadLinks extends LitElement {
     if (play_store && isAndroid) {
       return html`
         <wui-cta-button
-          label=${`Don't have ${shortName}?`}
+          label=${`Don't have ${name}?`}
           buttonLabel="Get"
           @click=${this.onPlayStore.bind(this)}
         ></wui-cta-button>

--- a/packages/ui/src/composites/wui-cta-button/styles.ts
+++ b/packages/ui/src/composites/wui-cta-button/styles.ts
@@ -17,6 +17,15 @@ export default css`
 
   wui-text {
     color: ${({ tokens }) => tokens.theme.textSecondary};
+    min-width: 0;
+    flex: 1 1 auto;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  wui-button {
+    flex-shrink: 0;
   }
 
   wui-icon {


### PR DESCRIPTION
# Description

The "Don't have X?" CTA shown at the bottom of the wallet connecting view (`w3m-mobile-download-links`) always hard-truncated the wallet name to 12 characters in JS before rendering it, regardless of how much space was actually available. A name like "Bitget Wallet" (13 chars) would always render as "Bitget Walle…" even though it fit fine.

Removed the JS pre-truncation and instead let `wui-cta-button`'s label truncate with CSS ellipsis (the pattern already used elsewhere in this codebase, e.g. `wui-card-select`, `w3m-all-wallets-list-item`), so the full wallet name is shown whenever it fits and only truncates with `…` when the row genuinely runs out of room.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes FS-161

# Showcase (Optional)

## Before
<img width="682" height="138" alt="image" src="https://github.com/user-attachments/assets/7498992c-2ed2-43f9-876a-c3a708539b7b" />

## After
<img width="315" height="63" alt="image" src="https://github.com/user-attachments/assets/dd455694-7aaf-4fe6-b0c2-7e10177534fa" />


# Checklist

- [ ] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
- [ ] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
