### PR TITLE
fix: accessible names for the modal card and header icon buttons

### DIFF
--- a/.changeset/modal-accessible-names.md
+++ b/.changeset/modal-accessible-names.md
@@ -1,0 +1,31 @@
+---
+'@reown/appkit': patch
+'@reown/appkit-ui': patch
+'pay-test-exchange': patch
+'@reown/appkit-adapter-bitcoin': patch
+'@reown/appkit-adapter-ethers': patch
+'@reown/appkit-adapter-ethers5': patch
+'@reown/appkit-adapter-solana': patch
+'@reown/appkit-adapter-ton': patch
+'@reown/appkit-adapter-tron': patch
+'@reown/appkit-adapter-wagmi': patch
+'@reown/appkit-utils': patch
+'@reown/appkit-cdn': patch
+'@reown/appkit-cli': patch
+'@reown/appkit-codemod': patch
+'@reown/appkit-common': patch
+'@reown/appkit-controllers': patch
+'@reown/appkit-core': patch
+'@reown/appkit-experimental': patch
+'@reown/appkit-pay': patch
+'@reown/appkit-polyfills': patch
+'@reown/appkit-scaffold-ui': patch
+'@reown/appkit-siwe': patch
+'@reown/appkit-siwx': patch
+'@reown/appkit-testing': patch
+'@reown/appkit-universal-connector': patch
+'@reown/appkit-wallet': patch
+'@reown/appkit-wallet-button': patch
+---
+
+Give the modal card and the header's icon buttons accessible names. `wui-icon-button` gains a `label` property rendered as `aria-label` on its inner button; the header labels its close, help, back and smart sessions buttons; and `w3m-modal` labels the card with the current view's heading, falling back to the view name on screens that have none.

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -21,7 +21,7 @@ import '@reown/appkit-ui/wui-card'
 import '@reown/appkit-ui/wui-flex'
 
 import '../../partials/w3m-alertbar/index.js'
-import '../../partials/w3m-header/index.js'
+import { headings } from '../../partials/w3m-header/index.js'
 import '../../partials/w3m-snackbar/index.js'
 import '../../partials/w3m-tooltip-trigger/index.js'
 import '../../partials/w3m-tooltip/index.js'
@@ -32,6 +32,13 @@ import styles from './styles.js'
 
 // -- Helpers --------------------------------------------- //
 const SCROLL_LOCK = 'scroll-lock'
