### PR TITLE
fix(scaffold-ui): show SIWX sign-message prompt after connecting without a refresh

### DIFF
--- a/.changeset/eighty-turkeys-shine.md
+++ b/.changeset/eighty-turkeys-shine.md
@@ -1,0 +1,32 @@
+---
+'@reown/appkit-scaffold-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-stellar': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-ui': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Fixed the SIWX sign-message prompt not appearing after connecting until the page was refreshed, reproducible with the Solana adapter on email sign-in and more generally with Farcaster login or browser-injected-wallet connections.

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-browser/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-browser/index.ts
@@ -6,7 +6,8 @@ import {
   ConnectorController,
   EventsController,
   ModalController,
-  RouterController
+  RouterController,
+  SIWXUtil
 } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
 
@@ -53,7 +54,9 @@ export class W3mConnectingWcBrowser extends W3mConnectingWidget {
         throw new Error('w3m-connecting-wc-browser: No connector found')
       }
 
-      ModalController.close()
+      if (await SIWXUtil.isAuthenticated()) {
+        ModalController.close()
+      }
     } catch (error) {
       const isUserRejectedRequestError =
         error instanceof AppKitError &&

--- a/packages/scaffold-ui/src/partials/w3m-connecting-wc-browser/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-connecting-wc-browser/index.ts
@@ -6,6 +6,7 @@ import {
   ConnectorController,
   EventsController,
   ModalController,
+  OptionsController,
   RouterController,
   SIWXUtil
 } from '@reown/appkit-controllers'
@@ -54,7 +55,8 @@ export class W3mConnectingWcBrowser extends W3mConnectingWidget {
         throw new Error('w3m-connecting-wc-browser: No connector found')
       }
 
-      if (await SIWXUtil.isAuthenticated()) {
+      const isAuthenticated = !OptionsController.state.siwx || (await SIWXUtil.isAuthenticated())
+      if (isAuthenticated) {
         ModalController.close()
       }
     } catch (error) {

--- a/packages/scaffold-ui/src/views/w3m-connecting-farcaster-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-farcaster-view/index.ts
@@ -210,7 +210,8 @@ export class W3mConnectingFarcasterView extends LitElement {
           })
         }
         this.loading = false
