### PR TITLE
fix(onramp): include countryCode and source params in Meld URL

### DIFF
--- a/.changeset/onramp-meld-country-code.md
+++ b/.changeset/onramp-meld-country-code.md
@@ -1,0 +1,5 @@
+---
+"@reown/appkit-controllers": patch
+---
+
+Fix Meld on-ramp widget URL missing `countryCode`, `sourceCurrencyCode`, and `sourceAmount`, which left users on Binance Connect with a fabricated receive amount.

--- a/packages/controllers/src/controllers/OnRampController.ts
+++ b/packages/controllers/src/controllers/OnRampController.ts
@@ -6,6 +6,7 @@ import { ConstantsUtil } from '@reown/appkit-common'
 
 import { MELD_PUBLIC_KEY, ONRAMP_PROVIDERS } from '../utils/ConstantsUtil.js'
 import type { PaymentCurrency, PurchaseCurrency } from '../utils/TypeUtil.js'
+import { CoreHelperUtil } from '../utils/CoreHelperUtil.js'
 import { withErrorBoundary } from '../utils/withErrorBoundary.js'
 import { ApiController } from './ApiController.js'
 import { BlockchainApiController } from './BlockchainApiController.js'
@@ -34,6 +35,11 @@ export interface OnRampControllerState {
   providers: OnRampProvider[]
   error: string | null
   quotesLoading: boolean
+  /**
+   * ISO 3166-1 alpha-2 country code forwarded to Meld.
+   * When unset, AppKit falls back to the browser locale region, then US for USD.
+   */
+  countryCode?: string
 }
 
 type StateKey = keyof OnRampControllerState
@@ -88,6 +94,56 @@ const defaultState = {
 // -- State --------------------------------------------- //
 const state = proxy<OnRampControllerState>(defaultState)
 
+
+function getBrowserCountryCode(): string | undefined {
+  if (!CoreHelperUtil.isClient()) {
+    return undefined
+  }
+
+  try {
+    const locale =
+      Intl.DateTimeFormat().resolvedOptions().locale || window.navigator.language
+    if (!locale) {
+      return undefined
+    }
+
+    if (typeof Intl.Locale === 'function') {
+      const region = new Intl.Locale(locale).region
+      if (region) {
+        return region.toUpperCase()
+      }
+    }
+
+    const match = locale.match(/[-_]([A-Za-z]{2})$/)
+    if (match?.[1]) {
+      return match[1].toUpperCase()
+    }
+  } catch {
+    // Ignore locale resolution failures and fall through to currency defaults.
+  }
+
+  return undefined
+}
+
+function resolveOnRampCountryCode(paymentCurrencyId?: string): string | undefined {
+  if (state.countryCode) {
+    return state.countryCode.toUpperCase()
+  }
+
+  const browserCountry = getBrowserCountryCode()
+  if (browserCountry) {
+    return browserCountry
+  }
+
+  // Default USD on-ramp traffic without a locale region still needs a country so
+  // Meld does not route to Binance Connect with a fabricated receive amount.
+  if (paymentCurrencyId === 'USD') {
+    return 'US'
+  }
+
+  return undefined
+}
+
 // -- Controller ---------------------------------------- //
 const controller = {
   state,
@@ -112,10 +168,29 @@ const controller = {
       url.searchParams.append('destinationCurrencyCode', currency)
       url.searchParams.append('walletAddress', address)
       url.searchParams.append('externalCustomerId', OptionsController.state.projectId)
+
+      const countryCode = resolveOnRampCountryCode(state.paymentCurrency?.id)
+      if (countryCode) {
+        url.searchParams.append('countryCode', countryCode)
+      }
+
+      const sourceCurrencyCode = state.paymentCurrency?.id
+      if (sourceCurrencyCode) {
+        url.searchParams.append('sourceCurrencyCode', sourceCurrencyCode)
+      }
+
+      if (typeof state.paymentAmount === 'number') {
+        url.searchParams.append('sourceAmount', String(state.paymentAmount))
+      }
+
       state.selectedProvider = { ...provider, url: url.toString() }
     } else {
       state.selectedProvider = provider
     }
+  },
+
+  setCountryCode(countryCode: string | undefined) {
+    state.countryCode = countryCode
   },
 
   setOnrampProviders(providers: OnRampProviderName[]) {
@@ -191,6 +266,7 @@ const controller = {
     state.paymentAmount = undefined
     state.purchaseAmount = undefined
     state.quotesLoading = false
+    state.countryCode = undefined
   }
 }
 

--- a/packages/controllers/tests/controllers/OnRampController.test.ts
+++ b/packages/controllers/tests/controllers/OnRampController.test.ts
@@ -213,6 +213,8 @@ describe('OnRampController', () => {
     })
     OptionsController.state.projectId = 'test'
     OnRampController.resetState()
+    OnRampController.setCountryCode('US')
+    OnRampController.setPaymentAmount(100)
     const meldProvider = ONRAMP_PROVIDERS[0] as OnRampProvider
     OnRampController.setSelectedProvider(meldProvider)
     const resultUrl = new URL(meldProvider.url)
@@ -220,7 +222,31 @@ describe('OnRampController', () => {
     resultUrl.searchParams.append('destinationCurrencyCode', 'USDC')
     resultUrl.searchParams.append('walletAddress', '0x123')
     resultUrl.searchParams.append('externalCustomerId', 'test')
+    resultUrl.searchParams.append('countryCode', 'US')
+    resultUrl.searchParams.append('sourceCurrencyCode', 'USD')
+    resultUrl.searchParams.append('sourceAmount', '100')
 
     expect(OnRampController.state.selectedProvider?.url).toEqual(resultUrl.toString())
+  })
+
+  it('should prefer explicit countryCode over browser locale for meld url', () => {
+    mockChainControllerState({
+      activeChain: ConstantsUtil.CHAIN.EVM,
+      chains: new Map([
+        [
+          ConstantsUtil.CHAIN.EVM,
+          { accountState: { address: '0x123', caipAddress: 'eip155:1:0x123' } }
+        ]
+      ])
+    })
+    OptionsController.state.projectId = 'test'
+    OnRampController.resetState()
+    OnRampController.setCountryCode('GB')
+    const meldProvider = ONRAMP_PROVIDERS[0] as OnRampProvider
+    OnRampController.setSelectedProvider(meldProvider)
+
+    const selectedUrl = new URL(OnRampController.state.selectedProvider?.url || '')
+    expect(selectedUrl.searchParams.get('countryCode')).toEqual('GB')
+    expect(selectedUrl.searchParams.get('sourceCurrencyCode')).toEqual('USD')
   })
 })


