### PR TITLE
fix(controllers): cancel SIWX sign message instead of shaking modal on close

### DIFF
--- a/.changeset/salty-books-camp.md
+++ b/.changeset/salty-books-camp.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-controllers': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-stellar': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixes clicking the close (X) button while the SIWX "Sign In" screen is shown, which previously just shook the modal instead of canceling the pending sign request like the in-modal Cancel button already did.

--- a/packages/controllers/src/utils/ModalUtil.ts
+++ b/packages/controllers/src/utils/ModalUtil.ts
@@ -21,7 +21,11 @@ export const ModalUtil = {
 
     const isSIWXCloseDisabled = await SIWXUtil.isSIWXCloseDisabled()
     if (isSIWXCloseDisabled) {
-      ModalController.shake()
+      if (RouterController.state.view === 'SIWXSignMessage') {
+        await SIWXUtil.cancelSignMessage()
+      } else {
+        ModalController.shake()
+      }
 
       return
     }

--- a/packages/controllers/tests/utils/ModalUtil.test.ts
+++ b/packages/controllers/tests/utils/ModalUtil.test.ts
@@ -23,7 +23,8 @@ vi.mock('../../src/controllers/RouterController', () => ({
 
 vi.mock('../../src/utils/SIWXUtil', () => ({
   SIWXUtil: {
-    isSIWXCloseDisabled: vi.fn()
+    isSIWXCloseDisabled: vi.fn(),
+    cancelSignMessage: vi.fn()
   }
 }))
 
@@ -92,6 +93,15 @@ describe('ModalUtil', () => {
       await ModalUtil.safeClose()
       expect(ModalController.shake).not.toHaveBeenCalled()
       expect(ModalController.close).toHaveBeenCalled()
+    })
+
+    it('should cancel the sign message instead of shaking when on the SIWXSignMessage view', async () => {
+      RouterController.state.view = 'SIWXSignMessage'
+      vi.mocked(SIWXUtil.isSIWXCloseDisabled).mockResolvedValue(true)
+      await ModalUtil.safeClose()
+      expect(SIWXUtil.cancelSignMessage).toHaveBeenCalled()
+      expect(ModalController.shake).not.toHaveBeenCalled()
+      expect(ModalController.close).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
# Description

Clicking the X button (or backdrop/Escape) to close the modal while the SIWX "Sign In" screen is shown did not close it, it just shook the modal indefinitely. The in-modal "Cancel" button on that same screen already worked correctly (calls SIWXUtil.cancelSignMessage), the X button just never routed to it.

Root cause: ModalUtil.safeClose() calls ModalController.shake() whenever SIWXUtil.isSIWXCloseDisabled() is true, with no path to actually resolve the pending SIWX requirement.

Fix (packages/controllers/src/utils/ModalUtil.ts): when the close is blocked and the current view is SIWXSignMessage, call SIWXUtil.cancelSignMessage() instead of shaking, same as clicking Cancel. All other close-blocked cases (UnsupportedChain, SwitchNetwork with UnsupportedChain history) keep shaking, since those are intentionally blocking screens with no cancel action.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes FS-174

# Showcase (Optional)

## Before
<img width="847" height="764" alt="2026-07-17 SIWE Sign In modal not closing when X is clicked" src="https://github.com/user-attachments/assets/8b0acd4f-04ca-455e-a2d9-2c2ed2584282" />

## After
<img width="844" height="635" alt="2026-09-02 SIWE Sign In modal closing when X is clicked" src="https://github.com/user-attachments/assets/98eb159c-0831-4651-a256-e871a0dbe549" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link