-        if (await SIWXUtil.isAuthenticated()) {
+        const isAuthenticated = !OptionsController.state.siwx || (await SIWXUtil.isAuthenticated())
+        if (isAuthenticated) {
           if (hasConnections && isMultiWalletEnabled) {
             RouterController.replace('ProfileWallets')
             SnackController.showSuccess('New Wallet Added')

--- a/packages/scaffold-ui/src/views/w3m-connecting-farcaster-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-connecting-farcaster-view/index.ts
@@ -11,6 +11,7 @@ import {
   ModalController,
   OptionsController,
   RouterController,
+  SIWXUtil,
   SnackController,
   StorageUtil,
   ThemeController
@@ -209,11 +210,13 @@ export class W3mConnectingFarcasterView extends LitElement {
           })
         }
         this.loading = false
-        if (hasConnections && isMultiWalletEnabled) {
-          RouterController.replace('ProfileWallets')
-          SnackController.showSuccess('New Wallet Added')
-        } else {
-          ModalController.close()
+        if (await SIWXUtil.isAuthenticated()) {
+          if (hasConnections && isMultiWalletEnabled) {
+            RouterController.replace('ProfileWallets')
+            SnackController.showSuccess('New Wallet Added')
+          } else {
+            ModalController.close()
+          }
         }
       } catch (error) {
         if (this.socialProvider) {

--- a/packages/scaffold-ui/src/views/w3m-email-verify-otp-view/index.ts
+++ b/packages/scaffold-ui/src/views/w3m-email-verify-otp-view/index.ts
@@ -6,6 +6,7 @@ import {
   ModalController,
   OptionsController,
   RouterController,
+  SIWXUtil,
   SnackController
 } from '@reown/appkit-controllers'
 import { customElement } from '@reown/appkit-ui'
@@ -40,7 +41,9 @@ export class W3mEmailVerifyOtpView extends W3mEmailOtpWidget {
         }
 
         if (OptionsController.state.siwx) {
-          ModalController.close()
+          if (await SIWXUtil.isAuthenticated()) {
+            ModalController.close()
+          }
 
           return
         }

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-browser.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-browser.test.ts
@@ -11,7 +11,9 @@ import {
   ConnectorController,
   CoreHelperUtil,
   EventsController,
+  ModalController,
   RouterController,
+  SIWXUtil,
   type WcWallet
 } from '@reown/appkit-controllers'
 
@@ -60,8 +62,10 @@ describe('W3mConnectingWcBrowser', () => {
   })
 
   it('it should connect successfully if a connector exist', async () => {
-    vi.spyOn(ConnectionController, 'connectExternal')
+    vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
     vi.spyOn(EventsController, 'sendEvent')
+    vi.spyOn(ModalController, 'close').mockImplementation(() => {})
+    vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(true)
     vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
       ...ConnectorController.state,
       connectors: [CONNECTOR]
@@ -70,6 +74,23 @@ describe('W3mConnectingWcBrowser', () => {
     await fixture(html`<w3m-connecting-wc-browser></w3m-connecting-wc-browser>`)
 
     expect(ConnectionController.connectExternal).toHaveBeenCalledWith(CONNECTOR, CONNECTOR.chain)
+    expect(ModalController.close).toHaveBeenCalled()
+  })
+
+  it('it should not close the modal if siwx is enabled and not yet authenticated', async () => {
+    vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
+    vi.spyOn(EventsController, 'sendEvent')
+    vi.spyOn(ModalController, 'close').mockImplementation(() => {})
+    vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+    vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
+      ...ConnectorController.state,
+      connectors: [CONNECTOR]
+    })
+
+    await fixture(html`<w3m-connecting-wc-browser></w3m-connecting-wc-browser>`)
+
+    expect(ConnectionController.connectExternal).toHaveBeenCalledWith(CONNECTOR, CONNECTOR.chain)
+    expect(ModalController.close).not.toHaveBeenCalled()
   })
 
   it('it should throw an error if trying to connect when a connector does not exist', async () => {

--- a/packages/scaffold-ui/test/partials/w3m-connecting-wc-browser.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-connecting-wc-browser.test.ts
@@ -12,6 +12,7 @@ import {
   CoreHelperUtil,
   EventsController,
   ModalController,
+  OptionsController,
   RouterController,
   SIWXUtil,
   type WcWallet
@@ -82,6 +83,10 @@ describe('W3mConnectingWcBrowser', () => {
     vi.spyOn(EventsController, 'sendEvent')
     vi.spyOn(ModalController, 'close').mockImplementation(() => {})
     vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+    vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+      ...OptionsController.state,
+      siwx: {} as any
+    })
     vi.spyOn(ConnectorController, 'state', 'get').mockReturnValue({
       ...ConnectorController.state,
       connectors: [CONNECTOR]

--- a/packages/scaffold-ui/test/views/w3m-connecting-farcaster-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-connecting-farcaster-view.test.ts
@@ -137,6 +137,11 @@ describe('W3mConnectingFarcasterView', () => {
       vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([MOCK_CONNECTION])
       vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
       vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        remoteFeatures: { multiWallet: true },
+        siwx: {} as any
+      })
 
       await element['connectFarcaster']()
 
@@ -149,6 +154,10 @@ describe('W3mConnectingFarcasterView', () => {
       vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([])
       vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
       vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        siwx: {} as any
+      })
 
       await element['connectFarcaster']()
 

--- a/packages/scaffold-ui/test/views/w3m-connecting-farcaster-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-connecting-farcaster-view.test.ts
@@ -11,6 +11,7 @@ import {
   ModalController,
   OptionsController,
   RouterController,
+  SIWXUtil,
   SnackController
 } from '@reown/appkit-controllers'
 
@@ -65,6 +66,7 @@ describe('W3mConnectingFarcasterView', () => {
       vi.spyOn(RouterController, 'goBack').mockImplementation(() => {})
 
       vi.spyOn(ModalController, 'close').mockImplementation(() => {})
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(true)
 
       vi.spyOn(SnackController, 'showSuccess').mockImplementation(() => {})
       vi.spyOn(SnackController, 'showError').mockImplementation(() => {})
@@ -129,6 +131,28 @@ describe('W3mConnectingFarcasterView', () => {
       expect(RouterController.reset).not.toHaveBeenCalled()
       expect(RouterController.push).not.toHaveBeenCalled()
       expect(SnackController.showSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should not close modal or navigate when siwx is not yet authenticated, even with connections and multiWallet enabled', async () => {
+      vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([MOCK_CONNECTION])
+      vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+
+      await element['connectFarcaster']()
+
+      expect(ModalController.close).not.toHaveBeenCalled()
+      expect(RouterController.replace).not.toHaveBeenCalledWith('ProfileWallets')
+      expect(SnackController.showSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should not close modal when siwx is not yet authenticated and there are no connections', async () => {
+      vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([])
+      vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+
+      await element['connectFarcaster']()
+
+      expect(ModalController.close).not.toHaveBeenCalled()
     })
 
     it('should navigate back and show error when connection fails', async () => {

--- a/packages/scaffold-ui/test/views/w3m-email-verify-otp-view.test.ts
+++ b/packages/scaffold-ui/test/views/w3m-email-verify-otp-view.test.ts
@@ -12,6 +12,7 @@ import {
   OptionsController,
   RouterController,
   type SIWXConfig,
+  SIWXUtil,
   SnackController
 } from '@reown/appkit-controllers'
 
@@ -70,6 +71,7 @@ describe('W3mEmailVerifyOtpView', () => {
       vi.spyOn(RouterController, 'replace').mockImplementation(() => {})
       vi.spyOn(ModalController, 'close').mockImplementation(() => {})
       vi.spyOn(SnackController, 'showSuccess').mockImplementation(() => {})
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(true)
       vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
         ...OptionsController.state,
         remoteFeatures: { multiWallet: true },
@@ -103,6 +105,7 @@ describe('W3mEmailVerifyOtpView', () => {
       expect(RouterController.reset).not.toHaveBeenCalled()
       expect(RouterController.push).not.toHaveBeenCalled()
       expect(SnackController.showSuccess).not.toHaveBeenCalled()
+      expect(SIWXUtil.isAuthenticated).not.toHaveBeenCalled()
     })
 
     it('should close modal when has no connections and multiWallet is enabled', async () => {
@@ -150,8 +153,8 @@ describe('W3mEmailVerifyOtpView', () => {
       vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
         ...OptionsController.state,
         remoteFeatures: { multiWallet: true },
-        siwx: true
-      } as any)
+        siwx: {} as SIWXConfig
+      })
 
       vi.spyOn(ConnectionController, 'connectExternal').mockResolvedValue(undefined)
 
@@ -162,6 +165,38 @@ describe('W3mEmailVerifyOtpView', () => {
       expect(RouterController.reset).not.toHaveBeenCalled()
       expect(RouterController.push).not.toHaveBeenCalled()
       expect(SnackController.showSuccess).not.toHaveBeenCalled()
+    })
+
+    it('should close modal when siwx is enabled and already authenticated', async () => {
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        remoteFeatures: { multiWallet: true },
+        siwx: {} as SIWXConfig
+      })
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(true)
+
+      element = await fixture(html`<w3m-email-verify-otp-view></w3m-email-verify-otp-view>`)
+
+      await element.onOtpSubmit('123456')
+
+      expect(ModalController.close).toHaveBeenCalled()
+    })
+
+    it('should not close modal when siwx is enabled and not yet authenticated', async () => {
+      vi.spyOn(ConnectionController, 'getConnections').mockReturnValue([MOCK_CONNECTION])
+      vi.spyOn(OptionsController, 'state', 'get').mockReturnValue({
+        ...OptionsController.state,
+        remoteFeatures: { multiWallet: true },
+        siwx: {} as SIWXConfig
+      })
+      vi.spyOn(SIWXUtil, 'isAuthenticated').mockResolvedValue(false)
+
+      element = await fixture(html`<w3m-email-verify-otp-view></w3m-email-verify-otp-view>`)
+
+      await element.onOtpSubmit('123456')
+
+      expect(ModalController.close).not.toHaveBeenCalled()
+      expect(RouterController.replace).not.toHaveBeenCalledWith('ProfileWallets')
     })
   })
 })


### PR DESCRIPTION
# Description

With SIWX configured on the Solana adapter, signing in by email did not show the SIWXSignMessage popup after the OTP was verified. The modal just closed, and the popup only appeared after a manual page refresh.

Root cause: three connect flows (w3m-email-verify-otp-view, w3m-connecting-farcaster-view, w3m-connecting-wc-browser) closed the modal unconditionally right after connecting, racing the address-change subscription that opens the SIWXSignMessage view. The close was synchronous, and the open was async, so the close consistently won and discarded the pending sign-message screen.

Fix: each of the three now awaits SIWXUtil.isAuthenticated() before closing, mirroring the guard w3m-network-switch-view already uses for the same problem after a network switch. The modal only closes once a session already exists (or SIWX is not configured); otherwise, it defers to the SIWX flow to open the sign-message prompt.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

Closes FS-166

# Showcase (Optional)

## Before
<img width="666" height="664" alt="2026-09-02 Sign with email needs refresh" src="https://github.com/user-attachments/assets/9091a0a8-640c-4903-ab18-23cb81621a7b" />

## After
<img width="629" height="667" alt="2026-09-02 Sign with email working ok" src="https://github.com/user-attachments/assets/ae0b0f76-73f0-4848-83e0-898bcbb0261a" />

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link