+
+function getCardLabel() {
+  const { view } = RouterController.state
+
+  // Views without a header title, such as the account screens, fall back to the view name
+  return headings()[view] || view.replace(/(?<=[a-z])(?=[A-Z])/gu, ' ')
+}
 
 // -- Constants --------------------------------------------- //
 const PADDING_OVERRIDES: Record<string, string> = {
@@ -67,6 +74,8 @@ export class W3mModalBase extends LitElement {
 
   @state() private padding = vars.spacing[1]
 
+  @state() private cardLabel = getCardLabel()
+
   @state() private mobileFullScreen = OptionsController.state.enableMobileFullScreen
 
   public constructor() {
@@ -89,6 +98,7 @@ export class W3mModalBase extends LitElement {
         RouterController.subscribeKey('view', () => {
           this.dataset['border'] = HelpersUtil.hasFooter() ? 'true' : 'false'
           this.padding = PADDING_OVERRIDES[RouterController.state.view] ?? vars.spacing[1]
+          this.cardLabel = getCardLabel()
         })
       ]
     )
@@ -152,6 +162,7 @@ export class W3mModalBase extends LitElement {
       data-embedded="${ifDefined(this.enableEmbedded)}"
       role="alertdialog"
       aria-modal="true"
+      aria-label=${this.cardLabel}
       tabindex="0"
       data-testid="w3m-modal-card"
     >

--- a/packages/scaffold-ui/src/partials/w3m-header/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-header/index.ts
@@ -30,7 +30,7 @@ const BACKGROUND_OVERRIDES: Record<string, string> = {
 }
 
 // -- Helpers ------------------------------------------- //
-function headings() {
+export function headings() {
   const connectorName = RouterController.state.data?.connector?.name
   const walletName = RouterController.state.data?.wallet?.name
   const networkName = RouterController.state.data?.network?.name
@@ -43,7 +43,7 @@ function headings() {
     : 'Connect Social'
 
   return {
-    Connect: `Connect ${isEmail ? 'Email' : ''} Wallet`,
+    Connect: `Connect ${isEmail ? 'Email ' : ''}Wallet`,
     Create: 'Create Wallet',
     ChooseAccountName: undefined,
     Account: undefined,
@@ -199,6 +199,7 @@ export class W3mHeader extends LitElement {
     return html`<wui-flex>
       <wui-icon-button
         icon="clock"
+        label="Smart Sessions"
         size="lg"
         iconSize="lg"
         type="neutral"
@@ -214,6 +215,7 @@ export class W3mHeader extends LitElement {
     return html`
       <wui-icon-button
         icon="close"
+        label="Close"
         size="lg"
         type="neutral"
         variant="primary"
@@ -278,6 +280,7 @@ export class W3mHeader extends LitElement {
         data-testid="header-back"
         id="dynamic"
         icon="chevronLeft"
+        label="Back"
         size="lg"
         iconSize="lg"
         type="neutral"
@@ -290,6 +293,7 @@ export class W3mHeader extends LitElement {
       data-hidden=${!isConnectHelp}
       id="dynamic"
       icon="helpCircle"
+      label="Help"
       size="lg"
       iconSize="lg"
       type="neutral"

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -75,6 +75,21 @@ describe('W3mModal', () => {
       expect(overlay).toBeNull()
     })
 
+    it('should name the card after the current view heading', async () => {
+      RouterController.reset('Connect')
+      element = await fixture(html`<w3m-modal .enableEmbedded=${true}></w3m-modal>`)
+      const card = HelpersUtil.getByTestId(element, 'w3m-modal-card')
+      expect(card.getAttribute('aria-label')).toBe('Connect Wallet')
+
+      RouterController.push('Networks')
+      await elementUpdated(element)
+      expect(card.getAttribute('aria-label')).toBe('Choose Network')
+
+      RouterController.push('Account')
+      await elementUpdated(element)
+      expect(card.getAttribute('aria-label')).toBe('Account')
+    })
+
     it('should close modal when wallet is connected', async () => {
       ChainController.state.activeCaipAddress = 'eip155:1:0x123...'
       await fixture(html`<w3m-modal .enableEmbedded=${true}></w3m-modal>`)

--- a/packages/scaffold-ui/test/partials/w3m-header.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-header.test.ts
@@ -294,4 +294,24 @@ describe('W3mHeader', () => {
       expect(networkSelect).toBeNull()
     })
   })
+
+  describe('Accessible Names', () => {
+    it('should label the help and close buttons', async () => {
+      const helpButton = element.shadowRoot?.querySelector('wui-icon-button[icon="helpCircle"]')
+      const closeButton = HelpersUtil.getByTestId(element, 'w3m-header-close')
+
+      expect(helpButton?.getAttribute('label')).toBe('Help')
+      expect(closeButton?.getAttribute('label')).toBe('Close')
+    })
+
+    it('should label the back button', async () => {
+      RouterController.push('Networks')
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const backButton = HelpersUtil.getByTestId(element, 'header-back')
+      expect(backButton?.getAttribute('label')).toBe('Back')
+    })
+  })
 })

--- a/packages/ui/src/composites/wui-icon-button/index.ts
+++ b/packages/ui/src/composites/wui-icon-button/index.ts
@@ -27,6 +27,9 @@ export class WuiIconButton extends LitElement {
 
   @property({ type: Boolean }) public disabled = false
 
+  /** Accessible name for the icon-only button, rendered as aria-label on the inner button */
+  @property() public label?: string = undefined
+
   // -- Render -------------------------------------------- //
   public override render() {
     return html`<button
@@ -35,6 +38,7 @@ export class WuiIconButton extends LitElement {
       data-size=${this.size}
       data-full-width=${this.fullWidth}
       ?disabled=${this.disabled}
+      aria-label=${ifDefined(this.label)}
     >
       <wui-icon color="inherit" name=${this.icon} size=${ifDefined(this.iconSize)}></wui-icon>
     </button>`

--- a/packages/ui/tests/wui-icon-button.test.ts
+++ b/packages/ui/tests/wui-icon-button.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import '../src/composites/wui-icon-button/index.js'
+import type { WuiIconButton } from '../src/composites/wui-icon-button/index.js'
+
+// -- Helpers ------------------------------------------------------------------
+async function render(label?: string) {
+  const element = document.createElement('wui-icon-button') as WuiIconButton
+  if (label) {
+    element.label = label
+  }
+  document.body.appendChild(element)
+  await element.updateComplete
+
+  return element
+}
+
+// -- Tests --------------------------------------------------------------------
+describe('wui-icon-button', () => {
+  it('forwards label to the inner button as its accessible name', async () => {
+    const element = await render('Close')
+    const button = element.shadowRoot?.querySelector('button')
+
+    expect(button?.getAttribute('aria-label')).toBe('Close')
+  })
+
+  it('renders no aria-label when no label is given', async () => {
+    const element = await render()
+    const button = element.shadowRoot?.querySelector('button')
+
+    expect(button?.hasAttribute('aria-label')).toBe(false)
+  })
+})


### PR DESCRIPTION
# Description

The modal card (`wui-card`, `role="alertdialog"`) had no accessible name in any view, and the header's icon-only buttons could not be given one because `wui-icon-button` never forwarded a label to its inner `<button>`. A screen reader announced the modal as an unnamed dialog and the close and help controls as a bare "button".

- `wui-icon-button` gains a `label` property, rendered as `aria-label` on the inner `<button>` and omitted when unset.
- `w3m-header` labels its close ("Close"), help ("Help"), back ("Back") and smart sessions ("Smart Sessions") buttons. Those are the only four `wui-icon-button` usages in scaffold-ui.
- `w3m-modal` labels the card with the current view's heading. `aria-labelledby` cannot cross the shadow boundary into `w3m-header`, so the `headings()` map is exported from the header and the modal computes the same string on every view change. Views without a heading (the account screens) fall back to the view name split into words, so "Account" and "Account Settings".
- The Connect heading no longer carries a double space when the email wallet is not the only connector (`Connect  Wallet`). HTML collapsed it visually, but it would have become the card's literal label.

## Type of change

- [ ] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5761 (the two defects originally reported in #2698, still present in 1.8.23)

# Showcase (Optional)

No visual change. Accessibility tree of the header, before and after:

```
button                      ->  button "Help"
button                      ->  button "Close"
alertdialog (no name)       ->  alertdialog "Connect Wallet"
```

Verified outside the unit tests by re-running axe-core and IBM Equal Access against the built `@reown/appkit-ui` and `@reown/appkit-scaffold-ui` in a small Vite app with an injected test wallet: axe `aria-dialog-name` on the card went from 3 occurrences (connect, account and switch-network views) to 0, axe `button-name` on the header buttons from 6 to 0, and Equal Access `input_label_exists` on them from 2 to 0, with nothing else changed. The one `button-name` left is on the connect button's own loading spinner, which is outside this issue.

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests): new tests in `packages/ui/tests/wui-icon-button.test.ts`, and in the header and modal suites for the labels and for the card name across the Connect, Networks and Account views
- [x] My changes generate no new warnings (`lint` on scaffold-ui: 0 errors, the 34 pre-existing warnings unchanged)
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link (not available from a fork; tested locally as above)
- [ ] Approver of this PR confirms that the changes are tested on the preview link
