### PR TITLE
fix(ui): keep sign modal buttons inside the modal boundary

### DIFF
--- a/.changeset/open-hairs-fly.md
+++ b/.changeset/open-hairs-fly.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-stellar': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fix Sign modal Cancel/Sign buttons rendering outside the modal boundary when both show their loading label at once (e.g. after a network hiccup lets a user press both before either resolves). `wui-button` can now shrink as a flex item and truncates its label with an ellipsis instead of overflowing past its own bounds.

--- a/packages/ui/src/composites/wui-button/styles.ts
+++ b/packages/ui/src/composites/wui-button/styles.ts
@@ -3,6 +3,7 @@ import { css } from '../../utils/ThemeHelperUtil.js'
 export default css`
   :host {
     width: var(--local-width);
+    min-width: 0;
   }
 
   button {
@@ -17,6 +18,18 @@ export default css`
         ${({ easings }) => easings['ease-out-power-1']};
     will-change: scale, background-color, border-radius;
     cursor: pointer;
+  }
+
+  wui-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  wui-loading-spinner,
+  slot[name='iconLeft'],
+  slot[name='iconRight'] {
+    flex-shrink: 0;
   }
 
   /* -- Sizes --------------------------------------------------- */


### PR DESCRIPTION
# Description

On the Sign modal (SIWE/SIWX "sign this message" screen), the Cancel and Sign buttons could
render outside the modal's boundary when both showed their longer loading labels
("Cancelling..." / "Signing..."), reachable when a sign flow is disrupted by a
network problem, since neither button is disabled while the other is loading.

Root cause: `wui-button`'s CSS used `white-space: nowrap` with no way for the button or its
label to shrink, so once the combined content (label + spinner) needed more width than the
button's flex-shrunk share of the row, it spilled outside the button and outside the modal
instead of adapting.

Fix (`packages/ui/src/composites/wui-button/styles.ts`, CSS-only, no template/behavior changes):

- `:host { min-width: 0; }`: lets `wui-button` shrink below its natural content width as a flex
  item, instead of refusing to shrink at all.
- `wui-text { min-width: 0; overflow: hidden; text-overflow: ellipsis; }`: truncates the label
  with `…` once the button is compressed, instead of overflowing.
- `wui-loading-spinner, slot[name='iconLeft'], slot[name='iconRight'] { flex-shrink: 0; }`:
  keeps the spinner/icons from being squeezed or distorted; only the text truncates.

This guarantees both buttons stay within the modal boundary regardless of label length or how
many buttons are simultaneously in a loading state. Normal short labels ("Cancel"/"Sign") are
unaffected: no visual change when there's enough room, since these rules only engage once space
is genuinely insufficient. See `.claude/docs/fs-160-sign-modal-buttons-out-of-bounds/findings.md`
for the full investigation, including why an initial `wui-text`-only fix (matching the pattern
already used in `wui-cta-button`) was insufficient here and the `:host` change was also required.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes FS-160

# Showcase (Optional)

## Before
<img width="822" height="774" alt="image" src="https://github.com/user-attachments/assets/e341b8ad-48a9-4ae4-a1c7-ca921e1d5be3" />

## After
<img width="372" height="360" alt="2026-09-01 SignIn and Cancel" src="https://github.com/user-attachments/assets/43afacc4-9922-4ec1-a337-9dce9f90e71d" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