### PR DESCRIPTION
## Summary

Selecting Meld in the on-ramp builds a widget URL with only `publicKey`, `destinationCurrencyCode`, `walletAddress`, and `externalCustomerId`. Without `countryCode`, Meld routes to Binance Connect and paints a fabricated "You receive" figure (around `0.0012`) on first load. Adding `countryCode=US` to that same URL switches providers and removes the bogus amount.

This change makes AppKit send `countryCode` (plus `sourceCurrencyCode` / `sourceAmount` when known) so the widget opens on a provider that can actually quote.

## What changed

- Resolve a country code in this order: explicit `OnRampController.setCountryCode()`, browser locale region via `Intl` / `navigator.language`, then `US` when the payment currency is `USD`.
- Append `countryCode`, `sourceCurrencyCode` (from `paymentCurrency.id`), and `sourceAmount` (from `paymentAmount` when set) to the Meld URL inside `setSelectedProvider()`.
- Add `countryCode` to on-ramp state, clear it in `resetState()`, and cover the URL builder with unit tests including an explicit GB override.

## Why

Meld's initial render is sensitive to country. Omitting it leaves US users on Binance Connect with a skeleton receive amount next to an enabled Buy button. Passing country (and source currency/amount) is the AppKit-side fix called out in #5752; the remaining placeholder behavior is on Meld's widget.

## How tested

- Updated `OnRampController` unit tests for the Meld URL shape with `countryCode`, `sourceCurrencyCode`, and `sourceAmount`.
- Added a case that prefers an explicit `setCountryCode('GB')` over locale defaults.
- Could not run the full package suite in this API-only workflow. Changes are localized to the controller and its existing vitest file.

Fixes #5752