### PR TITLE
fix: give the modal card and header icon buttons accessible names

### DIFF
--- a/.changeset/modal-header-accessible-names.md
+++ b/.changeset/modal-header-accessible-names.md
@@ -1,0 +1,6 @@
+---
+'@reown/appkit-ui': patch
+'@reown/appkit-scaffold-ui': patch
+---
+
+Give the modal card and header icon buttons accessible names.

--- a/packages/scaffold-ui/src/modal/w3m-modal/index.ts
+++ b/packages/scaffold-ui/src/modal/w3m-modal/index.ts
@@ -21,7 +21,7 @@ import '@reown/appkit-ui/wui-card'
 import '@reown/appkit-ui/wui-flex'
 
 import '../../partials/w3m-alertbar/index.js'
-import '../../partials/w3m-header/index.js'
+import { headings } from '../../partials/w3m-header/index.js'
 import '../../partials/w3m-snackbar/index.js'
 import '../../partials/w3m-tooltip-trigger/index.js'
 import '../../partials/w3m-tooltip/index.js'
@@ -69,6 +69,8 @@ export class W3mModalBase extends LitElement {
 
   @state() private mobileFullScreen = OptionsController.state.enableMobileFullScreen
 
+  @state() private view = RouterController.state.view
+
   public constructor() {
     super()
     this.initializeTheming()
@@ -86,9 +88,10 @@ export class W3mModalBase extends LitElement {
             this.filterByNamespace = val
           }
         }),
-        RouterController.subscribeKey('view', () => {
+        RouterController.subscribeKey('view', val => {
+          this.view = val
           this.dataset['border'] = HelpersUtil.hasFooter() ? 'true' : 'false'
-          this.padding = PADDING_OVERRIDES[RouterController.state.view] ?? vars.spacing[1]
+          this.padding = PADDING_OVERRIDES[val] ?? vars.spacing[1]
         })
       ]
     )
@@ -146,12 +149,22 @@ export class W3mModalBase extends LitElement {
   }
 
   // -- Private ------------------------------------------- //
+  private dialogLabel() {
+    const heading = headings()[this.view]
+    if (heading) {
+      return heading.replace(/\s+/g, ' ').trim()
+    }
+
+    return this.view.replace(/([a-z])([A-Z])/g, '$1 $2')
+  }
+
   private contentTemplate() {
     return html` <wui-card
       shake="${this.shake}"
       data-embedded="${ifDefined(this.enableEmbedded)}"
       role="alertdialog"
       aria-modal="true"
+      aria-label=${this.dialogLabel()}
       tabindex="0"
       data-testid="w3m-modal-card"
     >

--- a/packages/scaffold-ui/src/partials/w3m-header/index.ts
+++ b/packages/scaffold-ui/src/partials/w3m-header/index.ts
@@ -30,7 +30,7 @@ const BACKGROUND_OVERRIDES: Record<string, string> = {
 }
 
 // -- Helpers ------------------------------------------- //
-function headings() {
+export function headings() {
   const connectorName = RouterController.state.data?.connector?.name
   const walletName = RouterController.state.data?.wallet?.name
   const networkName = RouterController.state.data?.network?.name
@@ -43,7 +43,7 @@ function headings() {
     : 'Connect Social'
 
   return {
-    Connect: `Connect ${isEmail ? 'Email' : ''} Wallet`,
+    Connect: isEmail ? 'Connect Email Wallet' : 'Connect Wallet',
     Create: 'Create Wallet',
     ChooseAccountName: undefined,
     Account: undefined,
@@ -203,6 +203,7 @@ export class W3mHeader extends LitElement {
         iconSize="lg"
         type="neutral"
         variant="primary"
+        label="Smart Sessions"
         @click=${() => RouterController.push('SmartSessionList')}
         data-testid="w3m-header-smart-sessions"
       ></wui-icon-button>
@@ -218,6 +219,7 @@ export class W3mHeader extends LitElement {
         type="neutral"
         variant="primary"
         iconSize="lg"
+        label="Close"
         @click=${this.onClose.bind(this)}
         data-testid="w3m-header-close"
       ></wui-icon-button>
@@ -282,6 +284,7 @@ export class W3mHeader extends LitElement {
         iconSize="lg"
         type="neutral"
         variant="primary"
+        label="Back"
         @click=${this.onGoBack.bind(this)}
       ></wui-icon-button>`
     }
@@ -294,6 +297,7 @@ export class W3mHeader extends LitElement {
       iconSize="lg"
       type="neutral"
       variant="primary"
+      label="Help"
       @click=${this.onWalletHelp.bind(this)}
     ></wui-icon-button>`
   }

--- a/packages/scaffold-ui/test/modal/w3m-modal.test.ts
+++ b/packages/scaffold-ui/test/modal/w3m-modal.test.ts
@@ -434,4 +434,44 @@ describe('W3mModal', () => {
       expect(ChainController.setIsSwitchingNamespace).toHaveBeenCalledWith(false)
     })
   })
+
+  describe('Accessible name', () => {
+    let element: W3mModal
+
+    beforeEach(async () => {
+      Element.prototype.animate = vi.fn().mockReturnValue({ finished: true })
+      vi.spyOn(ApiController, 'prefetch').mockImplementation(() => Promise.resolve([]))
+      vi.spyOn(ApiController, 'fetchWalletsByPage').mockImplementation(() => Promise.resolve())
+      vi.spyOn(ApiController, 'prefetchAnalyticsConfig').mockImplementation(() => Promise.resolve())
+      OptionsController.setEnableEmbedded(true)
+      RouterController.reset('Connect')
+      ModalController.close()
+      element = await fixture(html`<w3m-modal .enableEmbedded=${true}></w3m-modal>`)
+    })
+
+    it('should name the card after the Connect heading', () => {
+      const card = HelpersUtil.getByTestId(element, 'w3m-modal-card')
+      expect(card?.getAttribute('aria-label')).toBe('Connect Wallet')
+    })
+
+    it('should name the card after the Networks heading', async () => {
+      RouterController.reset('Networks')
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const card = HelpersUtil.getByTestId(element, 'w3m-modal-card')
+      expect(card?.getAttribute('aria-label')).toBe('Choose Network')
+    })
+
+    it('should fall back to a spaced view name when the heading is empty', async () => {
+      RouterController.reset('Account')
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const card = HelpersUtil.getByTestId(element, 'w3m-modal-card')
+      expect(card?.getAttribute('aria-label')).toBe('Account')
+    })
+  })
 })

--- a/packages/scaffold-ui/test/partials/w3m-header.test.ts
+++ b/packages/scaffold-ui/test/partials/w3m-header.test.ts
@@ -294,4 +294,47 @@ describe('W3mHeader', () => {
       expect(networkSelect).toBeNull()
     })
   })
+
+  describe('Accessible names', () => {
+    function innerButtonLabel(host: HTMLElement | null) {
+      return host?.shadowRoot?.querySelector('button')?.getAttribute('aria-label')
+    }
+
+    it('should label the close button', () => {
+      const closeButton = HelpersUtil.getByTestId(element, 'w3m-header-close')
+      expect(innerButtonLabel(closeButton)).toBe('Close')
+    })
+
+    it('should label the help button', async () => {
+      RouterController.reset('Connect')
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const helpButton = element.shadowRoot?.querySelector(
+        'wui-icon-button[icon="helpCircle"]'
+      ) as HTMLElement | null
+      expect(innerButtonLabel(helpButton)).toBe('Help')
+    })
+
+    it('should label the back button', async () => {
+      RouterController.push('Networks')
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const backButton = HelpersUtil.getByTestId(element, 'header-back')
+      expect(innerButtonLabel(backButton)).toBe('Back')
+    })
+
+    it('should label the smart sessions button', async () => {
+      RouterController.push('Account')
+      OptionsController.state.features = { smartSessions: true }
+      element.requestUpdate()
+      await element.updateComplete
+      await elementUpdated(element)
+
+      const smartSessionsButton = HelpersUtil.getByTestId(element, 'w3m-header-smart-sessions')
+      expect(innerButtonLabel(smartSessionsButton)).toBe('Smart Sessions')
+    })
+  })
 })

--- a/packages/ui/src/composites/wui-icon-button/index.ts
+++ b/packages/ui/src/composites/wui-icon-button/index.ts
@@ -27,6 +27,8 @@ export class WuiIconButton extends LitElement {
 
   @property({ type: Boolean }) public disabled = false
 
+  @property() public label?: string
+
   // -- Render -------------------------------------------- //
   public override render() {
     return html`<button
@@ -35,6 +37,7 @@ export class WuiIconButton extends LitElement {
       data-size=${this.size}
       data-full-width=${this.fullWidth}
       ?disabled=${this.disabled}
+      aria-label=${ifDefined(this.label)}
     >
       <wui-icon color="inherit" name=${this.icon} size=${ifDefined(this.iconSize)}></wui-icon>
     </button>`


### PR DESCRIPTION
# Description

The modal card (`wui-card`, `role="alertdialog"`) had no accessible name, and the header's icon-only buttons could not be given one because `wui-icon-button` never forwarded a label to its inner `<button>`. A screen reader announced the modal as an unnamed dialog and the close/help controls as a bare "button".

- `wui-icon-button` gains an optional `label` property, rendered as `aria-label` on the inner button and omitted when unset.
- `w3m-header` labels Close, Help, Back, and Smart Sessions — the four `wui-icon-button` call sites in scaffold-ui.
- `w3m-modal` sets `aria-label` on the card from the current view heading. `aria-labelledby` cannot cross the shadow boundary into `w3m-header`, so the heading map is exported and the modal computes the same string on view change. Views with no heading (Account, Account Settings) fall back to a spaced view name.
- The Connect heading no longer carries a double space when email is not the only connector (`Connect  Wallet`). HTML collapsed it visually; it would have become the card's literal name.

## Type of change

- [x] Chore (non-breaking change that addresses non-functional tasks, maintenance, or code quality improvements)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Associated Issues

closes #5761

# Showcase (Optional)

No visual change.

button  ->  button "Help"
button  ->  button "Close"
alertdialog (no name)  ->  alertdialog "Connect Wallet"

# Checklist

- [x] Code in this PR is covered by automated tests (Unit tests, E2E tests)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
- [x] I have filled out all required sections
- [ ] I have tested my changes on the preview link
- [ ] Approver of this PR confirms that the changes are tested on the preview link